### PR TITLE
Simple mode, pause, menu bar, one-turn redo, faster long transcripts, corrections as references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,57 @@
 
 ## Unreleased
 
+### Simple mode
+
+- The app has two modes. **Simple** is the default. It shows the recordings, a
+  **Record** button, a **Transcribe a File** button, the transcript and the
+  notes. **Advanced** shows every control: the model tiers, the audio controls,
+  the benchmark, the decode statistics and the transcript revisions. To change
+  the mode, click the mode name at the bottom of the sidebar, select **View ›
+  Advanced Mode** (⌥⌘A), or go to **Settings › General › Mode**.
+- The detail column with nothing selected is a drop target with two buttons and
+  three steps. The whole window shows a frame while a file is over it.
+- A drop on the Dock icon, **Open With › Notero** in the Finder and
+  `open -a Notero file.m4a` all transcribe the file. The app declared the file
+  types since the first release, but nothing received them.
+- Live text is off by default. The app records only and makes the transcript
+  when you stop. The app also loads no model at the start when live text is
+  off. Before this change the app loaded a 1.6 GB model at each start for a
+  path that did not run.
+- Simple mode asks for the microphone permission at the first recording, and
+  not on the first-run card.
+- The labels, the messages and the help texts follow ASD-STE100 Simplified
+  Technical English. The status names are nouns: In queue, Preparation,
+  Transcription, Speaker identification, Complete.
+
+### A long transcript opens fast
+
+- The transcript view reads the rows in one query, in time order, off the main
+  thread, and groups them before they reach the view. Before this change the
+  view walked the relationship, which faulted each row one by one on the main
+  thread, and it did this again on each redraw. On a store on disk with 4000
+  rows, the walk takes 278 ms and the query takes 50 ms. In the app, a
+  3909-row transcript of a 3 h 51 min meeting is on the screen in 0.3 to 0.7 s,
+  and the window does not wait for it.
+- The info bar, the export, the search index and the editor read the rows the
+  same way. The editor read the whole transcript at each keystroke. It now
+  reads its own lines one time.
+- The transcript view no longer reloads when the notes column opens on the
+  first layout.
+
+### Live text
+
+- The decoder drops a word that the model places inside a pause that the
+  voice detector found, from every hypothesis and not only from the final
+  decode. On the paused synthetic clip the word error rate went from 51.6% to
+  39.1%, and the decoder committed 13 fewer words with no agreement. Finding 12
+  in `docs/FINDINGS.md` gives the mechanism.
+- Measured and not shipped: a Taglish style primer in the prompt made the live
+  path repeat the primer (27% to 96% WER), and `suppressBlank` was noise.
+  `transcribe --style-hint` and `--prompt` repeat the measurement.
+
+### The audio input
+
 - When the room listens through speakers, the microphone also hears the persons
   on the call, and the room lane transcribed each remote sentence a second
   time. The app now drops a room line that repeats a call line at the same

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@
   path that did not run.
 - Simple mode asks for the microphone permission at the first recording, and
   not on the first-run card.
+- A recording has a **Pause** button (⇧⌘P). The clock, the file and the live
+  text stop, and Resume continues on the same timeline with no gap. Mute is
+  the other switch: the clock continues and the file gets silence. Before this
+  change, Mute was the only way to stop the sound.
 - The labels, the messages and the help texts follow ASD-STE100 Simplified
   Technical English. The status names are nouns: In queue, Preparation,
   Transcription, Speaker identification, Complete.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@
   path that did not run.
 - Simple mode asks for the microphone permission at the first recording, and
   not on the first-run card.
+- A menu bar item gives Record, Pause, Resume, Stop and Add a Bookmark from any
+  application, and its menu shows the clock of the recording. During a
+  recording, macOS draws its orange microphone indicator on the item. ⌃⌥R starts or stops a
+  recording and ⌃⌥P pauses or resumes it, in every application, with no
+  accessibility permission. **Settings › General › Show Notero in the menu
+  bar** turns the item and the two shortcuts off together.
 - A recording has a **Pause** button (⇧⌘P). The clock, the file and the live
   text stop, and Resume continues on the same timeline with no gap. Mute is
   the other switch: the clock continues and the file gets silence. Before this

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,25 @@
   Technical English. The status names are nouns: In queue, Preparation,
   Transcription, Speaker identification, Complete.
 
+### One turn again, and your corrections as references
+
+- Right-click a turn and select **Transcribe This Turn Again**. The app
+  decodes only that turn, on the Accurate tier in Simple mode or on the tier
+  you select in Advanced mode, and replaces its lines in place. The turn keeps
+  its speaker. Before this change, one bad window in a four-hour meeting cost a
+  second decode of the four hours.
+- **File › Export Corrections as References…** (Advanced) writes a folder with
+  a copy of each corrected recording, the reference text with your edits, the
+  raw model text, the corrected lines with the raw text beside each, a
+  `manifest.json` for `eval/compare_language.py`, and a `summary.md` that
+  scores the raw text against your corrections with no new decode. The project
+  had no real Taglish references before this.
+
+- A double-click or a right-click works on the whole turn. Before this change,
+  the words of a turn were selectable text: a double-click on them selected a
+  word instead of opening the editor, and a right-click on them showed the text
+  menu of macOS instead of the menu of the turn. Copy is in the menu of the turn.
+
 ### A long transcript opens fast
 
 - The transcript view reads the rows in one query, in time order, off the main

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,11 +46,11 @@ deliberate, and you must keep this property. Refer to "The four layers".
 Run each command that applies to your change:
 
 ```bash
-cd app && swift build && swift test    # 289 tests, and 0 warnings
+cd app && swift build && swift test    # 301 tests, and 0 warnings
 ./.venv/bin/python -m pytest           # 75 tests
 ```
 
-The 289 tests are 261 XCTest tests and 28 swift-testing tests. Keep
+The 301 tests are 273 XCTest tests and 28 swift-testing tests. Keep
 `swift build` at **zero warnings**. There is no linter and no formatter for
 either language. Write code in the style of the code around it.
 `.editorconfig` gives the indentation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,11 +46,11 @@ deliberate, and you must keep this property. Refer to "The four layers".
 Run each command that applies to your change:
 
 ```bash
-cd app && swift build && swift test    # 278 tests, and 0 warnings
+cd app && swift build && swift test    # 289 tests, and 0 warnings
 ./.venv/bin/python -m pytest           # 75 tests
 ```
 
-The 278 tests are 250 XCTest tests and 28 swift-testing tests. Keep
+The 289 tests are 261 XCTest tests and 28 swift-testing tests. Keep
 `swift build` at **zero warnings**. There is no linter and no formatter for
 either language. Write code in the style of the code around it.
 `.editorconfig` gives the indentation.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ No recording, no transcript and no note goes off your Mac.
   icon, or record from the microphone.
 - Whole-file transcription after a recording or an import. Live text during a
   recording is optional, and off by default.
+- Pause and resume a recording. The break is not in the file.
 - Two modes. Simple shows the transcript, the notes and two buttons. Advanced
   shows every control.
 - 15 languages and automatic detection. Tagalog and Taglish are the default.

--- a/README.md
+++ b/README.md
@@ -13,8 +13,12 @@ No recording, no transcript and no note goes off your Mac.
 
 ## Features
 
-- Record from the microphone, or import an MP3, WAV, M4A, MP4 or MOV file.
-- Live transcription while you record, and whole-file transcription after.
+- Drop an MP3, WAV, M4A, AIFF, MP4 or MOV file on the window or on the Dock
+  icon, or record from the microphone.
+- Whole-file transcription after a recording or an import. Live text during a
+  recording is optional, and off by default.
+- Two modes. Simple shows the transcript, the notes and two buttons. Advanced
+  shows every control.
 - 15 languages and automatic detection. Tagalog and Taglish are the default.
 - Speaker identification, with manual merge and reassignment.
 - Meeting notes: a summary and five lists, which are key points, decisions,

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ No recording, no transcript and no note goes off your Mac.
 - Whole-file transcription after a recording or an import. Live text during a
   recording is optional, and off by default.
 - Pause and resume a recording. The break is not in the file.
+- A menu bar item with Record, Pause and Stop, and two shortcuts that work in
+  every application.
 - Two modes. Simple shows the transcript, the notes and two buttons. Advanced
   shows every control.
 - 15 languages and automatic detection. Tagalog and Taglish are the default.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,11 @@ No recording, no transcript and no note goes off your Mac.
 - Meeting notes: a summary and five lists, which are key points, decisions,
   action items, questions and follow-ups. Each item keeps the timestamp and the
   transcript line that it came from.
-- Transcript editing, with revisions and one-step undo for each turn.
+- Transcript editing, with revisions and one-step undo for each turn. One
+  turn can be transcribed again on another tier, without the rest of the
+  meeting.
+- Your corrections export as a reference set, thus the evaluation harness can
+  score each change on your own meetings.
 - Synchronized transcript and audio playback, with bookmarks.
 - Full-text search across each transcript, note, action item and bookmark.
 - Export to TXT, Markdown, SRT, VTT and JSON.

--- a/app/Sources/Transcriber/AppCommands.swift
+++ b/app/Sources/Transcriber/AppCommands.swift
@@ -56,6 +56,9 @@ struct AppCommands: Commands {
             Button("Export…") { state.isExporting = true }
                 .keyboardShortcut("e")
                 .disabled(state.selectedRecording == nil)
+            if state.settings.isAdvanced {
+                Button("Export Corrections as References…") { state.exportReferenceSet() }
+            }
         }
 
         CommandGroup(after: .textEditing) {

--- a/app/Sources/Transcriber/AppCommands.swift
+++ b/app/Sources/Transcriber/AppCommands.swift
@@ -42,6 +42,11 @@ struct AppCommands: Commands {
         }
 
         CommandGroup(after: .newItem) {
+            Button(state.isPaused ? "Resume the Recording" : "Pause the Recording") {
+                state.togglePause()
+            }
+            .keyboardShortcut("p", modifiers: [.command, .shift])
+            .disabled(!state.isRecording)
             Button("Stop the Recording") { Task { await state.stopRecording() } }
                 .keyboardShortcut(".", modifiers: .command)
                 .disabled(!state.isRecording)

--- a/app/Sources/Transcriber/AppCommands.swift
+++ b/app/Sources/Transcriber/AppCommands.swift
@@ -22,21 +22,27 @@ struct AppCommands: Commands {
         }
 
         CommandGroup(replacing: .newItem) {
-            Button("New Recording") { state.newItem(.recording) }
-                .keyboardShortcut("r")
-            Button("New Meeting") { state.newItem(.meeting) }
-                .keyboardShortcut("m", modifiers: [.command, .shift])
-            Button("New Note") { state.newItem(.note) }
-                .keyboardShortcut("n")
+            // ⌘R records in both modes. Simple mode makes a meeting, which
+            // opens with the notes beside the transcript.
+            Button(state.settings.isAdvanced ? "New Recording" : "Record") {
+                state.newItem(state.settings.isAdvanced ? .recording : .meeting)
+            }
+            .keyboardShortcut("r")
+            if state.settings.isAdvanced {
+                Button("New Meeting") { state.newItem(.meeting) }
+                    .keyboardShortcut("m", modifiers: [.command, .shift])
+                Button("New Note") { state.newItem(.note) }
+                    .keyboardShortcut("n")
+            }
 
             Divider()
 
-            Button("Import Audio or Video…") { state.isImporting = true }
+            Button("Transcribe a File…") { state.isImporting = true }
                 .keyboardShortcut("o")
         }
 
         CommandGroup(after: .newItem) {
-            Button("Stop Recording") { Task { await state.stopRecording() } }
+            Button("Stop the Recording") { Task { await state.stopRecording() } }
                 .keyboardShortcut(".", modifiers: .command)
                 .disabled(!state.isRecording)
 
@@ -69,14 +75,14 @@ struct AppCommands: Commands {
         }
 
         CommandMenu("Meeting") {
-            Button("Add Bookmark") { _ = state.addBookmark() }
+            Button("Add a Bookmark") { _ = state.addBookmark() }
                 .keyboardShortcut("b")
                 .disabled(state.selectedRecording == nil)
 
             Divider()
 
             ForEach(MeetingItemKind.allCases) { kind in
-                Button("Add Selection as \(kind.label)") {
+                Button("Add the Selection as \(kind.label)") {
                     state.addSelectionAsItem(kind)
                 }
                 .keyboardShortcut(shortcut(for: kind), modifiers: [.command, .control])
@@ -122,20 +128,28 @@ struct AppCommands: Commands {
         }
 
         CommandMenu("View") {
-            Toggle("Show Times of Day", isOn: Binding(
+            Toggle("Advanced Mode", isOn: Binding(
+                get: { state.settings.isAdvanced },
+                set: { state.settings.isAdvanced = $0 }
+            ))
+            .keyboardShortcut("a", modifiers: [.command, .option])
+            Divider()
+            Toggle("Show the Time of Day", isOn: Binding(
                 get: { state.settings.clockTimestamps },
                 set: { state.settings.clockTimestamps = $0 }
             ))
             .keyboardShortcut("t", modifiers: [.command, .option])
-            Toggle("Follow Playback", isOn: Binding(
+            Toggle("Follow the Playback", isOn: Binding(
                 get: { state.followPlayback },
                 set: { state.followPlayback = $0 }
             ))
         }
 
-        CommandGroup(after: .toolbar) {
-            Button("Model Benchmark") { state.route = .benchmark }
-                .keyboardShortcut("k", modifiers: [.command, .shift])
+        if state.settings.isAdvanced {
+            CommandGroup(after: .toolbar) {
+                Button("Model Benchmark") { state.route = .benchmark }
+                    .keyboardShortcut("k", modifiers: [.command, .shift])
+            }
         }
     }
 

--- a/app/Sources/Transcriber/AppState+Jobs.swift
+++ b/app/Sources/Transcriber/AppState+Jobs.swift
@@ -60,6 +60,7 @@ extension AppState {
                 try? await writer.appendPartial(segments, to: transcriptId)
             }
             progress[id]?.coveredMs = coveredMs
+            transcriptTicks[id, default: 0] += 1
 
         case .transcribed(let id, let payload):
             let performanceJSON = (try? JSONEncoder().encode(payload.metrics))
@@ -78,9 +79,11 @@ extension AppState {
                 waveform: payload.waveform.isEmpty ? nil : payload.waveform,
                 for: id
             )
+            transcriptTicks[id, default: 0] += 1
 
         case .diarized(let id, let spans, let roster):
             try? await writer.applySpeakers(spans: spans, roster: roster, for: id)
+            transcriptTicks[id, default: 0] += 1
 
         case .failed(let id, let message):
             // No alert: a background job failing should not interrupt whatever

--- a/app/Sources/Transcriber/AppState+Jobs.swift
+++ b/app/Sources/Transcriber/AppState+Jobs.swift
@@ -81,6 +81,10 @@ extension AppState {
             )
             transcriptTicks[id, default: 0] += 1
 
+        case .rangeTranscribed(let id, let fromMs, let toMs, let segments, _):
+            _ = try? await writer.replaceSegments(fromMs: fromMs, toMs: toMs, with: segments, for: id)
+            transcriptTicks[id, default: 0] += 1
+
         case .diarized(let id, let spans, let roster):
             try? await writer.applySpeakers(spans: spans, roster: roster, for: id)
             transcriptTicks[id, default: 0] += 1

--- a/app/Sources/Transcriber/AppState+Library.swift
+++ b/app/Sources/Transcriber/AppState+Library.swift
@@ -130,6 +130,33 @@ extension AppState {
                              modelId: tier.map { settings.modelId(for: $0) })
     }
 
+    /// One turn again, on a tier, without the rest of the meeting. Accurate
+    /// unless another tier is named: the turn is being redone because the
+    /// first model got it wrong. The rows of the turn are replaced in place,
+    /// with the turn's speaker on them.
+    func retranscribe(_ recording: StoredRecording, turn block: TranscriptBlock,
+                      tier: ModelTier = .accurate) {
+        guard let name = recording.audioFileName, progress[recording.id] == nil else { return }
+        let job = TranscriptionJob(
+            id: recording.id,
+            title: recording.title,
+            sourceURL: Paths.recordingURL(name),
+            cacheURL: AudioCache.url(for: recording.id, under: Paths.support),
+            modelId: settings.modelId(for: tier),
+            language: settings.language,
+            prompt: settings.promptOrNil,
+            diarizationMode: .off,
+            work: .range(TranscriptionJob.RangeRequest(fromMs: block.startMs, toMs: block.endMs,
+                                                       speakerId: block.speakerId)),
+            discardCacheWhenDone: !settings.keepWorkingCopy,
+            roomMode: settings.roomMode,
+            lanes: recording.lanes
+        )
+        progress[recording.id] = JobProgress(status: .pending, fraction: 0)
+        queuedJobs[recording.id] = job
+        Task { await queue.enqueue(job) }
+    }
+
     /// Speaker identification only, over the transcript that exists. Forced on
     /// regardless of the setting: asking for it is the setting.
     func rediarize(_ recording: StoredRecording) {

--- a/app/Sources/Transcriber/AppState+Models.swift
+++ b/app/Sources/Transcriber/AppState+Models.swift
@@ -33,7 +33,7 @@ extension AppState {
                     Task { @MainActor in self.modelDownloads[id] = fraction }
                 }
             } catch {
-                alert = AppAlert(title: "Download failed", message: error.localizedDescription)
+                alert = AppAlert(title: "The download failed", message: error.localizedDescription)
             }
             modelDownloads[id] = nil
             modelsRevision += 1
@@ -48,7 +48,7 @@ extension AppState {
             do {
                 try await engines.removeModel(id)
             } catch {
-                alert = AppAlert(title: "Could not remove the model",
+                alert = AppAlert(title: "The app could not remove the model",
                                  message: error.localizedDescription)
             }
             modelsRevision += 1
@@ -71,6 +71,9 @@ extension AppState {
     /// 1.6 GB download at launch that nobody asked for.
     func warmUpEngines() {
         guard warmup == nil, live.state == .idle else { return }
+        // Only for the live path. With live transcription off, the model is
+        // loaded when a whole-file job needs it, and the launch costs nothing.
+        guard settings.liveTranscription else { return }
         guard ModelCatalogue.isDownloaded(settings.liveModelId,
                                           modelsDirectory: Paths.models) else { return }
         warmup = Task { [weak self] in

--- a/app/Sources/Transcriber/AppState+Recording.swift
+++ b/app/Sources/Transcriber/AppState+Recording.swift
@@ -23,6 +23,16 @@ extension AppState {
     /// phase.
     func isLive(_ id: UUID) -> Bool { activeRecordingId == id && isLiveBusy }
 
+    /// The recording is under way and paused: the clock and the file stand
+    /// still until Resume.
+    var isPaused: Bool { isRecording && live.isPaused }
+
+    /// ⇧⌘P, the Pause button and the toolbar. Nothing to do outside a recording.
+    func togglePause() {
+        guard isRecording else { return }
+        live.isPaused.toggle()
+    }
+
     func beginRecording(_ recording: StoredRecording) async {
         // A launch warmup may still be loading the model. Waiting for it is the
         // point -- the `isBusy` guard below would otherwise drop the recording

--- a/app/Sources/Transcriber/AppState+References.swift
+++ b/app/Sources/Transcriber/AppState+References.swift
@@ -1,0 +1,106 @@
+import AppKit
+import Foundation
+import TranscriberCore
+import TranscriberStore
+
+/// The corrected transcripts of the library, written as a reference set for
+/// the evaluation harness. Refer to `ReferenceSet`.
+extension AppState {
+
+    /// Asks for a folder, then writes the set into a dated subfolder of it.
+    /// Reports the count and the pooled raw word error rate in an alert.
+    func exportReferenceSet() {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.canCreateDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.prompt = "Export Here"
+        panel.message = "The app writes a folder with a copy of each corrected recording, "
+                      + "its reference text and a manifest for the evaluation harness."
+        guard panel.runModal() == .OK, let parent = panel.url else { return }
+
+        Task {
+            do {
+                let result = try await writeReferenceSet(into: parent)
+                alert = AppAlert(
+                    title: result.count == 0 ? "No corrections to export" : "Reference set written",
+                    message: result.count == 0
+                        ? "No transcript has an edited line. Double-click a turn, correct it, "
+                          + "and export again."
+                        : "\(result.count) recording\(result.count == 1 ? "" : "s") with corrections. "
+                          + "Raw model text against your corrections: "
+                          + "\(String(format: "%.1f%%", result.pooledWER * 100)) WER over "
+                          + "\(result.words) reference words. The folder is "
+                          + "\(result.folder.lastPathComponent), and its README says how to score a "
+                          + "configuration against it."
+                )
+                if result.count > 0 { NSWorkspace.shared.activateFileViewerSelecting([result.folder]) }
+            } catch {
+                alert = AppAlert(title: "The export failed", message: error.localizedDescription)
+            }
+        }
+    }
+
+    struct ReferenceExport {
+        var folder: URL
+        var count: Int
+        var words: Int
+        var pooledWER: Double
+    }
+
+    /// The files: `audio/`, `refs/`, `raw/`, `edits/`, `manifest.json`,
+    /// `summary.md`, `README.md`. The audio is copied, not linked: the folder
+    /// is meant to leave this Mac's library, to the eval directory or another
+    /// machine, and a link would point at nothing there.
+    func writeReferenceSet(into parent: URL) async throws -> ReferenceExport {
+        let corrected = try await makeReader().correctedTranscripts()
+        let stamp = Date().formatted(.iso8601.year().month().day().dateSeparator(.dash))
+        let folder = parent.appendingPathComponent("notero-references-\(stamp)", isDirectory: true)
+        guard !corrected.isEmpty else {
+            return ReferenceExport(folder: folder, count: 0, words: 0, pooledWER: 0)
+        }
+        let files = FileManager.default
+        for sub in ["audio", "refs", "raw", "edits"] {
+            try files.createDirectory(at: folder.appendingPathComponent(sub),
+                                      withIntermediateDirectories: true)
+        }
+
+        var entries: [ReferenceSet.Entry] = []
+        var summaries: [ReferenceSet.Summary] = []
+        var words = 0
+        var errors = 0.0
+        for item in corrected {
+            let id = item.recordingId.uuidString.lowercased()
+            let ext = item.audioURL?.pathExtension ?? "m4a"
+            let audioPath = "audio/\(id).\(ext)"
+            if let source = item.audioURL, files.fileExists(atPath: source.path) {
+                let destination = folder.appendingPathComponent(audioPath)
+                try? files.removeItem(at: destination)
+                try files.copyItem(at: source, to: destination)
+            }
+            try ReferenceSet.referenceText(item.segments)
+                .write(to: folder.appendingPathComponent("refs/\(id).txt"), atomically: true, encoding: .utf8)
+            try ReferenceSet.rawText(item.segments)
+                .write(to: folder.appendingPathComponent("raw/\(id).txt"), atomically: true, encoding: .utf8)
+            try ReferenceSet.editsTSV(item.segments)
+                .write(to: folder.appendingPathComponent("edits/\(id).tsv"), atomically: true, encoding: .utf8)
+            entries.append(ReferenceSet.Entry(
+                id: id, audio: audioPath, ref: "refs/\(id).txt", raw: "raw/\(id).txt",
+                edits: "edits/\(id).tsv", title: item.title, durationMs: item.durationMs
+            ))
+            let summary = ReferenceSet.summary(title: item.title, durationMs: item.durationMs,
+                                               segments: item.segments)
+            summaries.append(summary)
+            words += summary.referenceWords
+            errors += summary.rawWER * Double(summary.referenceWords)
+        }
+        try ReferenceSet.manifestJSON(entries).write(to: folder.appendingPathComponent("manifest.json"))
+        try ReferenceSet.summaryMarkdown(summaries)
+            .write(to: folder.appendingPathComponent("summary.md"), atomically: true, encoding: .utf8)
+        try ReferenceSet.readme(count: entries.count)
+            .write(to: folder.appendingPathComponent("README.md"), atomically: true, encoding: .utf8)
+        return ReferenceExport(folder: folder, count: entries.count, words: words,
+                               pooledWER: words > 0 ? errors / Double(words) : 0)
+    }
+}

--- a/app/Sources/Transcriber/AppState.swift
+++ b/app/Sources/Transcriber/AppState.swift
@@ -34,6 +34,8 @@ final class AppState {
     let live: LiveSession
     let player = AudioPlayer()
     let writer: TranscriptWriter
+    /// ⌃⌥R and ⌃⌥P in every application, while the menu bar item is on.
+    let hotKeys = GlobalHotKeys()
 
     /// Sidebar selection. Nil is the empty state.
     var route: Route?

--- a/app/Sources/Transcriber/AppState.swift
+++ b/app/Sources/Transcriber/AppState.swift
@@ -130,6 +130,11 @@ final class AppState {
 
     /// Per-recording pipeline progress, keyed by recording id.
     var progress: [UUID: JobProgress] = [:]
+    /// Bumped when a job writes rows into a recording's transcript: a batch of
+    /// partial rows, the final rows, the speaker labels. The transcript view
+    /// reads it instead of counting the rows, which is a query it would run
+    /// on every redraw.
+    var transcriptTicks: [UUID: Int] = [:]
     /// Per-recording notes about work that finished imperfectly.
     var warnings: [UUID: String] = [:]
     /// The recording the live session is working on, set the moment the user
@@ -187,6 +192,11 @@ final class AppState {
         live.config = settings.sessionConfig
         live.inputGainDb = settings.inputGainDb
         live.isRoomMode = settings.roomMode
+        // Read here, not only at the first recording: the launch warm-up asks
+        // the session whether it decodes live, and the session's own default
+        // is yes. With the setting off, a 1.6 GB model loaded at every launch
+        // for a path that was never going to run.
+        live.decodeLive = settings.liveTranscription
         // Before any view reads the store: the live session and the queue did
         // not survive the last quit, so anything they still claim to be working
         // on is stranded.
@@ -210,6 +220,12 @@ final class AppState {
     }
 
     var context: ModelContext { container.mainContext }
+
+    /// A reader on its own context, for one read of a transcript off the main
+    /// actor. New each time on purpose: refer to `TranscriptReader`.
+    func makeReader() -> TranscriptReader {
+        TranscriptReader(modelContainer: container)
+    }
 
     /// Pending questions, asked one at a time.
     var duplicateImports: [DuplicateImport] = []
@@ -239,7 +255,7 @@ final class AppState {
             if kind != .note { Task { await beginRecording(recording) } }
             return recording
         } catch {
-            alert = AppAlert(title: "Could not create that", message: error.localizedDescription)
+            alert = AppAlert(title: "The app could not create that", message: error.localizedDescription)
             return nil
         }
     }
@@ -252,8 +268,7 @@ final class AppState {
     func addSelectionAsItem(_ kind: MeetingItemKind) {
         guard let recording = selectedRecording,
               let segmentId = selectedSegmentId,
-              let segment = (recording.transcript?.orderedSegments ?? [])
-                  .first(where: { $0.id == segmentId })
+              let segment = try? TranscriptReader.segmentRow(id: segmentId, in: context)
         else { return }
         do {
             try RecordingStore.addItem(kind, text: segment.displayText,
@@ -261,7 +276,7 @@ final class AppState {
             RecordingStore.reindex(recording)
             try context.save()
         } catch {
-            alert = AppAlert(title: "Could not add that note", message: error.localizedDescription)
+            alert = AppAlert(title: "The app could not add the note", message: error.localizedDescription)
         }
     }
 

--- a/app/Sources/Transcriber/MenuBar.swift
+++ b/app/Sources/Transcriber/MenuBar.swift
@@ -1,0 +1,198 @@
+import AppKit
+import Carbon.HIToolbox
+import SwiftUI
+import TranscriberCore
+
+/// The menu bar item: the clock of the recording beside the icon, and
+/// Record, Pause and Stop from any application.
+///
+/// Its purpose is the moment a meeting starts while another window is in
+/// front. Finding the Notero window first is the step that loses the first
+/// minute of the meeting; the menu bar and the global shortcuts remove it.
+struct MenuBarLabel: View {
+    @Environment(AppState.self) private var state
+
+    var body: some View {
+        if state.isRecording {
+            Label {
+                Text(TimeFormat.short(ms: state.live.elapsedMs))
+                    .monospacedDigit()
+            } icon: {
+                Image(systemName: state.isPaused ? "pause.circle.fill" : "record.circle.fill")
+            }
+            .labelStyle(.titleAndIcon)
+        } else if state.isLiveBusy {
+            Image(systemName: "record.circle")
+        } else {
+            Image(systemName: "waveform")
+        }
+    }
+}
+
+struct MenuBarMenu: View {
+    @Environment(AppState.self) private var state
+    @Environment(\.openWindow) private var openWindow
+
+    var body: some View {
+        if state.isRecording {
+            Text(state.isPaused
+                 ? "Paused at \(TimeFormat.short(ms: state.live.elapsedMs))"
+                 : "Recording · \(TimeFormat.short(ms: state.live.elapsedMs))")
+            Button(state.isPaused ? "Resume" : "Pause") { state.togglePause() }
+                .keyboardShortcut("p", modifiers: [.control, .option])
+            Button("Stop") { Task { await state.stopRecording() } }
+                .keyboardShortcut("r", modifiers: [.control, .option])
+            Button("Add a Bookmark") { _ = state.addBookmark() }
+        } else if state.isLiveBusy {
+            Text(state.live.state.label)
+        } else {
+            Button("Record") { state.toggleRecording() }
+                .keyboardShortcut("r", modifiers: [.control, .option])
+            Button("Transcribe a File…") {
+                // The file panel is attached to the main window, so the
+                // window has to be up first.
+                state.showMainWindow(openWindow)
+                state.isImporting = true
+            }
+        }
+
+        Divider()
+
+        Button("Open Notero") { state.showMainWindow(openWindow) }
+        SettingsLink { Text("Settings…") }
+
+        Divider()
+
+        Button("Quit Notero") { NSApp.terminate(nil) }
+            .disabled(state.isLiveBusy)
+    }
+}
+
+/// Keyboard shortcuts that work in every application, through the Carbon
+/// hot-key API. That API needs no accessibility permission, which is what
+/// makes it the right one: a permission prompt at the first recording is the
+/// thing this feature exists to remove.
+///
+/// Two shortcuts, fixed: ⌃⌥R starts or stops a recording, ⌃⌥P pauses or
+/// resumes it. Both are free in macOS and in the common applications.
+final class GlobalHotKeys {
+
+    /// "NTRO", so an event handler can tell these hot keys from any other.
+    private static let signature: OSType = 0x4E54_524F
+
+    private var handler: EventHandlerRef?
+    private var registered: [EventHotKeyRef] = []
+    private var actions: [UInt32: () -> Void] = [:]
+
+    struct Shortcut {
+        var keyCode: UInt32
+        var modifiers: UInt32
+        var action: () -> Void
+    }
+
+    /// Replaces whatever was registered before.
+    func register(_ shortcuts: [Shortcut]) {
+        unregister()
+        guard !shortcuts.isEmpty else { return }
+
+        var spec = EventTypeSpec(eventClass: OSType(kEventClassKeyboard),
+                                 eventKind: UInt32(kEventHotKeyPressed))
+        let status = InstallEventHandler(
+            GetEventDispatcherTarget(),
+            { _, event, userData in
+                guard let event, let userData else { return noErr }
+                var id = EventHotKeyID()
+                let status = GetEventParameter(
+                    event, EventParamName(kEventParamDirectObject),
+                    EventParamType(typeEventHotKeyID), nil,
+                    MemoryLayout<EventHotKeyID>.size, nil, &id
+                )
+                guard status == noErr, id.signature == GlobalHotKeys.signature else { return noErr }
+                // Carbon delivers the event on the main thread; the actions
+                // touch main-actor state.
+                let keys = Unmanaged<GlobalHotKeys>.fromOpaque(userData).takeUnretainedValue()
+                MainActor.assumeIsolated { keys.actions[id.id]?() }
+                return noErr
+            },
+            1, &spec, Unmanaged.passUnretained(self).toOpaque(), &handler
+        )
+        guard status == noErr else { return }
+
+        for (index, shortcut) in shortcuts.enumerated() {
+            let id = UInt32(index + 1)
+            var ref: EventHotKeyRef?
+            let hotKeyID = EventHotKeyID(signature: Self.signature, id: id)
+            if RegisterEventHotKey(shortcut.keyCode, shortcut.modifiers, hotKeyID,
+                                   GetEventDispatcherTarget(), 0, &ref) == noErr, let ref {
+                registered.append(ref)
+                actions[id] = shortcut.action
+            }
+        }
+    }
+
+    func unregister() {
+        for ref in registered { UnregisterEventHotKey(ref) }
+        registered = []
+        actions = [:]
+        if let handler {
+            RemoveEventHandler(handler)
+            self.handler = nil
+        }
+    }
+
+    // No `deinit`: `AppState` owns the one instance for the life of the
+    // process, and `unregister()` is the explicit way to let the keys go.
+}
+
+extension AppState {
+
+    /// The menu bar item and the global shortcuts, on or off together.
+    func setMenuBarItem(_ shown: Bool) {
+        settings.menuBarItem = shown
+        applyMenuBarSetting()
+    }
+
+    /// Registers the global shortcuts when the menu bar item is on, and
+    /// removes them when it is off. Called once at launch and on each change.
+    func applyMenuBarSetting() {
+        guard settings.menuBarItem else {
+            hotKeys.unregister()
+            return
+        }
+        hotKeys.register([
+            GlobalHotKeys.Shortcut(keyCode: UInt32(kVK_ANSI_R),
+                                   modifiers: UInt32(controlKey | optionKey)) { [weak self] in
+                self?.toggleRecording()
+            },
+            GlobalHotKeys.Shortcut(keyCode: UInt32(kVK_ANSI_P),
+                                   modifiers: UInt32(controlKey | optionKey)) { [weak self] in
+                self?.togglePause()
+            },
+        ])
+    }
+
+    /// ⌃⌥R and the menu bar: stop the recording that runs, or start one.
+    /// Nothing during the preparation phase, where a second start would be
+    /// refused with an alert in a window that may not be in front.
+    func toggleRecording() {
+        if isRecording {
+            Task { await stopRecording() }
+        } else if !isLiveBusy {
+            newItem(settings.isAdvanced ? .recording : .meeting)
+        }
+    }
+
+    /// Brings the main window to the front, and makes one if the user closed
+    /// it. The identifier prefix is what SwiftUI gives the windows of the
+    /// `WindowGroup` with id "main".
+    func showMainWindow(_ openWindow: OpenWindowAction) {
+        NSApp.activate(ignoringOtherApps: true)
+        if let window = NSApp.windows.first(where: {
+            $0.identifier?.rawValue.hasPrefix("main") == true
+        }) {
+            window.makeKeyAndOrderFront(nil)
+        } else {
+            openWindow(id: "main")
+        }
+    }
+}

--- a/app/Sources/Transcriber/Settings.swift
+++ b/app/Sources/Transcriber/Settings.swift
@@ -2,6 +2,37 @@ import Foundation
 import Observation
 import TranscriberCore
 
+/// How much of the app is on show.
+///
+/// Simple is the default. It has one button to record, one place to drop a
+/// file, the transcript and the notes. Advanced adds the model tiers, the
+/// audio controls, the benchmark, the decode statistics and the revision menu.
+/// Both modes use the same store and the same pipeline; the switch changes
+/// what the window shows and nothing else.
+enum InterfaceMode: String, CaseIterable, Identifiable {
+    case simple, advanced
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .simple: return "Simple"
+        case .advanced: return "Advanced"
+        }
+    }
+
+    var detail: String {
+        switch self {
+        case .simple:
+            return "Record, drop a file, read the transcript, write notes. "
+                 + "The app selects the model and the audio settings."
+        case .advanced:
+            return "Adds the model tiers, the audio controls, the benchmark, "
+                 + "the decode statistics and the transcript revisions."
+        }
+    }
+}
+
 /// User preferences. Small enough to live in `UserDefaults`, and deliberately
 /// not in the store: none of it is per-recording, and none of it is worth a
 /// migration when it changes.
@@ -30,6 +61,7 @@ final class AppSettings {
         static let inspectorShown = "ui.inspectorShown"
         static let clockTimestamps = "ui.clockTimestamps"
         static let hasSeenWelcome = "ui.hasSeenWelcome"
+        static let interfaceMode = "ui.interfaceMode"
     }
 
     private let defaults: UserDefaults
@@ -47,7 +79,10 @@ final class AppSettings {
             diarizationMode = legacy ? .accurate : .off
         }
         neuralVAD = defaults.object(forKey: Key.neuralVAD) as? Bool ?? true
-        liveTranscription = defaults.object(forKey: Key.liveTranscription) as? Bool ?? true
+        // Off unless asked for. The whole-file pass after the recording is the
+        // better transcript, and a meeting with no model running keeps the
+        // Mac cool and quiet at the table. Nothing loads at launch either.
+        liveTranscription = defaults.object(forKey: Key.liveTranscription) as? Bool ?? false
         keepWorkingCopy = defaults.object(forKey: Key.keepWorkingCopy) as? Bool ?? false
         overrides = defaults.dictionary(forKey: Key.overrides) as? [String: String] ?? [:]
         roomMode = defaults.object(forKey: Key.roomMode) as? Bool ?? false
@@ -60,9 +95,21 @@ final class AppSettings {
         inspectorShown = defaults.dictionary(forKey: Key.inspectorShown) as? [String: Bool] ?? [:]
         clockTimestamps = defaults.object(forKey: Key.clockTimestamps) as? Bool ?? false
         hasSeenWelcome = defaults.object(forKey: Key.hasSeenWelcome) as? Bool ?? false
+        interfaceMode = InterfaceMode(rawValue: defaults.string(forKey: Key.interfaceMode) ?? "")
+            ?? .simple
     }
 
     // MARK: - Interface
+
+    /// Simple or Advanced. Refer to `InterfaceMode`.
+    var interfaceMode: InterfaceMode {
+        didSet { defaults.set(interfaceMode.rawValue, forKey: Key.interfaceMode) }
+    }
+
+    var isAdvanced: Bool {
+        get { interfaceMode == .advanced }
+        set { interfaceMode = newValue ? .advanced : .simple }
+    }
 
     /// Show transcript times as time of day ("9:47:12 PM") rather than offsets.
     var clockTimestamps: Bool { didSet { defaults.set(clockTimestamps, forKey: Key.clockTimestamps) } }
@@ -151,8 +198,13 @@ final class AppSettings {
 
     var offlineModelId: String { modelId(for: tier) }
 
+    /// What the decoder is told before each window: the names and terms the
+    /// user typed, and nothing else. The Taglish style primer in
+    /// `TranscriptionPrompt` is measured through the CLI only: on the live
+    /// path it made the model repeat the primer instead of the room
+    /// (docs/FINDINGS.md, finding 12), so the app never sends it.
     var promptOrNil: String? {
-        prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : prompt
+        TranscriptionPrompt.compose(language: language, usePrimer: false, vocabulary: prompt)
     }
 
     var sessionConfig: SessionConfig {

--- a/app/Sources/Transcriber/Settings.swift
+++ b/app/Sources/Transcriber/Settings.swift
@@ -62,6 +62,7 @@ final class AppSettings {
         static let clockTimestamps = "ui.clockTimestamps"
         static let hasSeenWelcome = "ui.hasSeenWelcome"
         static let interfaceMode = "ui.interfaceMode"
+        static let menuBarItem = "ui.menuBarItem"
     }
 
     private let defaults: UserDefaults
@@ -97,6 +98,7 @@ final class AppSettings {
         hasSeenWelcome = defaults.object(forKey: Key.hasSeenWelcome) as? Bool ?? false
         interfaceMode = InterfaceMode(rawValue: defaults.string(forKey: Key.interfaceMode) ?? "")
             ?? .simple
+        menuBarItem = defaults.object(forKey: Key.menuBarItem) as? Bool ?? true
     }
 
     // MARK: - Interface
@@ -110,6 +112,10 @@ final class AppSettings {
         get { interfaceMode == .advanced }
         set { interfaceMode = newValue ? .advanced : .simple }
     }
+
+    /// The Notero item in the menu bar, with the global shortcuts. Change it
+    /// through `AppState.setMenuBarItem`, which also registers the shortcuts.
+    var menuBarItem: Bool { didSet { defaults.set(menuBarItem, forKey: Key.menuBarItem) } }
 
     /// Show transcript times as time of day ("9:47:12 PM") rather than offsets.
     var clockTimestamps: Bool { didSet { defaults.set(clockTimestamps, forKey: Key.clockTimestamps) } }

--- a/app/Sources/Transcriber/TranscriberApp.swift
+++ b/app/Sources/Transcriber/TranscriberApp.swift
@@ -12,6 +12,14 @@ import TranscriberStore
 /// nothing. Files that arrive before the app has a state to give them to are
 /// kept and delivered when it does.
 final class AppDelegate: NSObject, NSApplicationDelegate {
+    /// Runs once the application has finished its launch. The global
+    /// shortcuts register here: the Carbon event target exists by then.
+    var onLaunch: (() -> Void)?
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        onLaunch?()
+    }
+
     var onOpen: (([URL]) -> Void)? {
         didSet {
             guard let onOpen, !pending.isEmpty else { return }
@@ -59,10 +67,11 @@ struct TranscriberApp: App {
         _state = State(initialValue: state)
         _startupFailure = State(initialValue: failure)
         delegate.onOpen = { urls in state.importFiles(urls) }
+        delegate.onLaunch = { state.applyMenuBarSetting() }
     }
 
     var body: some Scene {
-        WindowGroup("Notero") {
+        WindowGroup("Notero", id: "main") {
             ContentView()
                 .environment(state)
                 .modelContainer(state.container)
@@ -98,5 +107,20 @@ struct TranscriberApp: App {
                 .environment(state)
                 .modelContainer(state.container)
         }
+
+        // Record, Pause and Stop from any application, with the clock beside
+        // the icon. Off in Settings › General if a person does not want it.
+        MenuBarExtra(isInserted: Binding(
+            get: { state.settings.menuBarItem },
+            set: { state.setMenuBarItem($0) }
+        )) {
+            MenuBarMenu()
+                .environment(state)
+                .modelContainer(state.container)
+        } label: {
+            MenuBarLabel()
+                .environment(state)
+        }
+        .menuBarExtraStyle(.menu)
     }
 }

--- a/app/Sources/Transcriber/TranscriberApp.swift
+++ b/app/Sources/Transcriber/TranscriberApp.swift
@@ -1,19 +1,49 @@
+import AppKit
 import SwiftData
 import SwiftUI
 import TranscriberCore
 import TranscriberStore
 
+/// Files that arrive from outside the window: a drop on the Dock icon, "Open
+/// With" in the Finder, or `open -a Notero file.m4a`.
+///
+/// `Info.plist` has declared the audio and video types since the first
+/// release, but nothing received them, thus a drop on the Dock icon did
+/// nothing. Files that arrive before the app has a state to give them to are
+/// kept and delivered when it does.
+final class AppDelegate: NSObject, NSApplicationDelegate {
+    var onOpen: (([URL]) -> Void)? {
+        didSet {
+            guard let onOpen, !pending.isEmpty else { return }
+            let urls = pending
+            pending = []
+            onOpen(urls)
+        }
+    }
+    private var pending: [URL] = []
+
+    func application(_ application: NSApplication, open urls: [URL]) {
+        if let onOpen {
+            onOpen(urls)
+        } else {
+            pending.append(contentsOf: urls)
+        }
+    }
+}
+
 @main
 struct TranscriberApp: App {
 
+    @NSApplicationDelegateAdaptor(AppDelegate.self) private var delegate
     @State private var state: AppState
     @State private var startupFailure: String?
 
     init() {
         let settings = AppSettings()
+        let state: AppState
+        var failure: String?
         do {
-            _state = State(initialValue: AppState(container: try StoreContainer.make(),
-                                                  settings: settings))
+            state = AppState(container: try StoreContainer.make(), settings: settings)
         } catch {
             // An in-memory store rather than a crash: the user can still record,
             // and the message says plainly that nothing will be kept. If even an
@@ -23,9 +53,12 @@ struct TranscriberApp: App {
                 fatalError("Storage is unavailable and an in-memory store could not "
                            + "be created either: \(error.localizedDescription)")
             }
-            _state = State(initialValue: AppState(container: fallback, settings: settings))
-            _startupFailure = State(initialValue: error.localizedDescription)
+            state = AppState(container: fallback, settings: settings)
+            failure = error.localizedDescription
         }
+        _state = State(initialValue: state)
+        _startupFailure = State(initialValue: failure)
+        delegate.onOpen = { urls in state.importFiles(urls) }
     }
 
     var body: some Scene {
@@ -46,12 +79,13 @@ struct TranscriberApp: App {
                 .task {
                     // Ahead of the first tap, not on it: the model load is the
                     // several seconds between hitting record and the recording
-                    // starting.
+                    // starting. Only when live transcription is on; otherwise
+                    // nothing runs until the user asks for something.
                     state.warmUpEngines()
                     if let startupFailure {
                         state.alert = AppState.AppAlert(
-                            title: "Storage unavailable",
-                            message: "Recordings will not be saved this session. \(startupFailure)"
+                            title: "Storage is not available",
+                            message: "The app cannot save recordings in this session. \(startupFailure)"
                         )
                     }
                 }

--- a/app/Sources/Transcriber/Views/BenchmarkView.swift
+++ b/app/Sources/Transcriber/Views/BenchmarkView.swift
@@ -42,8 +42,8 @@ struct BenchmarkView: View {
                     ContentUnavailableView {
                         Label("No measurements yet", systemImage: "speedometer")
                     } description: {
-                        Text("Pick a clip of Tagalog or Taglish speech — a few minutes is "
-                             + "plenty — and each tier will be timed on this machine.")
+                        Text("Select a clip of Tagalog or Taglish speech. A few minutes is "
+                             + "enough. The app then times each tier on this Mac.")
                     }
                 }
             }
@@ -60,9 +60,9 @@ struct BenchmarkView: View {
     private var header: some View {
         VStack(alignment: .leading, spacing: 12) {
             Text("Model Benchmark").font(.title2.weight(.semibold))
-            Text("Published Whisper numbers are English, on other hardware. Neither half "
-                 + "transfers. What matters here is narrower: on this Mac, with this "
-                 + "audio, which tier still decodes faster than the audio arrives.")
+            Text("The published Whisper numbers are for English, on other hardware. "
+                 + "Neither part applies here. The question here is smaller: on this Mac, "
+                 + "with this audio, which tier decodes faster than the audio arrives?")
                 .font(.callout)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
@@ -76,7 +76,7 @@ struct BenchmarkView: View {
                     .toggleStyle(.button)
                 }
                 Spacer()
-                Button("Choose Audio…") { picking = true }
+                Button("Choose a Clip…") { picking = true }
                     // Blocked, not merely warned about: the benchmark bypasses
                     // the queue, so nothing else would stop it competing with a
                     // live recording for the Neural Engine and mismeasuring both.
@@ -87,8 +87,8 @@ struct BenchmarkView: View {
                 Text(clipName).font(.caption).foregroundStyle(.secondary)
             }
             if state.isRecording {
-                Label("A recording is in progress. Benchmarking now would compete with it "
-                      + "for the Neural Engine and mismeasure both.",
+                Label("A recording is in progress. A benchmark now would compete with it "
+                      + "for the Neural Engine, and both measurements would be wrong.",
                       systemImage: "exclamationmark.triangle")
                     .font(.caption)
                     .foregroundStyle(.orange)
@@ -145,16 +145,16 @@ struct BenchmarkView: View {
                 }
             }
 
-            Text("RTF is processing time over audio duration; lower is better. Below 1.0 "
-                 + "is faster than real time, and roughly below 0.6 is fast enough to keep "
-                 + "up with live audio once VAD and the commit policy take their share.")
+            Text("RTF is the processing time divided by the audio duration. Lower is better. "
+                 + "Below 1.0 is faster than real time. Below about 0.6 is fast enough for "
+                 + "live audio, after the voice detection and the commit policy take their share.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
 
             if let recommended = report.recommendedTier {
                 HStack {
-                    Label("Best quality that keeps up: \(recommended.label)",
+                    Label("The best quality that keeps up: \(recommended.label)",
                           systemImage: "checkmark.seal.fill")
                         .foregroundStyle(.green)
                     Spacer()
@@ -168,7 +168,7 @@ struct BenchmarkView: View {
             if let fastest = report.fastestTier,
                fastest != report.recommendedTier {
                 HStack {
-                    Label("Fastest measured: \(fastest.label)",
+                    Label("The fastest tier: \(fastest.label)",
                           systemImage: "bolt.fill")
                         .foregroundStyle(.blue)
                     Spacer()
@@ -183,7 +183,7 @@ struct BenchmarkView: View {
     private func start(_ url: URL) {
         guard running == nil else { return }
         clipName = url.lastPathComponent
-        stage = "Preparing audio…"
+        stage = "Audio preparation…"
         fraction = 0
 
         running = Task {
@@ -195,7 +195,7 @@ struct BenchmarkView: View {
 
                 _ = try await AudioCache.build(from: url, to: cacheURL) { value in
                     Task { @MainActor in
-                        stage = "Preparing audio…"
+                        stage = "Audio preparation…"
                         fraction = value
                     }
                 }
@@ -216,7 +216,7 @@ struct BenchmarkView: View {
             } catch is CancellationError {
                 // Nothing to report; the user asked it to stop.
             } catch {
-                state.alert = AppState.AppAlert(title: "Benchmark failed",
+                state.alert = AppState.AppAlert(title: "The benchmark failed",
                                                 message: error.localizedDescription)
             }
             try? FileManager.default.removeItem(at: cacheURL)

--- a/app/Sources/Transcriber/Views/Components/RecordingInfoBar.swift
+++ b/app/Sources/Transcriber/Views/Components/RecordingInfoBar.swift
@@ -10,6 +10,7 @@ import TranscriberStore
 /// question asked of a transcript that reads oddly, and re-transcribing to find
 /// out is an expensive way to answer it.
 struct RecordingInfoBar: View {
+    @Environment(AppState.self) private var state
     let recording: StoredRecording
     /// The revision on show in the transcript. Nil is the latest.
     @Binding var revision: Int?
@@ -32,11 +33,19 @@ struct RecordingInfoBar: View {
     private var reloadKey: String {
         [recording.id.uuidString,
          shown?.id.uuidString ?? "-",
-         // Rows arrive in batches while a job runs; the word count follows them.
-         String(shown?.segments?.count ?? 0),
+         // Rows arrive in batches while a job runs; the word count follows
+         // them. The tick moves with each batch, and it costs no query.
+         String(state.transcriptTicks[recording.id] ?? 0),
+         String(recording.updatedAt.timeIntervalSinceReferenceDate),
          recording.statusRaw,
-         String(recording.durationMs)].joined(separator: "|")
+         String(recording.durationMs),
+         state.settings.interfaceMode.rawValue].joined(separator: "|")
     }
+
+    /// The model, the decode cost and the revisions are for the Advanced
+    /// mode. In Simple mode the bar gives the date, the length, the language
+    /// and the word count.
+    private var technical: Bool { state.settings.isAdvanced }
 
     var body: some View {
         HStack(spacing: 6) {
@@ -61,7 +70,17 @@ struct RecordingInfoBar: View {
         .lineLimit(1)
         .padding(.horizontal, 16)
         .padding(.bottom, 8)
-        .task(id: reloadKey) { facts = RecordingFacts(recording, transcript: shown) }
+        .task(id: reloadKey) {
+            // The word count reads every row. One query off the main actor,
+            // not a walk of the relationship on it.
+            var segments: [Segment] = []
+            if let id = shown?.id {
+                segments = (try? await state.makeReader().segments(ofTranscript: id)) ?? []
+            }
+            guard !Task.isCancelled else { return }
+            facts = RecordingFacts(recording, transcript: shown, segments: segments,
+                                   technical: technical)
+        }
     }
 
     /// One candidate width for the bar. Every text is `fixedSize` so a row
@@ -77,7 +96,7 @@ struct RecordingInfoBar: View {
                     .help("\(item.label): \(item.value)\(item.help.isEmpty ? "" : "\n\n\(item.help)")")
             }
 
-            if let revisions = recording.transcripts, revisions.count > 1 {
+            if technical, let revisions = recording.transcripts, revisions.count > 1 {
                 if !items.isEmpty { Text("·").foregroundStyle(.quaternary) }
                 revisionMenu(revisions.sorted { $0.revision > $1.revision })
             }
@@ -89,7 +108,7 @@ struct RecordingInfoBar: View {
                     Image(systemName: "info.circle")
                 }
                 .buttonStyle(.borderless)
-                .help("Everything recorded about this transcript")
+                .help("All the facts about this transcript")
                 .popover(isPresented: $showAll, arrowEdge: .bottom) {
                     RecordingFactsTable(facts: facts)
                 }
@@ -124,7 +143,7 @@ struct RecordingInfoBar: View {
         .menuStyle(.borderlessButton)
         .fixedSize()
         .help("Read an earlier transcript of this recording. Edits and notes stay "
-            + "with the revision they were made on.")
+            + "on the revision where you made them.")
     }
 }
 
@@ -184,9 +203,11 @@ struct RecordingFacts {
 
     init() {}
 
-    init(_ recording: StoredRecording, transcript: StoredTranscript? = nil) {
-        let transcript = transcript ?? recording.transcript
-        let segments = transcript?.orderedSegments ?? []
+    /// `segments` are the rows of `transcript`, read by the caller. With
+    /// `technical` false the model, the decode cost, the segment count, the
+    /// revision and the audio file stay out.
+    init(_ recording: StoredRecording, transcript: StoredTranscript?, segments: [Segment],
+         technical: Bool = true) {
 
         items.append(Item(
             label: "Recorded",
@@ -204,19 +225,21 @@ struct RecordingFacts {
             if !transcript.isComplete {
                 items.append(Item(
                     label: "Transcript",
-                    value: recording.status.isBusy ? "Arriving" : "Partial",
+                    value: recording.status.isBusy ? "In progress" : "Partial",
                     help: recording.status.isBusy
-                        ? "Segments are added as each window is decoded."
-                        : "Transcription did not finish. What was decoded is shown; "
-                          + "transcribe again for the rest.",
+                        ? "The app adds lines as it decodes each window."
+                        : "The transcription did not finish. The app shows the lines it "
+                          + "has. Transcribe again to get the rest.",
                     inSummary: true))
             }
             let model = ModelCatalogue.option(transcript.modelId)
-            items.append(Item(
-                label: "Model",
-                value: model?.label ?? transcript.modelId,
-                help: model?.detail ?? "Not one of the catalogued models.",
-                inSummary: true))
+            if technical {
+                items.append(Item(
+                    label: "Model",
+                    value: model?.label ?? transcript.modelId,
+                    help: model?.detail ?? "Not one of the catalogued models.",
+                    inSummary: true))
+            }
 
             let language = LanguageCatalogue.option(transcript.language)
             items.append(Item(
@@ -235,35 +258,36 @@ struct RecordingFacts {
                     value: "\(words.formatted()) words",
                     inSummary: true))
             }
-            items.append(Item(
-                label: "Segments",
-                value: segments.count.formatted()))
-
-            if transcript.processMs > 0 {
+            if technical {
                 items.append(Item(
-                    label: "Processing",
-                    value: processing(transcript.processMs, audioMs: recording.durationMs),
-                    help: "Time the model spent on this recording. A live session "
-                        + "decodes while it records, so this overlaps the recording "
-                        + "itself rather than following it."))
-            }
+                    label: "Segments",
+                    value: segments.count.formatted()))
 
-            if let json = transcript.performanceJSON,
-               let data = json.data(using: .utf8),
-               let metrics = try? JSONDecoder().decode(TranscriptionMetrics.self, from: data) {
-                items.append(contentsOf: performanceItems(metrics))
+                if transcript.processMs > 0 {
+                    items.append(Item(
+                        label: "Processing",
+                        value: processing(transcript.processMs, audioMs: recording.durationMs),
+                        help: "The time the model spent on this recording. A live session "
+                            + "decodes while it records, thus this time overlaps the recording."))
+                }
+
+                if let json = transcript.performanceJSON,
+                   let data = json.data(using: .utf8),
+                   let metrics = try? JSONDecoder().decode(TranscriptionMetrics.self, from: data) {
+                    items.append(contentsOf: performanceItems(metrics))
+                }
             }
 
             items.append(Item(
                 label: "Transcribed",
                 value: transcript.createdAt.formatted(date: .abbreviated, time: .shortened)))
 
-            if transcript.revision > 1 {
+            if technical, transcript.revision > 1 {
                 items.append(Item(
                     label: "Revision",
                     value: "\(transcript.revision)",
-                    help: "Earlier revisions are kept. Re-transcribing adds one "
-                        + "rather than overwriting what you may have annotated."))
+                    help: "The app keeps the earlier revisions. A new transcription adds "
+                        + "a revision and does not overwrite your notes."))
             }
 
             let speakers = recording.speakers ?? []
@@ -282,7 +306,7 @@ struct RecordingFacts {
                 inSummary: true))
         }
 
-        if let audio = recording.audioFileName {
+        if technical, let audio = recording.audioFileName {
             items.append(Item(
                 label: "Audio",
                 value: audioDescription(recording, fileName: audio),

--- a/app/Sources/Transcriber/Views/ContentView.swift
+++ b/app/Sources/Transcriber/Views/ContentView.swift
@@ -18,8 +18,48 @@ struct ContentView: View {
     @State private var isDropTargeted = false
 
     var body: some View {
-        @Bindable var state = state
+        splitView
+            // Up on every launch until a button answers it. An overlay, not a
+            // pane in the detail column and not a sheet: as a pane it took the
+            // split view's layout with it (see WelcomeCard), and a sheet cannot
+            // be left up -- macOS refuses to quit the app while one is open, so
+            // ⌘Q did nothing until the card was answered. An overlay is laid
+            // out inside the frame the window already gave the split view, so
+            // it can neither resize anything nor block the app.
+            .overlay { welcomeDialog }
+            .overlay { dropOverlay }
+            .task { showWelcome = !state.settings.hasSeenWelcome }
+            .navigationTitle(title)
+            .navigationSubtitle(subtitle)
+            .background {
+                // The window's width, not the split view's: an overflowing
+                // split view never reports a smaller size, so the fold below
+                // would never happen.
+                WindowWidthReader { width in state.contentWidth = width }
+            }
+            // Narrow: fold the sidebar rather than let the split view overflow.
+            // The user can still open it from the toolbar; that choice holds
+            // until the width changes again. Wide: put back whatever they had.
+            .onChange(of: state.isCompact) { _, compact in
+                withAnimation(.snappy) {
+                    columnVisibility = compact ? .detailOnly : wideVisibility
+                }
+            }
+            .onChange(of: columnVisibility) { _, visibility in
+                if !state.isCompact { wideVisibility = visibility }
+            }
+            // Drop anywhere in the window. Dropping onto a specific recording
+            // would suggest the audio joins that recording, which is not what
+            // happens.
+            .dropDestination(for: URL.self, action: dropFiles, isTargeted: setDropTargeted)
+            .modifier(Presentations(state: state))
+            .toolbar { toolbar }
+    }
 
+    /// The sidebar beside the detail. Its own expression, and the sheets and
+    /// alerts a modifier of their own (see `Presentations`): with all of it in
+    /// one expression the compiler on CI gave up type-checking `body`.
+    private var splitView: some View {
         NavigationSplitView(columnVisibility: $columnVisibility) {
             SidebarView()
                 .navigationSplitViewColumnWidth(min: 200, ideal: 268, max: 300)
@@ -30,98 +70,19 @@ struct ContentView: View {
                 // is what decides whether the sidebar fits beside it.
                 .navigationSplitViewColumnWidth(min: 260, ideal: 400)
         }
-        // Up on every launch until a button answers it. An overlay, not a pane
-        // in the detail column and not a sheet: as a pane it took the split
-        // view's layout with it (see WelcomeCard), and a sheet cannot be left
-        // up -- macOS refuses to quit the app while one is open, so ⌘Q did
-        // nothing until the card was answered. An overlay is laid out inside
-        // the frame the window already gave the split view, so it can neither
-        // resize anything nor block the app.
-        .overlay { welcomeDialog }
-        .overlay { dropOverlay }
-        .task { showWelcome = !state.settings.hasSeenWelcome }
-        .navigationTitle(title)
-        .navigationSubtitle(subtitle)
-        .background {
-            // The window's width, not the split view's: an overflowing split
-            // view never reports a smaller size, so the fold below would
-            // never happen.
-            WindowWidthReader { width in state.contentWidth = width }
-        }
-        // Narrow: fold the sidebar rather than let the split view overflow.
-        // The user can still open it from the toolbar; that choice holds until
-        // the width changes again. Wide: put back whatever they had.
-        .onChange(of: state.isCompact) { _, compact in
-            withAnimation(.snappy) {
-                columnVisibility = compact ? .detailOnly : wideVisibility
-            }
-        }
-        .onChange(of: columnVisibility) { _, visibility in
-            if !state.isCompact { wideVisibility = visibility }
-        }
-        // Drop anywhere in the window. Dropping onto a specific recording would
-        // suggest the audio joins that recording, which is not what happens.
-        .dropDestination(for: URL.self) { urls, _ in
-            let audio = urls.filter(Self.isImportable)
-            guard !audio.isEmpty else { return false }
-            state.importFiles(audio)
-            return true
-        } isTargeted: { targeted in
-            withAnimation(.easeOut(duration: 0.15)) { isDropTargeted = targeted }
-        }
-        .fileImporter(
-            isPresented: $state.isImporting,
-            allowedContentTypes: AppState.importableTypes,
-            allowsMultipleSelection: true
-        ) { result in
-            switch result {
-            case .success(let urls): state.importFiles(urls)
-            case .failure(let error):
-                state.alert = AppState.AppAlert(title: "The import failed",
-                                                message: error.localizedDescription)
-            }
-        }
-        .sheet(isPresented: $state.isExporting) {
-            if let recording = state.selectedRecording {
-                ExportSheet(recording: recording)
-            }
-        }
-        .alert(
-            "Keep this recording?",
-            isPresented: Binding(
-                get: { state.shortTake != nil },
-                set: { if !$0 { state.shortTake = nil } }
-            ),
-            presenting: state.shortTake
-        ) { _ in
-            Button("Keep") { state.resolveShortTake(keep: true) }
-                .keyboardShortcut(.defaultAction)
-            Button("Discard", role: .destructive) { state.resolveShortTake(keep: false) }
-        } message: { take in
-            Text(Self.shortTakeMessage(take))
-        }
-        .alert(
-            "Already in the library?",
-            isPresented: Binding(
-                get: { !state.duplicateImports.isEmpty },
-                set: { if !$0, let first = state.duplicateImports.first {
-                    state.duplicateImports.removeAll { $0.id == first.id }
-                } }
-            ),
-            presenting: state.duplicateImports.first
-        ) { duplicate in
-            Button("Open the Existing One") { state.resolveDuplicate(duplicate, importAnyway: false) }
-                .keyboardShortcut(.defaultAction)
-            Button("Import a Copy") { state.resolveDuplicate(duplicate, importAnyway: true) }
-            Button("Cancel", role: .cancel) {
-                state.duplicateImports.removeAll { $0.id == duplicate.id }
-            }
-        } message: { duplicate in
-            Text("“\(duplicate.url.lastPathComponent)” has the same size as the audio of "
-                 + "“\(duplicate.existingTitle)”. Open that recording, or import a second copy?")
-        }
-        .toolbar { toolbar }
     }
+
+    private func dropFiles(_ urls: [URL], at _: CGPoint) -> Bool {
+        let audio = urls.filter(Self.isImportable)
+        guard !audio.isEmpty else { return false }
+        state.importFiles(audio)
+        return true
+    }
+
+    private func setDropTargeted(_ targeted: Bool) {
+        withAnimation(.easeOut(duration: 0.15)) { isDropTargeted = targeted }
+    }
+
 
     /// The first-run card, over a scrim that takes the clicks meant for the
     /// window behind it.
@@ -311,5 +272,73 @@ struct ContentView: View {
     static func isImportable(_ url: URL) -> Bool {
         guard let type = UTType(filenameExtension: url.pathExtension) else { return false }
         return AppState.importableTypes.contains { type.conforms(to: $0) }
+    }
+}
+
+/// The sheets and alerts the window can show: the file picker, the export
+/// sheet, the short-take question and the duplicate question. A modifier of
+/// its own so that `ContentView.body` stays an expression the compiler can
+/// type-check in reasonable time.
+private struct Presentations: ViewModifier {
+    @Bindable var state: AppState
+
+    func body(content: Content) -> some View {
+        content
+            .fileImporter(
+                isPresented: $state.isImporting,
+                allowedContentTypes: AppState.importableTypes,
+                allowsMultipleSelection: true,
+                onCompletion: importPicked
+            )
+            .sheet(isPresented: $state.isExporting) {
+                if let recording = state.selectedRecording {
+                    ExportSheet(recording: recording)
+                }
+            }
+            .alert("Keep this recording?", isPresented: askingShortTake, presenting: state.shortTake) { _ in
+                Button("Keep") { state.resolveShortTake(keep: true) }
+                    .keyboardShortcut(.defaultAction)
+                Button("Discard", role: .destructive) { state.resolveShortTake(keep: false) }
+            } message: { take in
+                Text(ContentView.shortTakeMessage(take))
+            }
+            .alert("Already in the library?", isPresented: askingDuplicate, presenting: firstDuplicate) { duplicate in
+                Button("Open the Existing One") { state.resolveDuplicate(duplicate, importAnyway: false) }
+                    .keyboardShortcut(.defaultAction)
+                Button("Import a Copy") { state.resolveDuplicate(duplicate, importAnyway: true) }
+                Button("Cancel", role: .cancel) { dismissDuplicate(duplicate) }
+            } message: { duplicate in
+                Text("“\(duplicate.url.lastPathComponent)” has the same size as the audio of "
+                     + "“\(duplicate.existingTitle)”. Open that recording, or import a second copy?")
+            }
+    }
+
+    private var firstDuplicate: AppState.DuplicateImport? { state.duplicateImports.first }
+
+    private var askingShortTake: Binding<Bool> {
+        Binding(
+            get: { state.shortTake != nil },
+            set: { if !$0 { state.shortTake = nil } }
+        )
+    }
+
+    private var askingDuplicate: Binding<Bool> {
+        Binding(
+            get: { !state.duplicateImports.isEmpty },
+            set: { if !$0, let first = state.duplicateImports.first { dismissDuplicate(first) } }
+        )
+    }
+
+    private func dismissDuplicate(_ duplicate: AppState.DuplicateImport) {
+        state.duplicateImports.removeAll { $0.id == duplicate.id }
+    }
+
+    private func importPicked(_ result: Result<[URL], any Error>) {
+        switch result {
+        case .success(let urls): state.importFiles(urls)
+        case .failure(let error):
+            state.alert = AppState.AppAlert(title: "The import failed",
+                                            message: error.localizedDescription)
+        }
     }
 }

--- a/app/Sources/Transcriber/Views/ContentView.swift
+++ b/app/Sources/Transcriber/Views/ContentView.swift
@@ -12,6 +12,10 @@ struct ContentView: View {
     /// What the user last chose while there was room, restored on widening.
     @State private var wideVisibility = NavigationSplitViewVisibility.all
     @State private var showWelcome = false
+    /// A drag is over the window. The whole window says "drop here" while it
+    /// is, because a drop target that gives no sign is a drop target nobody
+    /// finds.
+    @State private var isDropTargeted = false
 
     var body: some View {
         @Bindable var state = state
@@ -34,6 +38,7 @@ struct ContentView: View {
         // the frame the window already gave the split view, so it can neither
         // resize anything nor block the app.
         .overlay { welcomeDialog }
+        .overlay { dropOverlay }
         .task { showWelcome = !state.settings.hasSeenWelcome }
         .navigationTitle(title)
         .navigationSubtitle(subtitle)
@@ -61,6 +66,8 @@ struct ContentView: View {
             guard !audio.isEmpty else { return false }
             state.importFiles(audio)
             return true
+        } isTargeted: { targeted in
+            withAnimation(.easeOut(duration: 0.15)) { isDropTargeted = targeted }
         }
         .fileImporter(
             isPresented: $state.isImporting,
@@ -70,7 +77,7 @@ struct ContentView: View {
             switch result {
             case .success(let urls): state.importFiles(urls)
             case .failure(let error):
-                state.alert = AppState.AppAlert(title: "Import failed",
+                state.alert = AppState.AppAlert(title: "The import failed",
                                                 message: error.localizedDescription)
             }
         }
@@ -94,7 +101,7 @@ struct ContentView: View {
             Text(Self.shortTakeMessage(take))
         }
         .alert(
-            "Already imported?",
+            "Already in the library?",
             isPresented: Binding(
                 get: { !state.duplicateImports.isEmpty },
                 set: { if !$0, let first = state.duplicateImports.first {
@@ -103,14 +110,14 @@ struct ContentView: View {
             ),
             presenting: state.duplicateImports.first
         ) { duplicate in
-            Button("Open Existing") { state.resolveDuplicate(duplicate, importAnyway: false) }
+            Button("Open the Existing One") { state.resolveDuplicate(duplicate, importAnyway: false) }
                 .keyboardShortcut(.defaultAction)
-            Button("Import Anyway") { state.resolveDuplicate(duplicate, importAnyway: true) }
+            Button("Import a Copy") { state.resolveDuplicate(duplicate, importAnyway: true) }
             Button("Cancel", role: .cancel) {
                 state.duplicateImports.removeAll { $0.id == duplicate.id }
             }
         } message: { duplicate in
-            Text("“\(duplicate.url.lastPathComponent)” is the same size as the audio behind "
+            Text("“\(duplicate.url.lastPathComponent)” has the same size as the audio of "
                  + "“\(duplicate.existingTitle)”. Open that recording, or import a second copy?")
         }
         .toolbar { toolbar }
@@ -140,15 +147,46 @@ struct ContentView: View {
         }
     }
 
+    /// The whole window as a drop target while a drag is over it. It takes no
+    /// clicks and no drops of its own: the split view under it receives the
+    /// drop, and this is only the sign that it will.
+    @ViewBuilder
+    private var dropOverlay: some View {
+        if isDropTargeted {
+            ZStack {
+                Rectangle().fill(Color.accentColor.opacity(0.10))
+                RoundedRectangle(cornerRadius: 16)
+                    .strokeBorder(Color.accentColor, style: StrokeStyle(lineWidth: 3, dash: [12, 8]))
+                    .padding(14)
+                VStack(spacing: 10) {
+                    Image(systemName: "arrow.down.doc.fill")
+                        .font(.system(size: 44))
+                    Text("Drop to transcribe")
+                        .font(.title2.weight(.semibold))
+                    Text("MP3, WAV, M4A, AIFF, MP4 or MOV")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(28)
+                .background(RoundedRectangle(cornerRadius: 14).fill(.regularMaterial))
+                .foregroundStyle(Color.accentColor)
+            }
+            .allowsHitTesting(false)
+            .transition(.opacity)
+        }
+    }
+
     static func shortTakeMessage(_ take: AppState.ShortTake) -> String {
         let seconds = max(1, (take.durationMs + 500) / 1000)
-        let length = "It ran for \(seconds) second\(seconds == 1 ? "" : "s")"
+        let length = "The recording ran for \(seconds) second\(seconds == 1 ? "" : "s")."
+        let heard: String
         switch take.words {
-        case nil: return "\(length). Discarding deletes the audio."
-        case 0: return "\(length) and no words were heard. Discarding deletes the audio."
-        case 1: return "\(length) and one word was heard. Discarding deletes the audio."
-        case let words?: return "\(length) and \(words) words were heard. Discarding deletes the audio."
+        case nil: heard = ""
+        case 0: heard = " The app heard no words."
+        case 1: heard = " The app heard one word."
+        case let words?: heard = " The app heard \(words) words."
         }
+        return "\(length)\(heard) Discard deletes the audio."
     }
 
     private var title: String {
@@ -173,25 +211,49 @@ struct ContentView: View {
 
     @ToolbarContentBuilder
     private var toolbar: some ToolbarContent {
-        ToolbarItem(placement: .primaryAction) {
-            Menu {
-                Button("Recording", systemImage: RecordingKind.recording.symbol) {
-                    state.newItem(.recording)
+        if state.settings.isAdvanced {
+            ToolbarItem(placement: .primaryAction) {
+                Menu {
+                    Button("Recording", systemImage: RecordingKind.recording.symbol) {
+                        state.newItem(.recording)
+                    }
+                    Button("Meeting", systemImage: RecordingKind.meeting.symbol) {
+                        state.newItem(.meeting)
+                    }
+                    Button("Note", systemImage: RecordingKind.note.symbol) {
+                        state.newItem(.note)
+                    }
+                    Divider()
+                    Button("Transcribe a File…", systemImage: "square.and.arrow.down") {
+                        state.isImporting = true
+                    }
+                } label: {
+                    Label("New", systemImage: "plus")
                 }
-                Button("Meeting", systemImage: RecordingKind.meeting.symbol) {
-                    state.newItem(.meeting)
-                }
-                Button("Note", systemImage: RecordingKind.note.symbol) {
-                    state.newItem(.note)
-                }
-                Divider()
-                Button("Import Audio or Video…", systemImage: "square.and.arrow.down") {
-                    state.isImporting = true
-                }
-            } label: {
-                Label("New", systemImage: "plus")
+                .menuIndicator(.hidden)
             }
-            .menuIndicator(.hidden)
+        } else {
+            // Simple mode: the two things a person does, as two buttons, with
+            // their names on them. An icon alone is a guess.
+            ToolbarItemGroup(placement: .primaryAction) {
+                Button {
+                    state.isImporting = true
+                } label: {
+                    Label("Transcribe a File", systemImage: "square.and.arrow.down")
+                        .labelStyle(.titleAndIcon)
+                }
+                .help("Select an audio or video file to transcribe (⌘O)")
+                .disabled(state.isLiveBusy)
+
+                Button {
+                    state.newItem(.meeting)
+                } label: {
+                    Label("Record", systemImage: "record.circle")
+                        .labelStyle(.titleAndIcon)
+                }
+                .help("Record a meeting from the microphone (⌘R)")
+                .disabled(state.isLiveBusy)
+            }
         }
 
         if state.isRecording {
@@ -202,7 +264,7 @@ struct ContentView: View {
                     Label("Stop", systemImage: "stop.fill")
                 }
                 .tint(.red)
-                .help("Stop recording (⌘.)")
+                .help("Stop the recording (⌘.)")
             }
         } else if state.isLiveBusy {
             // The model load, which is seconds cold. Without this the toolbar

--- a/app/Sources/Transcriber/Views/ContentView.swift
+++ b/app/Sources/Transcriber/Views/ContentView.swift
@@ -257,7 +257,15 @@ struct ContentView: View {
         }
 
         if state.isRecording {
-            ToolbarItem(placement: .principal) {
+            ToolbarItemGroup(placement: .principal) {
+                Button {
+                    state.togglePause()
+                } label: {
+                    Label(state.isPaused ? "Resume" : "Pause",
+                          systemImage: state.isPaused ? "play.fill" : "pause.fill")
+                }
+                .help(state.isPaused ? "Continue the recording (⇧⌘P)" : "Pause the recording (⇧⌘P)")
+
                 Button {
                     Task { await state.stopRecording() }
                 } label: {

--- a/app/Sources/Transcriber/Views/DetailView.swift
+++ b/app/Sources/Transcriber/Views/DetailView.swift
@@ -29,19 +29,97 @@ struct DetailView: View {
                         .id(recording.id)
                 }
             } else {
-                ContentUnavailableView("Recording not found", systemImage: "questionmark.folder")
+                ContentUnavailableView("The recording is not in the library",
+                                       systemImage: "questionmark.folder")
             }
         case nil:
-            // The welcome card is a dialog over the window, not a pane here.
-            // See WelcomeCard.
-            ContentUnavailableView {
-                Label("Nothing selected", systemImage: "waveform")
-            } description: {
-                Text("Pick something from the sidebar, press ⌘R to record, or drop an audio file here.")
-            } actions: {
-                Button("New Recording") { state.newItem(.recording) }
-                Button("New Meeting") { state.newItem(.meeting) }
+            HomeView()
+        }
+    }
+}
+
+/// The detail column with nothing selected: a drop zone, and the two things
+/// a person can do first.
+///
+/// One target, two buttons. The whole window accepts a drop (see
+/// `ContentView`), but a target that looks like one is what tells a new user
+/// that a drop is possible at all.
+struct HomeView: View {
+    @Environment(AppState.self) private var state
+
+    var body: some View {
+        VStack(spacing: 24) {
+            VStack(spacing: 10) {
+                Image(systemName: "waveform.badge.plus")
+                    .font(.system(size: 44, weight: .light))
+                    .foregroundStyle(.secondary)
+                Text("Drop an audio or video file here")
+                    .font(.title2.weight(.semibold))
+                Text("The app transcribes the file on this Mac. No audio leaves it.")
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
             }
+
+            HStack(spacing: 12) {
+                Button {
+                    state.isImporting = true
+                } label: {
+                    Label("Choose a File…", systemImage: "folder")
+                        .frame(minWidth: 130)
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+                .keyboardShortcut(.defaultAction)
+
+                Button {
+                    state.newItem(state.settings.isAdvanced ? .recording : .meeting)
+                } label: {
+                    Label("Record", systemImage: "record.circle")
+                        .frame(minWidth: 130)
+                }
+                .controlSize(.large)
+            }
+
+            if state.settings.isAdvanced {
+                HStack(spacing: 16) {
+                    Button("New Meeting") { state.newItem(.meeting) }
+                    Button("New Note") { state.newItem(.note) }
+                }
+                .buttonStyle(.link)
+                .font(.callout)
+            } else {
+                VStack(alignment: .leading, spacing: 6) {
+                    step(1, "Drop a file, or click Record.")
+                    step(2, "Wait. The transcript appears line by line.")
+                    step(3, "Read it, correct it, and export it.")
+                }
+                .font(.callout)
+                .foregroundStyle(.secondary)
+            }
+
+            Text("MP3, WAV, M4A, AIFF, MP4 or MOV")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+        }
+        .padding(.horizontal, 40)
+        .padding(.vertical, 36)
+        .frame(maxWidth: 520)
+        .background {
+            RoundedRectangle(cornerRadius: 18)
+                .strokeBorder(style: StrokeStyle(lineWidth: 1.5, dash: [9, 7]))
+                .foregroundStyle(.quaternary)
+        }
+        .padding(30)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func step(_ number: Int, _ text: String) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Text("\(number)")
+                .font(.caption.weight(.bold))
+                .frame(width: 18, height: 18)
+                .background(Circle().fill(.quaternary))
+            Text(text)
         }
     }
 }
@@ -61,6 +139,10 @@ struct DetailView: View {
 ///
 /// A dialog is also the right shape for what this is: asked once, and up until
 /// it is answered.
+///
+/// In Simple mode the card asks for no microphone permission. The first
+/// recording asks for it, at the moment it is needed; a person who only drops
+/// files is never asked.
 struct WelcomeCard: View {
     @Environment(AppState.self) private var state
 
@@ -68,7 +150,7 @@ struct WelcomeCard: View {
     /// is the card's; taking it off the screen is the caller's.
     var onAnswer: () -> Void = {}
 
-    private var modelId: String { state.settings.liveModelId }
+    private var modelId: String { state.settings.offlineModelId }
     private var model: ModelOption? { ModelCatalogue.option(modelId) }
 
     var body: some View {
@@ -76,16 +158,20 @@ struct WelcomeCard: View {
 
         VStack(alignment: .leading, spacing: 18) {
             VStack(alignment: .leading, spacing: 4) {
-                Text("Before your first recording")
+                Text("Welcome to Notero")
                     .font(.title2.weight(.semibold))
-                Text("Everything runs on this Mac. Nothing leaves it.")
+                Text("Drop an audio or video file on the window, or record a meeting. "
+                     + "Everything runs on this Mac. Nothing leaves it.")
                     .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
             }
 
             GroupBox {
                 VStack(alignment: .leading, spacing: 14) {
-                    MicrophonePermissionRow()
-                    Divider()
+                    if state.settings.isAdvanced {
+                        MicrophonePermissionRow()
+                        Divider()
+                    }
                     modelRow
                     Divider()
                     HStack {
@@ -110,7 +196,7 @@ struct WelcomeCard: View {
             }
 
             HStack {
-                Button("Import Audio…") {
+                Button("Choose a File…") {
                     answered()
                     state.isImporting = true
                 }
@@ -119,10 +205,10 @@ struct WelcomeCard: View {
                 // download continues without the card, and everything on it
                 // is in Settings too.
                 Button("Done") { answered() }
-                    .help("Close this. Everything on it is also in Settings.")
-                Button("New Recording") {
+                    .help("Close this card. Everything on it is also in Settings.")
+                Button("Record") {
                     answered()
-                    state.newItem(.recording)
+                    state.newItem(state.settings.isAdvanced ? .recording : .meeting)
                 }
                 .buttonStyle(.borderedProminent)
                 .keyboardShortcut(.defaultAction)
@@ -179,11 +265,11 @@ struct WelcomeCard: View {
         if downloaded { return "\(name) is on this Mac." }
         let size = model?.sizeLabel ?? ""
         if downloading {
-            return "Downloading \(name). This runs in the background; you can close this card."
+            return "The app downloads \(name) in the background. You can close this card."
         }
-        return "\(name) (\(size)) is not on this Mac yet, and nothing can be transcribed "
-             + "without it. Downloading it now means the first recording does not wait for "
-             + "it. You can skip this and download it later in Settings."
+        return "\(name) (\(size)) is not on this Mac. The app cannot transcribe without it. "
+             + "Download it now, and the first transcription does not wait for it. "
+             + "You can also download it later in Settings."
     }
 }
 
@@ -195,7 +281,12 @@ struct RecordingDetailView: View {
     let recording: StoredRecording
 
     @State private var inspector: InspectorTab = .notes
-    @State private var showInspector = true
+    /// Nil until the user has clicked the toggle in this view: until then the
+    /// remembered choice for the recording kind applies. Read on demand, not
+    /// copied in `onAppear`: an `onAppear` write flipped the inspector after
+    /// the first layout, and the flip rebuilt the transcript view, which read
+    /// the whole transcript a second time.
+    @State private var showInspector: Bool?
     /// An earlier transcript revision open for reading. Nil is the latest.
     @State private var revision: Int?
 
@@ -247,7 +338,7 @@ struct RecordingDetailView: View {
         // their left edge and the inspector its right. Folding the inspector
         // keeps the transcript whole; widening the window brings it back.
         .inspector(isPresented: Binding(
-            get: { showInspector && state.hasRoomForInspector },
+            get: { inspectorWanted && state.hasRoomForInspector },
             set: { showInspector = $0 }
         )) {
             VStack(spacing: 0) {
@@ -268,23 +359,26 @@ struct RecordingDetailView: View {
             }
             .inspectorColumnWidth(min: 260, ideal: 320, max: 520)
         }
-        .onAppear { showInspector = state.settings.inspectorShown(for: recording.kind) }
         .onChange(of: showInspector) { _, shown in
-            state.settings.setInspectorShown(shown, for: recording.kind)
+            if let shown { state.settings.setInspectorShown(shown, for: recording.kind) }
         }
         .toolbar {
             ToolbarItem {
                 Button {
-                    withAnimation(.snappy) { showInspector.toggle() }
+                    withAnimation(.snappy) { showInspector = !inspectorWanted }
                 } label: {
-                    Label("Meeting Notes", systemImage: "sidebar.right")
+                    Label("Notes", systemImage: "sidebar.right")
                 }
                 .disabled(!state.hasRoomForInspector)
                 .help(state.hasRoomForInspector
-                      ? "Show or hide the meeting workspace"
-                      : "Widen the window to show the meeting workspace beside the transcript")
+                      ? "Show or hide the notes"
+                      : "Make the window wider to show the notes beside the transcript")
             }
         }
+    }
+
+    private var inspectorWanted: Bool {
+        showInspector ?? state.settings.inspectorShown(for: recording.kind)
     }
 
     /// "Notes 7", "Speakers 6": the count is the reason to open the tab.
@@ -340,20 +434,19 @@ struct RecordingDetailView: View {
                 StatusChip(status: recording.status)
             } else if recording.status == .failed {
                 StatusChip(status: .failed)
-                if recording.hasAudio { RerunButton(recording: recording, label: "Retry") }
+                if recording.hasAudio { rerun("Retry") }
             } else if recording.status == .cancelled {
                 StatusChip(status: .cancelled)
-                if recording.hasAudio { RerunButton(recording: recording, label: "Transcribe") }
+                if recording.hasAudio { rerun("Transcribe") }
             } else if let warning = recording.warningMessage ?? state.warnings[recording.id] {
                 Label(warning, systemImage: "exclamationmark.triangle.fill")
                     .font(.caption)
                     .foregroundStyle(.orange)
                     .lineLimit(2)
                     .help(warning)
-                if recording.hasAudio { RerunButton(recording: recording) }
+                if recording.hasAudio { rerun("Transcribe Again") }
             } else if recording.hasAudio {
-                RerunButton(recording: recording, label: "Re-run")
-                    .help("Transcribe again on another tier, or identify speakers again")
+                rerun("Transcribe Again")
             }
 
             // Click exports; the arrow offers the clipboard. Copy is the more
@@ -374,9 +467,24 @@ struct RecordingDetailView: View {
             } primaryAction: {
                 state.isExporting = true
             }
-            .help("Export as text, Markdown minutes, SRT, VTT or JSON (⌘E). "
-                + "The arrow copies to the clipboard instead.")
+            .help("Export as text, Markdown, SRT, VTT or JSON (⌘E). "
+                + "The arrow copies the transcript to the clipboard.")
             .disabled(recording.transcript == nil)
+        }
+    }
+
+    /// Advanced mode offers the tiers and the speaker pass; Simple mode has
+    /// one button that uses the tier from Settings.
+    @ViewBuilder
+    private func rerun(_ label: String) -> some View {
+        if state.settings.isAdvanced {
+            RerunButton(recording: recording, label: label)
+                .help("Transcribe again on another tier, or identify the speakers again")
+        } else {
+            Button(label) { state.retranscribe(recording) }
+                .buttonStyle(.borderless)
+                .font(.caption)
+                .help("Transcribe this recording again")
         }
     }
 }

--- a/app/Sources/Transcriber/Views/ExportSheet.swift
+++ b/app/Sources/Transcriber/Views/ExportSheet.swift
@@ -85,7 +85,7 @@ struct ExportSheet: View {
                         .padding(.horizontal, 6)
                         .padding(.vertical, 1)
                         .background(Capsule().fill(.quaternary))
-                        .help("Only the ticked speakers and the time range are exported")
+                        .help("The export contains only the ticked speakers and the time range")
                 }
                 Spacer()
                 Button("Cancel") { dismiss() }
@@ -109,7 +109,7 @@ struct ExportSheet: View {
             )
         ) { result in
             if case .failure(let error) = result {
-                state.alert = AppState.AppAlert(title: "Export failed",
+                state.alert = AppState.AppAlert(title: "The export failed",
                                                 message: error.localizedDescription)
             }
             dismiss()
@@ -161,7 +161,7 @@ struct ExportSheet: View {
             }
             .textFieldStyle(.roundedBorder)
             .font(.system(.callout, design: .monospaced))
-            .help("Lines starting inside this range. Type times as 12:34 or 1:02:03.")
+            .help("Lines that start inside this range. Type a time as 12:34 or 1:02:03.")
         }
         .frame(minWidth: 200, alignment: .leading)
     }

--- a/app/Sources/Transcriber/Views/MeetingPanes.swift
+++ b/app/Sources/Transcriber/Views/MeetingPanes.swift
@@ -39,7 +39,7 @@ struct NotesPane: View {
                     .background(RoundedRectangle(cornerRadius: 6).fill(.background))
                     .overlay(alignment: .topLeading) {
                         if recording.summary.isEmpty {
-                            Text("What was this about?")
+                            Text("What was the meeting about?")
                                 .foregroundStyle(.tertiary)
                                 .font(.callout)
                                 .padding(.horizontal, 11)
@@ -92,7 +92,7 @@ struct NotesPane: View {
             }
             .menuStyle(.borderlessButton)
             .fixedSize()
-            .help("What kind of note this is")
+            .help("The kind of note")
 
             TextField("Add a \(quickKind.label.lowercased())…", text: $quickText)
                 .textFieldStyle(.roundedBorder)
@@ -202,7 +202,7 @@ struct ItemRow: View {
                     }
                     .buttonStyle(.plain)
                     .foregroundStyle(.tint)
-                    .help("Jump to where this came from")
+                    .help("Go to the line this came from")
                 }
             }
             Spacer(minLength: 0)
@@ -239,7 +239,7 @@ struct BookmarksPane: View {
                 ContentUnavailableView {
                     Label("No bookmarks", systemImage: "bookmark")
                 } description: {
-                    Text("Press ⌘B while recording or playing to mark the moment.")
+                    Text("Press ⌘B during a recording or during playback to mark the moment.")
                 }
             } else {
                 List {
@@ -310,8 +310,8 @@ struct SpeakersPane: View {
                     Label("No speakers yet", systemImage: "person.2")
                 } description: {
                     Text(state.progress[recording.id]?.status == .diarizing
-                         ? "Identifying speakers…"
-                         : "Speakers are identified after transcription finishes.")
+                         ? "Speaker identification in progress…"
+                         : "The app identifies the speakers after the transcription.")
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
@@ -325,9 +325,9 @@ struct SpeakersPane: View {
                 }
                 .listStyle(.inset)
                 .safeAreaInset(edge: .bottom) {
-                    Text("Rename here and every line follows. Right-click a speaker to "
-                         + "merge it into another; right-click a transcript line to move "
-                         + "just that line.")
+                    Text("Rename a speaker here, and every line follows. Right-click a "
+                         + "speaker to merge it into another one. Right-click a transcript "
+                         + "line to move only that line.")
                         .font(.caption2)
                         .foregroundStyle(.secondary)
                         .padding(12)
@@ -351,7 +351,7 @@ struct SpeakersPane: View {
                     }
                 ), in: 0...30) {
                     HStack(spacing: 6) {
-                        Text("People in the room")
+                        Text("Persons in the room")
                         Text(recording.expectedSpeakers.map(String.init) ?? "Any")
                             .foregroundStyle(.secondary)
                             .monospacedDigit()
@@ -363,19 +363,19 @@ struct SpeakersPane: View {
                 if recording.hasAudio, state.progress[recording.id] == nil {
                     Button("Identify Again") { state.rediarize(recording) }
                         .controlSize(.small)
-                        .help("Run speaker identification again, aiming at this count")
+                        .help("Run the speaker identification again, with this count as the target")
                 }
             }
             if speakers.count > 1, let expected = recording.expectedSpeakers,
                speakers.count > expected {
-                Text("\(speakers.count) found for \(expected) people. Merge the fragments "
-                     + "below, or Identify Again to let the count guide the pass.")
+                Text("The app found \(speakers.count) speakers for \(expected) persons. Merge "
+                     + "the fragments below, or click Identify Again.")
                     .font(.caption)
                     .foregroundStyle(.orange)
                     .fixedSize(horizontal: false, vertical: true)
             } else {
-                Text("A target for speaker identification, not a limit. Voices the "
-                     + "model hears as clearly different stay separate.")
+                Text("A target for the speaker identification, and not a limit. Voices "
+                     + "that the model hears as different stay separate.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)

--- a/app/Sources/Transcriber/Views/RecordingView.swift
+++ b/app/Sources/Transcriber/Views/RecordingView.swift
@@ -3,9 +3,15 @@ import TranscriberCore
 import TranscriberStore
 
 /// The live screen. Everything on it is transient except the committed text.
+///
+/// Simple mode shows the clock, the meter, the three buttons and the text.
+/// Advanced mode adds the gain slider, room mode, the model and the decode
+/// statistics.
 struct RecordingView: View {
     @Environment(AppState.self) private var state
     let recording: StoredRecording
+
+    private var advanced: Bool { state.settings.isAdvanced }
 
     /// The model is still loading. Capture has not started, so there is no
     /// elapsed time, no level and nothing to mute yet -- but there is very
@@ -23,13 +29,15 @@ struct RecordingView: View {
     private var modelSummary: String {
         let id = state.settings.liveModelId
         let model = ModelCatalogue.option(id)
-        let language = state.settings.language == "auto"
-            ? "Auto-detect"
-            : (LanguageCatalogue.option(state.settings.language)?.label
-               ?? state.settings.language)
-        return [model?.label ?? id, model?.sizeLabel, language]
+        return [model?.label ?? id, model?.sizeLabel, languageLabel]
             .compactMap { $0 }
             .joined(separator: " · ")
+    }
+
+    private var languageLabel: String {
+        state.settings.language == "auto"
+            ? "Automatic language"
+            : (LanguageCatalogue.option(state.settings.language)?.label ?? state.settings.language)
     }
 
     var body: some View {
@@ -68,12 +76,14 @@ struct RecordingView: View {
                 }
             }
             if isLoadingModel {
-                // Named here rather than left to WhisperKit's progress string,
-                // which only says "Loading" once the file is found.
-                Text(modelSummary)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                Text("The model loads once. Recordings after this one start immediately.")
+                if advanced {
+                    // Named here rather than left to WhisperKit's progress
+                    // string, which only says "Loading" once the file is found.
+                    Text(modelSummary)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Text("The model loads one time. The next recordings start at once.")
                     .font(.caption)
                     .foregroundStyle(.tertiary)
                     .multilineTextAlignment(.center)
@@ -116,22 +126,24 @@ struct RecordingView: View {
                     .frame(maxWidth: 480)
             }
 
-            InputGainSlider(gainDb: Binding(
-                get: { state.settings.inputGainDb },
-                set: { state.setInputGain($0) }
-            ), isClipping: InputGain.isClipping(state.live.level))
-            .padding(.horizontal, 40)
+            if advanced {
+                InputGainSlider(gainDb: Binding(
+                    get: { state.settings.inputGainDb },
+                    set: { state.setInputGain($0) }
+                ), isClipping: InputGain.isClipping(state.live.level))
+                .padding(.horizontal, 40)
 
-            Toggle(isOn: Binding(
-                get: { state.settings.roomMode },
-                set: { state.setRoomMode($0) }
-            )) {
-                Label("Room mode", systemImage: "person.3")
+                Toggle(isOn: Binding(
+                    get: { state.settings.roomMode },
+                    set: { state.setRoomMode($0) }
+                )) {
+                    Label("Room mode", systemImage: "person.3")
+                }
+                .toggleStyle(.button)
+                .help("Removes low-frequency room noise before transcription. "
+                    + "For a microphone that hears a table and not a person. "
+                    + "The saved recording does not change.")
             }
-            .toggleStyle(.button)
-            .help("Filters out low-frequency room noise before transcription. "
-                + "For a mic picking up a table rather than a person. "
-                + "The saved recording is not affected.")
 
             // Words on the buttons while there is room, icons in a narrow window.
             ViewThatFits(in: .horizontal) {
@@ -152,7 +164,7 @@ struct RecordingView: View {
                 Label(state.live.isMuted ? "Unmute" : "Mute",
                       systemImage: state.live.isMuted ? "mic.slash.fill" : "mic.fill")
             }
-            .help(state.live.isMuted ? "Unmute" : "Mute")
+            .help(state.live.isMuted ? "Unmute the microphone" : "Mute the microphone")
 
             Button {
                 Task { await state.stopRecording() }
@@ -163,7 +175,7 @@ struct RecordingView: View {
             .buttonStyle(.borderedProminent)
             .tint(.red)
             .keyboardShortcut(".", modifiers: .command)
-            .help("Stop recording (⌘.)")
+            .help("Stop the recording (⌘.)")
 
             Button {
                 _ = state.addBookmark()
@@ -205,11 +217,11 @@ struct RecordingView: View {
 
                     if state.live.segments.isEmpty && state.live.partial.isEmpty {
                         VStack(spacing: 6) {
-                            Text(isPreparing ? "Not recording yet…"
-                                 : (state.live.decodeLive ? "Listening…" : "Recording"))
+                            Text(isPreparing ? "The recording has not started."
+                                 : (state.live.decodeLive ? "The app listens. Text comes here." : "Recording"))
                             if !isPreparing, !state.live.decodeLive {
-                                Text("Transcription runs when you stop. Turn on "
-                                     + "“Transcribe while recording” in Settings to see text live.")
+                                Text("The transcript comes after you stop. To see text during "
+                                     + "a recording, turn on “Show text while you record” in Settings.")
                                     .font(.caption)
                                     .multilineTextAlignment(.center)
                                     .frame(maxWidth: 380)
@@ -241,9 +253,7 @@ struct RecordingView: View {
                 footerLeading.labelStyle(.iconOnly).fixedSize()
             }
             Spacer()
-            Text(state.settings.language == "auto"
-                 ? "Auto-detect"
-                 : (LanguageCatalogue.option(state.settings.language)?.label ?? state.settings.language))
+            Text(languageLabel)
                 .lineLimit(1)
         }
         .font(.caption)
@@ -253,12 +263,18 @@ struct RecordingView: View {
         .background(.bar)
     }
 
+    @ViewBuilder
     private var footerLeading: some View {
         HStack(spacing: 14) {
             if !state.live.decodeLive {
-                Label("Transcribes after you stop, on \(ModelCatalogue.option(state.settings.offlineModelId)?.label ?? state.settings.offlineModelId)",
-                      systemImage: "clock")
-            } else {
+                if advanced {
+                    Label("The transcript comes after you stop, on "
+                          + "\(ModelCatalogue.option(state.settings.offlineModelId)?.label ?? state.settings.offlineModelId)",
+                          systemImage: "clock")
+                } else {
+                    Label("The transcript comes after you stop", systemImage: "clock")
+                }
+            } else if advanced {
                 // Which model is decoding: the first thing anyone wants to know
                 // when the live text reads oddly.
                 Label(ModelCatalogue.option(state.settings.liveModelId)?.label
@@ -271,12 +287,14 @@ struct RecordingView: View {
                 Button {
                     showStats.toggle()
                 } label: {
-                    Label("Stats", systemImage: state.live.stats.droppedHops > 0
+                    Label("Statistics", systemImage: state.live.stats.droppedHops > 0
                           ? "exclamationmark.circle" : "info.circle")
                 }
                 .buttonStyle(.borderless)
                 .foregroundStyle(state.live.stats.droppedHops > 0 ? .orange : .secondary)
                 .popover(isPresented: $showStats, arrowEdge: .top) { statsPopover }
+            } else {
+                Label("Live text", systemImage: "text.bubble")
             }
         }
     }
@@ -296,14 +314,14 @@ struct RecordingView: View {
                 GridRow {
                     Text("RTF").foregroundStyle(.secondary)
                     Text(String(format: "%.2f", stats.meanRtf))
-                        .help("Decode time over audio duration. Below 1.0 keeps up with live audio.")
+                        .help("The decode time divided by the audio duration. Below 1.0, the app keeps up with the audio.")
                 }
             }
             GridRow {
                 Text("Dropped").foregroundStyle(.secondary)
                 Text("\(stats.droppedHops)")
                     .foregroundStyle(stats.droppedHops > 0 ? .orange : .primary)
-                    .help("Windows skipped because the previous decode was still running.")
+                    .help("Windows that the app skipped because the previous decode was not complete.")
             }
             if stats.failedHops > 0 {
                 GridRow {
@@ -314,16 +332,15 @@ struct RecordingView: View {
             GridRow {
                 Text("Utterances").foregroundStyle(.secondary)
                 Text("\(stats.boundaries) closed · \(stats.finalizations) final decodes")
-                    .help("Pauses that ended an utterance, and how many needed a decode of "
-                          + "their own rather than reusing the hop already running.")
+                    .help("Pauses that ended an utterance, and how many of them needed their own decode.")
             }
             if stats.unagreedTailCommits > 0 || stats.finalFlushOnEmpty > 0 {
                 GridRow {
-                    Text("Unagreed").foregroundStyle(.secondary)
+                    Text("Not agreed").foregroundStyle(.secondary)
                     Text("\(stats.unagreedTailCommits) words"
                          + (stats.finalFlushOnEmpty > 0 ? " · \(stats.finalFlushOnEmpty) empty finals" : ""))
-                        .help("Words committed at a pause from the final decode alone, before a "
-                              + "second pass could agree with them.")
+                        .help("Words that the app committed at a pause from the final decode alone, "
+                              + "before a second pass agreed.")
                 }
             }
             if stats.forcedCommits > 0 {
@@ -331,24 +348,25 @@ struct RecordingView: View {
                     Text("Forced").foregroundStyle(.secondary)
                     Text("\(stats.forcedCommits)")
                         .foregroundStyle(.orange)
-                        .help("Commits made without agreement because the window had to slide. "
-                              + "A high count means the hop and window are mistuned.")
+                        .help("Commits with no agreement, because the window had to move. "
+                              + "A high count means that the hop and the window do not match.")
                 }
             }
             if stats.hallucinationsDropped > 0 {
                 GridRow {
                     Text("Not spoken").foregroundStyle(.secondary)
                     Text("\(stats.hallucinationsDropped)")
-                        .help("Words the model placed past the end of the audio or inside a "
-                              + "pause the voice detector had already closed. Dropped.")
+                        .help("Words that the model placed after the end of the audio, or inside a "
+                              + "pause that the voice detector confirmed. The app dropped them.")
                 }
             }
             if stats.duplicatesDropped > 0 {
                 GridRow {
                     Text("Deduplicated").foregroundStyle(.secondary)
                     Text("\(stats.duplicatesDropped)")
-                        .help("Boundary words the model re-read from the pre-roll with drifted "
-                              + "timing, caught by text so they were not committed twice.")
+                        .help("Words at a boundary that the model read again from the pre-roll "
+                              + "with a different time. The app matched them by text and did "
+                              + "not commit them twice.")
                 }
             }
         }

--- a/app/Sources/Transcriber/Views/RecordingView.swift
+++ b/app/Sources/Transcriber/Views/RecordingView.swift
@@ -95,16 +95,24 @@ struct RecordingView: View {
         .background(.background.secondary)
     }
 
+    private var isPaused: Bool { state.live.isPaused }
+
+    private var headerTitle: String {
+        if isPaused { return "Paused" }
+        return state.live.isMuted ? "Muted" : "Recording"
+    }
+
     private var recordingHeader: some View {
         VStack(spacing: 14) {
             HStack(spacing: 8) {
                 Circle()
-                    .fill(.red)
+                    .fill(isPaused ? Color.secondary : Color.red)
                     .frame(width: 10, height: 10)
-                    .opacity(state.live.isMuted ? 0.3 : 1)
-                    .symbolEffect(.pulse, isActive: true)
-                Text(state.live.isMuted ? "Muted" : "Recording")
+                    .opacity(state.live.isMuted && !isPaused ? 0.3 : 1)
+                    .symbolEffect(.pulse, isActive: !isPaused)
+                Text(headerTitle)
                     .font(.headline)
+                    .contentTransition(.identity)
             }
 
             Text(TimeFormat.short(ms: state.live.elapsedMs))
@@ -164,7 +172,25 @@ struct RecordingView: View {
                 Label(state.live.isMuted ? "Unmute" : "Mute",
                       systemImage: state.live.isMuted ? "mic.slash.fill" : "mic.fill")
             }
-            .help(state.live.isMuted ? "Unmute the microphone" : "Mute the microphone")
+            .help(state.live.isMuted
+                  ? "Unmute the microphone"
+                  : "Mute the microphone. The clock continues, and the file gets silence.")
+
+            // Pause is the other way to stop the sound: the clock and the
+            // file stop too, and the break is not in the recording.
+            Button {
+                state.togglePause()
+            } label: {
+                Label(isPaused ? "Resume" : "Pause",
+                      systemImage: isPaused ? "play.fill" : "pause.fill")
+                    .frame(minWidth: 60)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(isPaused ? .green : .accentColor)
+            .keyboardShortcut("p", modifiers: [.command, .shift])
+            .help(isPaused
+                  ? "Continue the recording (⇧⌘P)"
+                  : "Pause the recording. The clock and the file stop until Resume (⇧⌘P).")
 
             Button {
                 Task { await state.stopRecording() }
@@ -215,7 +241,14 @@ struct RecordingView: View {
                         .id("partial")
                     }
 
-                    if state.live.segments.isEmpty && state.live.partial.isEmpty {
+                    if isPaused {
+                        Label("Paused. Click Resume to continue.", systemImage: "pause.circle")
+                            .foregroundStyle(.secondary)
+                            .padding(.top, 12)
+                            .frame(maxWidth: .infinity)
+                    }
+
+                    if state.live.segments.isEmpty && state.live.partial.isEmpty && !isPaused {
                         VStack(spacing: 6) {
                             Text(isPreparing ? "The recording has not started."
                                  : (state.live.decodeLive ? "The app listens. Text comes here." : "Recording"))

--- a/app/Sources/Transcriber/Views/SearchView.swift
+++ b/app/Sources/Transcriber/Views/SearchView.swift
@@ -16,7 +16,7 @@ struct SearchView: View {
         VStack(spacing: 0) {
             HStack(spacing: 10) {
                 Image(systemName: "magnifyingglass").foregroundStyle(.secondary)
-                TextField("Search transcripts, notes and bookmarks", text: $state.searchText)
+                TextField("Search the transcripts, notes and bookmarks", text: $state.searchText)
                     .textFieldStyle(.plain)
                     .font(.title3)
                     .focused($focused)
@@ -41,7 +41,8 @@ struct SearchView: View {
                         Label("Search everything", systemImage: "magnifyingglass")
                     } description: {
                         Text("Words from any transcript, note, action item or bookmark. "
-                             + "Quote a phrase to keep it together. Results jump to the moment.")
+                             + "Put a phrase in quotes to keep it together. A result opens the "
+                             + "recording at that moment.")
                     }
                 } else if visible.isEmpty {
                     ContentUnavailableView.search(text: state.searchText)

--- a/app/Sources/Transcriber/Views/SettingsView.swift
+++ b/app/Sources/Transcriber/Views/SettingsView.swift
@@ -7,6 +7,9 @@ import TranscriberStore
 /// The tab version was a fixed 560×430 and clipped its own content: the
 /// Models tab hid the tier picker under the toolbar. Panes scroll on their
 /// own, the window resizes, and each pane holds one subject.
+///
+/// Simple mode has three panes: General, Audio and About. Advanced mode adds
+/// Models and Storage, and more rows in the first two.
 struct SettingsView: View {
     @Environment(AppState.self) private var state
     @State private var pane: Pane? = .general
@@ -32,11 +35,16 @@ struct SettingsView: View {
             case .about: return "info.circle"
             }
         }
+        var isAdvanced: Bool { self == .models || self == .storage }
+    }
+
+    private var panes: [Pane] {
+        Pane.allCases.filter { state.settings.isAdvanced || !$0.isAdvanced }
     }
 
     var body: some View {
         NavigationSplitView {
-            List(Pane.allCases, selection: $pane) { pane in
+            List(panes, selection: $pane) { pane in
                 Label(pane.label, systemImage: pane.symbol).tag(pane)
             }
             .listStyle(.sidebar)
@@ -53,6 +61,35 @@ struct SettingsView: View {
         }
         .navigationTitle((pane ?? .general).label)
         .frame(minWidth: 700, idealWidth: 760, minHeight: 500, idealHeight: 580)
+        .onChange(of: state.settings.isAdvanced) { _, advanced in
+            // A pane that just left the list must not stay on show.
+            if !advanced, pane?.isAdvanced == true { pane = .general }
+        }
+    }
+}
+
+/// The Simple/Advanced switch, with what each mode means. The same switch
+/// is in the sidebar footer and in the View menu.
+struct InterfaceModeSection: View {
+    @Environment(AppState.self) private var state
+
+    var body: some View {
+        @Bindable var settings = state.settings
+
+        Section {
+            Picker("Mode", selection: $settings.interfaceMode) {
+                ForEach(InterfaceMode.allCases) { mode in
+                    Text(mode.label).tag(mode)
+                }
+            }
+            .pickerStyle(.segmented)
+            Text(settings.interfaceMode.detail)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        } header: {
+            Text("Mode")
+        }
     }
 }
 
@@ -63,8 +100,11 @@ struct GeneralSettings: View {
 
     var body: some View {
         @Bindable var settings = state.settings
+        let advanced = settings.isAdvanced
 
         Form {
+            InterfaceModeSection()
+
             Section {
                 Picker("Language", selection: $settings.language) {
                     ForEach(LanguageCatalogue.all) { option in
@@ -80,57 +120,81 @@ struct GeneralSettings: View {
             } header: {
                 Text("Language")
             } footer: {
-                Text("Transcripts are never translated or rewritten. Code-switched "
-                     + "English inside Tagalog is written as spoken.")
+                Text("The app does not translate a transcript and does not rewrite it. "
+                     + "It writes code-switched English inside Tagalog as the speaker said it.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
 
-            Section("Vocabulary") {
+            Section("Names and terms") {
                 TextField("Names and terms", text: $settings.prompt, axis: .vertical)
                     .lineLimit(2...4)
-                Text("Comma-separated hints, e.g. names of the people in the meeting. "
-                     + "The model is more likely to spell them correctly.")
+                Text("Names and terms, with commas between them. For example, the names of "
+                     + "the persons in the meeting. The model spells them correctly more often.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
 
-            Section("While recording") {
-                Toggle("Transcribe while recording", isOn: $settings.liveTranscription)
-                Text(settings.liveTranscription
-                     ? "Text appears as people speak, on the Balanced model. The "
-                       + "recording still gets the full whole-file pass afterwards "
-                       + "for speaker identification."
-                     : "Recording only. The transcript is made when you stop, by the "
-                       + "whole-file pass on the tier chosen under Models — the better "
-                       + "transcript, and nothing runs on the Mac during the meeting.")
+            Section("While you record") {
+                Toggle("Show text while you record", isOn: $settings.liveTranscription)
+                Text(liveDetail(advanced: advanced))
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
             }
 
-            Section("After recording") {
-                Picker("Speaker identification", selection: $settings.diarizationMode) {
-                    ForEach(DiarizationMode.allCases) { mode in
-                        Text(mode.label).tag(mode)
+            Section("After you record") {
+                if advanced {
+                    Picker("Speaker identification", selection: $settings.diarizationMode) {
+                        ForEach(DiarizationMode.allCases) { mode in
+                            Text(mode.label).tag(mode)
+                        }
                     }
+                    .pickerStyle(.segmented)
+                    Text(settings.diarizationMode.summary)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                    Toggle("Neural voice activity detection", isOn: $settings.neuralVAD)
+                    Text(settings.neuralVAD
+                         ? "Silero on the Neural Engine. Better in a noisy room. If the model "
+                           + "cannot load, the app uses energy detection."
+                         : "Energy detection. No model to download, and worse with background noise.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                } else {
+                    Toggle("Identify the speakers", isOn: Binding(
+                        get: { settings.diarizationMode.performsDiarization },
+                        set: { settings.diarizationMode = $0 ? .accurate : .off }
+                    ))
+                    Text(settings.diarizationMode.performsDiarization
+                         ? "Each line gets a speaker label: Speaker 1, Speaker 2, and more. "
+                           + "You can rename them. This adds time after the transcription."
+                         : "No speaker labels. The transcript is ready as soon as the speech "
+                           + "recognition is complete.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
-                .pickerStyle(.segmented)
-                Text(settings.diarizationMode.summary)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-                Toggle("Neural voice activity detection", isOn: $settings.neuralVAD)
-                Text(settings.neuralVAD
-                     ? "Silero on the Neural Engine. Better in a noisy room; falls back "
-                       + "to energy detection if the model cannot load."
-                     : "Energy thresholding. No model to download, worse with background noise.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
             }
         }
         .formStyle(.grouped)
+    }
+
+    private func liveDetail(advanced: Bool) -> String {
+        if state.settings.liveTranscription {
+            return "Text appears while the persons speak, on the Balanced model. The app "
+                 + "still runs the full pass after the recording, and that pass gives the "
+                 + "transcript you keep."
+        }
+        if advanced {
+            return "The app records only. It makes the transcript when you stop, with the "
+                 + "tier from Models. This is the better transcript, and nothing runs on "
+                 + "the Mac during the meeting."
+        }
+        return "The app records only. It makes the transcript when you stop. This is the "
+             + "better transcript, and nothing runs on the Mac during the meeting."
     }
 }
 
@@ -168,34 +232,36 @@ struct AudioSettings: View {
                 }
             }
 
-            Section("Input") {
-                InputGainSlider(gainDb: $settings.inputGainDb)
-                Text("Built-in laptop microphones run 15-20 dB quieter than a "
-                     + "headset at conversational distance. The boost applies to "
-                     + "the saved recording as well as to transcription, and can "
-                     + "be adjusted while recording.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
+            if settings.isAdvanced {
+                Section("Input") {
+                    InputGainSlider(gainDb: $settings.inputGainDb)
+                    Text("The microphone in a laptop is 15 to 20 dB quieter than a headset at "
+                         + "the distance of a conversation. The boost applies to the saved "
+                         + "recording and to the transcription. You can adjust it during a "
+                         + "recording.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
 
-            Section("Room") {
-                Toggle("Room mode", isOn: Binding(
-                    get: { settings.roomMode },
-                    set: { state.setRoomMode($0) }
-                ))
-                Text(settings.roomMode
-                     ? "Removes rumble below \(Int(HighPassFilter.roomCornerHz)) Hz — "
-                     + "desk knocks, typing and aircon — before transcription. The "
-                     + "saved recording keeps the full range, so turning this off "
-                     + "and transcribing again undoes it."
-                     : "For a microphone picking up a room rather than a person. On a "
-                     + "meeting recorded across a table, most of what reaches the mic "
-                     + "is low-frequency noise rather than speech. Leave this off for "
-                     + "dictation or a headset, where it would cut the voice instead.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
+                Section("Room") {
+                    Toggle("Room mode", isOn: Binding(
+                        get: { settings.roomMode },
+                        set: { state.setRoomMode($0) }
+                    ))
+                    Text(settings.roomMode
+                         ? "Removes the rumble below \(Int(HighPassFilter.roomCornerHz)) Hz before "
+                         + "transcription: desk knocks, typing and air conditioning. The saved "
+                         + "recording keeps the full range. To undo the effect, turn this off "
+                         + "and transcribe again."
+                         : "For a microphone that hears a room and not a person. In a meeting "
+                         + "across a table, most of the sound at the microphone is low-frequency "
+                         + "noise and not speech. Leave this off for dictation or a headset, "
+                         + "where it would cut the voice.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
             }
         }
         .formStyle(.grouped)
@@ -226,8 +292,8 @@ struct ModelSettings: View {
                     .fixedSize(horizontal: false, vertical: true)
 
                 if !settings.tier.suitableForLive {
-                    Label("Live recordings fall back to Balanced. Accurate cannot decode "
-                          + "a window inside the hop interval, so nothing would commit.",
+                    Label("A live recording uses Balanced. Accurate cannot decode a window "
+                          + "inside the hop interval, thus nothing would commit.",
                           systemImage: "info.circle")
                         .font(.caption)
                         .foregroundStyle(.orange)
@@ -239,8 +305,8 @@ struct ModelSettings: View {
                     VStack(alignment: .trailing, spacing: 2) {
                         Text(ModelCatalogue.option(id)?.label ?? id)
                         Text(state.isModelDownloaded(id)
-                             ? "Downloaded"
-                             : "Not downloaded — fetched on first use, or below")
+                             ? "On this Mac"
+                             : "Not on this Mac. The app downloads it at the first use, or below.")
                             .font(.caption)
                             .foregroundStyle(state.isModelDownloaded(id) ? Color.secondary : Color.orange)
                     }
@@ -255,15 +321,15 @@ struct ModelSettings: View {
                 Text("On this Mac")
             } footer: {
                 Text("Everything runs on this Mac. No account, no API key, and no audio "
-                     + "leaves the machine. Weights live in Application Support and can "
-                     + "be removed and fetched again at any time.")
+                     + "leaves the machine. The weights are in Application Support. You can "
+                     + "remove them and download them again at any time.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
 
             Section("Memory") {
                 LabeledContent("In use now", value: "\(footprint) MB")
-                Button("Release Models from Memory") { state.releaseIdleModels() }
+                Button("Release the Models from Memory") { state.releaseIdleModels() }
                     .disabled(state.isLiveBusy)
                 Button("Run the Benchmark…") { state.route = .benchmark }
             }
@@ -350,18 +416,18 @@ private struct ModelRow: View {
                     .foregroundStyle(.secondary)
                     .frame(width: 34, alignment: .trailing)
             }
-            .help("Downloading \(option.label)")
+            .help("Download of \(option.label) in progress")
         } else if isDownloaded {
             Button("Remove") { state.removeModel(option.id) }
                 .controlSize(.small)
                 .disabled(state.isLiveBusy)
                 .help(state.isLiveBusy
-                      ? "Not while a recording is in progress"
-                      : "Delete the weights from this Mac. They can be downloaded again.")
+                      ? "Not available during a recording"
+                      : "Delete the weights from this Mac. You can download them again.")
         } else {
             Button("Download") { state.downloadModel(option.id) }
                 .controlSize(.small)
-                .help("Fetch \(option.sizeLabel) now, so the first recording does not wait for it")
+                .help("Download \(option.sizeLabel) now, thus the first recording does not wait for it")
         }
     }
 }
@@ -380,8 +446,8 @@ struct StorageSettings: View {
                 Toggle("Keep the 16 kHz working copy after transcription",
                        isOn: $settings.keepWorkingCopy)
                 Text("The working copy is what transcription and speaker identification "
-                     + "read. It is about 115 MB per hour and is rebuilt from the original "
-                     + "when needed, so keeping it only saves time on a re-run.")
+                     + "read. It is about 115 MB per hour. The app rebuilds it from the "
+                     + "original when necessary, thus this only saves time on a second run.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
@@ -451,27 +517,25 @@ struct AboutSettings: View {
             }
 
             Section("A newer version") {
-                Text("Notero does not update itself. It downloads no code and "
-                     + "replaces nothing on this Mac by itself. To move to a newer "
-                     + "version, get it from the releases page and replace the app.")
+                Text("Notero does not update itself. It downloads no code and replaces "
+                     + "nothing on this Mac. To move to a newer version, get it from the "
+                     + "releases page and replace the app.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
-                Button("Open Releases Page") { About.openReleasesPage() }
+                Button("Open the Releases Page") { About.openReleasesPage() }
                     .buttonStyle(.link)
-                Text("Because the app is signed ad hoc rather than with a Developer "
-                     + "ID, macOS asks for microphone access again after you replace "
-                     + "the app.")
+                Text("The app has an ad-hoc signature and not a Developer ID. macOS therefore "
+                     + "asks for microphone access again after you replace the app.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
             }
 
             Section("Privacy") {
-                Text("Every model runs on this Mac. The app has no account, no API "
-                     + "key and no telemetry. The one request it makes is the model "
-                     + "download at the first start. No recording, transcript or "
-                     + "note goes anywhere.")
+                Text("Every model runs on this Mac. The app has no account, no API key and "
+                     + "no telemetry. It makes one request: the model download at the first "
+                     + "start. No recording, transcript or note goes anywhere.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)

--- a/app/Sources/Transcriber/Views/SettingsView.swift
+++ b/app/Sources/Transcriber/Views/SettingsView.swift
@@ -135,6 +135,19 @@ struct GeneralSettings: View {
                     .foregroundStyle(.secondary)
             }
 
+            Section("Menu bar") {
+                Toggle("Show Notero in the menu bar", isOn: Binding(
+                    get: { settings.menuBarItem },
+                    set: { state.setMenuBarItem($0) }
+                ))
+                Text("Record, pause and stop from any application. The item shows the "
+                     + "clock of the recording. ⌃⌥R starts or stops a recording, and ⌃⌥P "
+                     + "pauses or resumes it, in every application while the item is on.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
             Section("While you record") {
                 Toggle("Show text while you record", isOn: $settings.liveTranscription)
                 Text(liveDetail(advanced: advanced))

--- a/app/Sources/Transcriber/Views/SidebarView.swift
+++ b/app/Sources/Transcriber/Views/SidebarView.swift
@@ -352,6 +352,10 @@ struct HistoryRow: View {
                 if let progress = state.progress[recording.id] {
                     StatusChip(status: progress.status, fraction: progress.fraction,
                                remaining: progress.remaining)
+                } else if state.isLive(recording.id), state.isPaused {
+                    Label("Paused", systemImage: "pause.circle.fill")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
                 } else if recording.status.isBusy {
                     // Preparing and recording are live-path states; they never
                     // get a queue entry, so they need the stored status.

--- a/app/Sources/Transcriber/Views/SidebarView.swift
+++ b/app/Sources/Transcriber/Views/SidebarView.swift
@@ -33,7 +33,13 @@ struct SidebarView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            filterBar
+            // The filter is an Advanced control. Simple mode shows the whole
+            // library, newest first, and nothing to select before the list.
+            if state.settings.isAdvanced {
+                filterBar
+            } else {
+                simpleTopBar
+            }
             list
             footer
         }
@@ -48,6 +54,9 @@ struct SidebarView: View {
             if let route, !selection.contains(route) { selection = [route] }
             if route == nil { selection = [] }
         }
+        .onChange(of: state.settings.isAdvanced) { _, advanced in
+            if !advanced { filter = .all }
+        }
         .onDeleteCommand { pendingDelete = selectedRecordings }
         .confirmationDialog(
             deleteTitle, isPresented: Binding(
@@ -61,7 +70,7 @@ struct SidebarView: View {
                 pendingDelete = []
             }
         } message: {
-            Text("The audio and transcript are removed from this Mac. This cannot be undone.")
+            Text("The app removes the audio and the transcript from this Mac. You cannot undo this.")
         }
     }
 
@@ -79,13 +88,13 @@ struct SidebarView: View {
 
             if filtered.isEmpty {
                 ContentUnavailableView {
-                    Label(filter == .all ? "No recordings yet" : "Nothing here",
+                    Label(filter == .all ? "No recordings yet" : "No recordings match",
                           systemImage: filter == .active ? "hourglass" : "waveform")
                 } description: {
                     Text(filter == .all
-                         ? "Press ⌘R to record, or drop an audio file onto the window."
-                         : (filter == .active ? "Nothing is recording or being transcribed."
-                            : "Nothing matches this filter."))
+                         ? "Click Record, or drop an audio or video file on the window."
+                         : (filter == .active ? "No recording or transcription is in progress."
+                            : "No recording matches this filter."))
                 }
                 .listRowSeparator(.hidden)
             }
@@ -142,10 +151,36 @@ struct SidebarView: View {
                 filterPicker.pickerStyle(.menu)
             }
             .labelsHidden()
-            .help("Active: recording, queued or being transcribed right now")
+            .help("Active: the recordings in progress or in the queue")
             .padding(.horizontal, 10)
             .padding(.vertical, 8)
             .frame(maxWidth: .infinity)
+            Divider()
+        }
+        .background {
+            Rectangle().fill(.bar).ignoresSafeArea(edges: .top)
+        }
+    }
+
+    /// The same strip in Simple mode, with a title instead of a filter. It
+    /// exists for the same reason: it is what keeps rows out from under the
+    /// window controls.
+    private var simpleTopBar: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("Recordings")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Spacer()
+                if !recordings.isEmpty {
+                    Text("\(recordings.count)")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                        .monospacedDigit()
+                }
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
             Divider()
         }
         .background {
@@ -169,19 +204,38 @@ struct SidebarView: View {
                 } label: {
                     Label("Search", systemImage: "magnifyingglass")
                 }
-                Spacer()
+                .help("Search all recordings (⇧⌘F)")
+                .labelStyle(.iconOnly)
+
+                // The one switch between the two modes that is always on
+                // screen. Settings and the View menu have the same switch.
                 Button {
-                    state.route = .benchmark
+                    withAnimation(.snappy) { state.settings.isAdvanced.toggle() }
                 } label: {
-                    Label("Benchmark", systemImage: "speedometer")
+                    Label(state.settings.isAdvanced ? "Advanced" : "Simple",
+                          systemImage: "slider.horizontal.3")
+                        .font(.caption)
                 }
-                .help("Measure the model tiers on this Mac (⇧⌘K)")
+                .help(state.settings.isAdvanced
+                      ? "Advanced mode. Click to change to Simple mode, which has fewer controls."
+                      : "Simple mode. Click to change to Advanced mode, which shows all controls.")
+
+                Spacer()
+                if state.settings.isAdvanced {
+                    Button {
+                        state.route = .benchmark
+                    } label: {
+                        Label("Benchmark", systemImage: "speedometer")
+                    }
+                    .help("Measure the model tiers on this Mac (⇧⌘K)")
+                    .labelStyle(.iconOnly)
+                }
                 SettingsLink {
                     Label("Settings", systemImage: "gearshape")
                 }
                 .help("Settings (⌘,)")
+                .labelStyle(.iconOnly)
             }
-            .labelStyle(.iconOnly)
             .buttonStyle(.borderless)
             .padding(.horizontal, 12)
             .padding(.vertical, 8)
@@ -198,13 +252,19 @@ struct SidebarView: View {
             try? context.save()
         }
         if recording.hasAudio {
-            RerunItems(recording: recording)
-            Button("Show Audio in Finder", systemImage: "folder") {
+            if state.settings.isAdvanced {
+                RerunItems(recording: recording)
+            } else {
+                Button("Transcribe Again", systemImage: "arrow.clockwise") {
+                    state.retranscribe(recording)
+                }
+            }
+            Button("Show the Audio in Finder", systemImage: "folder") {
                 if let url = recording.audioURL { NSWorkspace.shared.activateFileViewerSelecting([url]) }
             }
         }
-        if recording.kind == .recording {
-            Button("Turn into a Meeting", systemImage: RecordingKind.meeting.symbol) {
+        if recording.kind == .recording, state.settings.isAdvanced {
+            Button("Make This a Meeting", systemImage: RecordingKind.meeting.symbol) {
                 recording.kind = .meeting
                 try? context.save()
             }

--- a/app/Sources/Transcriber/Views/TranscriptView.swift
+++ b/app/Sources/Transcriber/Views/TranscriptView.swift
@@ -1,3 +1,4 @@
+import OSLog
 import SwiftData
 import SwiftUI
 import TranscriberCore
@@ -8,6 +9,13 @@ import TranscriberStore
 /// Also where the transcript gets fixed: a turn opens for editing on
 /// double-click, ⌘F finds within it, and playback keeps the current turn in
 /// view until the reader scrolls away.
+///
+/// The rows are read once per change, off the main actor, through
+/// `TranscriptReader`: one query, in time order, grouped into blocks before
+/// they reach the view. The view itself never walks the relationship. On a
+/// four-hour meeting the old walk was thousands of faults on the main thread,
+/// and it ran again on every redraw, because the empty-state check sorted
+/// every row to ask whether there were any.
 struct TranscriptView: View {
     @Environment(AppState.self) private var state
     @Environment(\.modelContext) private var context
@@ -23,6 +31,11 @@ struct TranscriptView: View {
     /// playhead moves. The player ticks 20 times a second; regrouping tens of
     /// thousands of segments at that rate would make a long meeting unscrollable.
     @State private var blocks: [TranscriptBlock] = []
+    /// False until the first read returns. The empty state waits for it, or a
+    /// long transcript would show "No transcript yet" for the length of the read.
+    @State private var loaded = false
+    /// Shown only when a read takes long enough to notice.
+    @State private var showSpinner = false
     /// Bumped when an edit session ends, so the signature changes and the
     /// blocks pick up the new text.
     @State private var editVersion = 0
@@ -50,7 +63,9 @@ struct TranscriptView: View {
 
     var body: some View {
         Group {
-            if segments.isEmpty {
+            if !loaded {
+                loadingState
+            } else if blocks.isEmpty {
                 emptyState
             } else {
                 list
@@ -75,7 +90,7 @@ struct TranscriptView: View {
             // context holds; the window's is the one ⌘Z reaches.
             if context.undoManager == nil { context.undoManager = undoManager }
         }
-        .task(id: transcriptSignature) { regroup() }
+        .task(id: transcriptSignature) { await regroup() }
         .onChange(of: state.turnStep) { _, step in
             guard let step else { return }
             moveSelection(by: step.delta)
@@ -110,27 +125,59 @@ struct TranscriptView: View {
         isViewingOlderRevision || state.progress[recording.id] != nil
     }
 
-    private var segments: [StoredSegment] {
-        transcript?.orderedSegments ?? []
-    }
-
-    /// Changes exactly when the rows do: a new revision, edits, or an append.
+    /// Changes exactly when the rows do: a new revision, an edit, a batch of
+    /// rows from a job, a speaker moved. None of these counts the rows.
+    /// `updatedAt` moves on every write the UI makes to the recording, and the
+    /// tick moves on every write a job makes.
     private var transcriptSignature: String {
         let transcript = transcript
-        return "\(transcript?.id.uuidString ?? "-")-\(transcript?.segments?.count ?? 0)-\(editVersion)"
+        return [transcript?.id.uuidString ?? "-",
+                String(recording.updatedAt.timeIntervalSinceReferenceDate),
+                String(state.transcriptTicks[recording.id] ?? 0),
+                String(editVersion)].joined(separator: "|")
     }
 
-    private func regroup() {
-        blocks = TranscriptGrouping.blocks(from: segments.map(value(of:)))
+    /// Reads and groups the rows off the main actor, then publishes the
+    /// blocks. A new reader for each read, on a fresh context, so an edit
+    /// saved a moment ago is what comes back.
+    private func regroup() async {
+        guard let transcript else {
+            blocks = []
+            loaded = true
+            return
+        }
+        let id = transcript.id
+        let started = ContinuousClock.now
+        let reader = state.makeReader()
+        let grouped = try? await reader.blocks(ofTranscript: id)
+        guard !Task.isCancelled else { return }
+        blocks = grouped ?? []
+        loaded = true
+        // `log stream --info --predicate 'subsystem == "local.notero"'` reads
+        // this while the app runs. It is how the load of a long transcript is
+        // measured against the real store rather than a fixture.
+        Self.log.info("transcript \(id.uuidString, privacy: .public): \(blocks.count) turns from \(blocks.reduce(0) { $0 + $1.segments.count }) rows in \((ContinuousClock.now - started).formatted(.units(allowed: [.milliseconds])), privacy: .public)")
     }
 
-    private func value(of row: StoredSegment) -> Segment {
-        Segment(id: row.id, index: row.index, startMs: row.startMs, endMs: row.endMs,
-                text: row.text, textClean: row.textClean, speakerId: row.speakerId,
-                confidence: row.confidence)
-    }
+    private static let log = Logger(subsystem: "local.notero", category: "transcript")
 
     // MARK: - Layout
+
+    private var loadingState: some View {
+        VStack(spacing: 10) {
+            if showSpinner {
+                ProgressView()
+                Text("The app reads the transcript.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .task {
+            try? await Task.sleep(for: .milliseconds(400))
+            if !loaded { showSpinner = true }
+        }
+    }
 
     private var list: some View {
         VStack(spacing: 0) {
@@ -215,7 +262,7 @@ struct TranscriptView: View {
                             request(blocks[index].id, anchor: .center)
                         }
                     } label: {
-                        Label("Follow playback", systemImage: "arrow.down.to.line")
+                        Label("Follow the playback", systemImage: "arrow.down.to.line")
                             .font(.caption.weight(.medium))
                             .padding(.horizontal, 12)
                             .padding(.vertical, 6)
@@ -333,19 +380,19 @@ struct TranscriptView: View {
                 // Without this the row is a dead end: no audio means nothing to
                 // transcribe, and the only way out was to find it in the
                 // sidebar and work out that it should be deleted.
-                Button("Delete Recording", role: .destructive) { state.delete(recording) }
-                Button("Import Audio…") { state.isImporting = true }
+                Button("Delete This Recording", role: .destructive) { state.delete(recording) }
+                Button("Transcribe a File…") { state.isImporting = true }
             }
         }
     }
 
     private var label: String {
-        if state.progress[recording.id] != nil { return "Working on it" }
+        if state.progress[recording.id] != nil { return "Work in progress" }
         if recording.status == .cancelled { return "Transcription cancelled" }
         guard recording.status == .failed else { return "No transcript yet" }
         // "Transcription failed" is wrong for a recording that never captured
         // anything -- nothing got as far as being transcribed.
-        return recording.hasAudio ? "Transcription failed" : "Recording interrupted"
+        return recording.hasAudio ? "Transcription failed" : "The recording stopped early"
     }
 
     private var icon: String {
@@ -360,9 +407,9 @@ struct TranscriptView: View {
         }
         if let error = recording.errorMessage, recording.status == .failed { return error }
         return recording.hasAudio
-            ? "The audio is here but has not been transcribed."
-            : "No audio was captured, so there is nothing to transcribe. "
-              + "Importing a file makes a new recording; this one can be deleted."
+            ? "The audio is on this Mac. It has no transcript yet."
+            : "The app captured no audio, thus there is nothing to transcribe. "
+              + "A file that you import becomes a new recording. You can delete this one."
     }
 
     // MARK: - Speakers
@@ -398,7 +445,7 @@ private struct PlaybackFollower: View {
     }
 }
 
-/// "Transcribing · 42% · about 14 min left", over a transcript still arriving.
+/// "Transcription · 42% · about 14 min left", over a transcript still arriving.
 struct TranscriptProgressBanner: View {
     let progress: AppState.JobProgress
     let durationMs: Int
@@ -421,12 +468,12 @@ struct TranscriptProgressBanner: View {
                     .font(.system(.caption, design: .monospaced))
                     .monospacedDigit()
                     .foregroundStyle(.secondary)
-                    .help("How far into the audio the decode has reached")
+                    .help("The point in the audio that the decode has reached")
             }
             if progress.status != .cancelled {
                 Button("Cancel", role: .destructive, action: onCancel)
                     .buttonStyle(.borderless)
-                    .help("Stop this transcription and keep any transcript already produced")
+                    .help("Stop the transcription. The app keeps the lines it has.")
             }
         }
         .padding(.horizontal, 16)
@@ -448,7 +495,7 @@ struct TranscriptProgressBanner: View {
     }
 }
 
-/// "Viewing revision 1 of 3 · read-only". The way back is in the info bar.
+/// "Revision 1 of 3 · read-only". The way back is in the info bar.
 private struct RevisionBanner: View {
     let shown: StoredTranscript
     let latest: StoredTranscript
@@ -456,7 +503,7 @@ private struct RevisionBanner: View {
     var body: some View {
         HStack(spacing: 8) {
             Image(systemName: "clock.arrow.circlepath")
-            Text("Viewing revision \(shown.revision) of \(latest.revision) · "
+            Text("Revision \(shown.revision) of \(latest.revision) · "
                  + "\(ModelCatalogue.option(shown.modelId)?.label ?? shown.modelId) · "
                  + "\(shown.createdAt.formatted(date: .abbreviated, time: .shortened))")
             Text("Read-only")
@@ -483,7 +530,7 @@ struct TranscriptFindBar: View {
     var body: some View {
         HStack(spacing: 8) {
             Image(systemName: "magnifyingglass").foregroundStyle(.secondary)
-            TextField("Find in transcript", text: $find.text)
+            TextField("Find in this transcript", text: $find.text)
                 .textFieldStyle(.plain)
                 .focused($focused)
                 .onSubmit { onStep(1) }
@@ -516,7 +563,7 @@ struct TranscriptFindBar: View {
 
     private var count: String {
         if find.text.isEmpty { return "" }
-        if find.hits.isEmpty { return "No matches" }
+        if find.hits.isEmpty { return "No match" }
         return "\(find.current + 1) of \(find.hits.count)"
     }
 }
@@ -627,7 +674,7 @@ struct TranscriptBlockRow: View {
             }
             if let onEdit {
                 Divider()
-                Button("Edit Text…", systemImage: "pencil") { onEdit() }
+                Button("Edit the Text…", systemImage: "pencil") { onEdit() }
                 speakerMenu
             }
             Divider()
@@ -672,16 +719,18 @@ struct TranscriptBlockRow: View {
         }
     }
 
+    /// The rows of this turn, by id: one query, not a walk of the transcript.
+    private var rows: [StoredSegment] {
+        (try? TranscriptReader.segmentRows(ids: block.segments.map(\.id), in: context)) ?? []
+    }
+
     private func assign(to speaker: StoredSpeaker?) {
-        let ids = Set(block.segments.map(\.id))
-        let rows = (recording.transcript?.orderedSegments ?? []).filter { ids.contains($0.id) }
         try? RecordingStore.assign(rows, to: speaker, on: recording, in: context)
     }
 
     private func add(_ kind: MeetingItemKind) {
         guard let first = block.segments.first,
-              let row = (recording.transcript?.orderedSegments ?? [])
-                  .first(where: { $0.id == first.id })
+              let row = try? TranscriptReader.segmentRow(id: first.id, in: context)
         else { return }
         _ = try? RecordingStore.addItem(kind, text: block.text, source: row,
                                         to: recording, in: context)
@@ -724,11 +773,10 @@ struct TranscriptBlockEditor: View {
     let onDone: () -> Void
 
     @FocusState private var focusedRow: UUID?
-
-    private var rows: [StoredSegment] {
-        let ids = Set(block.segments.map(\.id))
-        return (recording.transcript?.orderedSegments ?? []).filter { ids.contains($0.id) }
-    }
+    /// Fetched once by id when the editor opens. Filtering the whole
+    /// transcript on every keystroke, which is what a computed property did,
+    /// walked every row of a long meeting for each character typed.
+    @State private var rows: [StoredSegment] = []
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -744,7 +792,7 @@ struct TranscriptBlockEditor: View {
                         .foregroundStyle(speakerColor)
                 }
                 Spacer()
-                Text("Editing · ↩ or Esc when done")
+                Text("Edit mode · Press ↩ or Esc to finish")
                     .font(.caption2)
                     .foregroundStyle(.tertiary)
                 Button("Done") { onDone() }
@@ -789,7 +837,10 @@ struct TranscriptBlockEditor: View {
             RoundedRectangle(cornerRadius: 8)
                 .strokeBorder(Color.accentColor.opacity(0.45), lineWidth: 1)
         }
-        .onAppear { focusedRow = rows.first?.id }
+        .onAppear {
+            rows = (try? TranscriptReader.segmentRows(ids: block.segments.map(\.id), in: context)) ?? []
+            focusedRow = rows.first?.id
+        }
         .onExitCommand { onDone() }
     }
 
@@ -814,12 +865,12 @@ struct TranscriptBlockEditor: View {
             }
         }
         if row.textClean != nil {
-            Button("Restore Original Text", systemImage: "arrow.uturn.backward") {
+            Button("Restore the Original Text", systemImage: "arrow.uturn.backward") {
                 row.textClean = nil
             }
         }
         Divider()
-        Button("Delete Line", systemImage: "trash", role: .destructive) {
+        Button("Delete This Line", systemImage: "trash", role: .destructive) {
             context.delete(row)
             onDone()
         }

--- a/app/Sources/Transcriber/Views/TranscriptView.swift
+++ b/app/Sources/Transcriber/Views/TranscriptView.swift
@@ -616,6 +616,11 @@ struct TranscriptBlockRow: View {
                 }
             }
 
+            // Not selectable. With selection on, a double-click on the words
+            // selected a word instead of opening the editor, and a right-click
+            // on them showed the text menu of macOS instead of the turn's
+            // menu: the gestures worked only on the time and the speaker name.
+            // The turn's menu has Copy, and the editor has the text.
             Group {
                 if highlights.isEmpty {
                     Text(block.text)
@@ -623,7 +628,6 @@ struct TranscriptBlockRow: View {
                     HighlightedText(text: block.text, highlights: highlights)
                 }
             }
-            .textSelection(.enabled)
             .fixedSize(horizontal: false, vertical: true)
         }
         .padding(10)
@@ -676,6 +680,24 @@ struct TranscriptBlockRow: View {
                 Divider()
                 Button("Edit the Text…", systemImage: "pencil") { onEdit() }
                 speakerMenu
+                if recording.hasAudio {
+                    // The one bad window in a long meeting, without the other
+                    // four hours. Advanced offers the tiers; Simple takes the
+                    // Accurate one, which is why anyone redoes a turn.
+                    if state.settings.isAdvanced {
+                        Menu("Transcribe This Turn Again", systemImage: "arrow.clockwise") {
+                            ForEach(ModelTier.allCases) { tier in
+                                Button("\(tier.label) · \(ModelCatalogue.option(state.settings.modelId(for: tier))?.label ?? "")") {
+                                    state.retranscribe(recording, turn: block, tier: tier)
+                                }
+                            }
+                        }
+                    } else {
+                        Button("Transcribe This Turn Again", systemImage: "arrow.clockwise") {
+                            state.retranscribe(recording, turn: block)
+                        }
+                    }
+                }
             }
             Divider()
             Button("Copy", systemImage: "doc.on.doc") {

--- a/app/Sources/TranscriberCLI/main.swift
+++ b/app/Sources/TranscriberCLI/main.swift
@@ -29,6 +29,11 @@ struct Options {
     var modelId: String?
     var tier: ModelTier = .balanced
     var language = LanguageCatalogue.defaultLanguage
+    /// Names and terms for the decoder, as the app's Vocabulary field.
+    var vocabulary: String?
+    /// Put the built-in style primer for the language in front of the prompt,
+    /// as the app does by default.
+    var styleHint = false
     var diarizationMode: DiarizationMode = .accurate
     var roomMode = false
     var format: ExportFormat = .txt
@@ -72,6 +77,8 @@ func parse() -> Options {
         case "--model": options.modelId = value()
         case "--tier": options.tier = value().flatMap(ModelTier.init(rawValue:)) ?? options.tier
         case "--language": options.language = value() ?? options.language
+        case "--prompt": options.vocabulary = value()
+        case "--style-hint": options.styleHint = true
         case "--format": options.format = value().flatMap(ExportFormat.init(rawValue:)) ?? options.format
         case "--out": options.output = value().map { URL(fileURLWithPath: $0) }
         case "--json": options.json = value().map { URL(fileURLWithPath: $0) }
@@ -99,7 +106,8 @@ func parse() -> Options {
             print("""
             transcribe --audio FILE [--reference FILE] [--models DIR]
                        [--model ID | --tier fast|balanced|accurate]
-                       [--language tl] [--fast-diarize | --no-diarize] [--room-mode]
+                       [--language tl] [--prompt "Maria, Jose"] [--style-hint]
+                       [--fast-diarize | --no-diarize] [--room-mode]
                        [--format txt|markdown|srt|vtt|json] [--out FILE] [--json FILE]
                        [--live [--realtime] [--hop MS] [--pre-roll MS] [--context MS] [--adaptive-hop]]
             transcribe --record [--source microphone|systemAudio|both] [--device UID]
@@ -223,6 +231,10 @@ log("audio: \(TimeFormat.short(ms: source.durationMs)) (\(source.sampleCount) sa
 let engines = EngineHost(modelsDirectory: options.models)
 let modelId = options.modelId ?? options.tier.defaultModelId
 log("model: \(modelId)")
+let prompt = TranscriptionPrompt.compose(language: options.language,
+                                         usePrimer: options.styleHint,
+                                         vocabulary: options.vocabulary)
+if let prompt { log("prompt: \(prompt)") }
 
 do {
     try await engines.loadModel(modelId) { message, _ in log("  \(message)") }
@@ -247,7 +259,7 @@ if options.live {
     // commit policy as a recording -- minus the microphone.
     let config = SessionConfig(
         contextMs: options.contextMs, hopMs: options.hopMs, language: options.language,
-        preRollMs: options.preRollMs, adaptiveHop: options.adaptiveHop
+        prompt: prompt, preRollMs: options.preRollMs, adaptiveHop: options.adaptiveHop
     )
     liveConfig = config
     await vad.reset()
@@ -305,7 +317,7 @@ if options.live {
     do {
         decoded = try await OfflinePipeline.transcribe(
             source: source, windows: windows, using: asr,
-            language: options.language, prompt: nil
+            language: options.language, prompt: prompt
         )
     } catch {
         log("error: transcription failed: \(error.localizedDescription)")

--- a/app/Sources/TranscriberCore/Benchmark.swift
+++ b/app/Sources/TranscriberCore/Benchmark.swift
@@ -171,7 +171,9 @@ public enum WordErrorRate {
         return Double(previous[target.count]) / Double(source.count)
     }
 
-    static func words(_ text: String) -> [String] {
+    /// The tokens the score counts: lower case, no diacritics, letters and
+    /// digits only.
+    public static func words(_ text: String) -> [String] {
         text.lowercased()
             .folding(options: .diacriticInsensitive, locale: nil)
             .components(separatedBy: CharacterSet.alphanumerics.inverted)

--- a/app/Sources/TranscriberCore/Capture.swift
+++ b/app/Sources/TranscriberCore/Capture.swift
@@ -59,13 +59,13 @@ public enum CaptureSource: String, Sendable, CaseIterable, Codable {
     public var detail: String {
         switch self {
         case .microphone:
-            return "People in the room. What an in-person meeting needs."
+            return "The persons in the room. What an in-person meeting needs."
         case .systemAudio:
-            return "People on the call, captured before the speakers. Nothing in "
-                 + "the room is recorded."
+            return "The persons on the call, captured before the speaker. The app "
+                 + "records nothing from the room."
         case .both:
-            return "Both, kept as separate tracks so the transcript can tell the "
-                 + "room from the call."
+            return "Both, in separate tracks, thus the transcript can tell the room "
+                 + "from the call."
         }
     }
 }

--- a/app/Sources/TranscriberCore/Catalogues.swift
+++ b/app/Sources/TranscriberCore/Catalogues.swift
@@ -109,7 +109,7 @@ public struct LanguageOption: Identifiable, Hashable, Sendable {
 public enum LanguageCatalogue {
     public static let all: [LanguageOption] = [
         LanguageOption(id: "tl", label: "Tagalog / Taglish",
-                       note: "Forced Tagalog. Code-switched English is transcribed as spoken.",
+                       note: "Forced Tagalog. The app writes code-switched English as the speaker said it.",
                        isAutoDetect: false),
         LanguageOption(id: "en", label: "English", note: "", isAutoDetect: false),
         LanguageOption(id: "id", label: "Indonesian", note: "", isAutoDetect: false),
@@ -126,9 +126,9 @@ public enum LanguageCatalogue {
         LanguageOption(id: "vi", label: "Vietnamese", note: "", isAutoDetect: false),
         LanguageOption(id: "th", label: "Thai", note: "", isAutoDetect: false),
         LanguageOption(id: "auto", label: "Auto-detect",
-                       note: "Not recommended for Taglish: the decoder picks a "
-                           + "language per window and may translate instead of "
-                           + "transcribe.",
+                       note: "Not recommended for Taglish. The decoder selects a "
+                           + "language for each window, and it can translate "
+                           + "instead of transcribe.",
                        isAutoDetect: true),
     ]
 
@@ -162,16 +162,16 @@ public enum ModelTier: String, CaseIterable, Identifiable, Sendable, Codable {
     public var summary: String {
         switch self {
         case .fast:
-            return "Quantized turbo. Lowest latency and the smallest memory "
-                 + "footprint; the accuracy cost on Taglish is unmeasured."
+            return "Quantized turbo. The lowest latency and the smallest memory "
+                 + "use. The accuracy cost on Taglish is not measured."
         case .balanced:
-            return "large-v3-turbo. The default: full large-v3 encoder with a "
-                 + "4-layer decoder, which is what keeps live transcription real-time."
+            return "large-v3-turbo. The default: the full large-v3 encoder with a "
+                 + "4-layer decoder, which keeps live transcription in real time."
         case .accurate:
             return "Full large-v3. Expected to give the best transcript, at "
-                 + "roughly 5x the decode cost per window — meant for "
-                 + "re-transcribing a finished recording, not for the live path. "
-                 + "This project has not measured its accuracy."
+                 + "about 5 times the decode cost per window. For a second "
+                 + "transcription of a finished recording, and not for the live "
+                 + "path. This project has not measured its accuracy."
         }
     }
 
@@ -223,11 +223,11 @@ public enum DiarizationMode: String, CaseIterable, Identifiable, Sendable, Codab
     public var summary: String {
         switch self {
         case .off:
-            return "Skip speaker identification. The transcript finishes as soon as speech recognition does."
+            return "No speaker identification. The transcript is ready as soon as the speech recognition is complete."
         case .fast:
-            return "One speaker pass. Much shorter on long recordings, but similar voices may be merged."
+            return "One speaker pass. Much shorter on a long recording, but the app can merge similar voices."
         case .accurate:
-            return "Rechecks every speaker turn. Best labels, with a longer post-transcription pass."
+            return "Checks each speaker turn a second time. The best labels, with a longer pass after the transcription."
         }
     }
 

--- a/app/Sources/TranscriberCore/Exports.swift
+++ b/app/Sources/TranscriberCore/Exports.swift
@@ -24,12 +24,12 @@ public enum ExportFormat: String, CaseIterable, Identifiable, Sendable {
 
     public var detail: String {
         switch self {
-        case .txt: return "Speaker-labelled transcript and the meeting notes."
-        case .markdown: return "Minutes with headings, attendees, checkable action items "
-            + "and the transcript — pastes cleanly into email, chat and wikis."
+        case .txt: return "The transcript with speaker labels, and the meeting notes."
+        case .markdown: return "Minutes with headings, attendees, action items with "
+            + "checkboxes, and the transcript. It pastes into email, chat and wikis."
         case .srt: return "Subtitle cues for video editors."
         case .vtt: return "Subtitle cues for web players."
-        case .json: return "Everything: segments, speakers, bookmarks, notes."
+        case .json: return "Everything: the segments, the speakers, the bookmarks and the notes."
         }
     }
 }

--- a/app/Sources/TranscriberCore/Meeting.swift
+++ b/app/Sources/TranscriberCore/Meeting.swift
@@ -38,13 +38,13 @@ public enum TranscriptionStatus: String, Codable, CaseIterable, Sendable {
 
     public var label: String {
         switch self {
-        case .pending: return "Queued"
-        case .preparing: return "Preparing"
+        case .pending: return "In queue"
+        case .preparing: return "Preparation"
         case .recording: return "Recording"
-        case .transcribing: return "Transcribing"
-        case .diarizing: return "Identifying speakers"
-        case .finalizing: return "Finalizing"
-        case .completed: return "Completed"
+        case .transcribing: return "Transcription"
+        case .diarizing: return "Speaker identification"
+        case .finalizing: return "Last step"
+        case .completed: return "Complete"
         case .cancelled: return "Cancelled"
         case .failed: return "Failed"
         }

--- a/app/Sources/TranscriberCore/Prompting.swift
+++ b/app/Sources/TranscriberCore/Prompting.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// The text handed to the decoder as a "previous transcript" before each
+/// window.
+///
+/// Whisper reads the prompt as the words that came just before the audio, so
+/// the prompt sets the style of the output: the spelling, the casing and, for
+/// code-switched speech, which language an English word is written in. The
+/// primer below is one sentence of ordinary Taglish with the hyphenated
+/// affixes and the English nouns that a meeting is made of; it names nothing
+/// that a real meeting would say, so it cannot leak into a measurement.
+///
+/// **The app does not send the primer.** Measured on 2026-09-06 through
+/// `transcribe --style-hint` (docs/FINDINGS.md, finding 12): on the live path
+/// the model repeated the primer instead of the room and the word error rate
+/// went from 27% to 96%; offline it was worse on one clip and better on the
+/// other. The primer stays here so the measurement can be repeated, and so
+/// the next person does not have to rediscover the result.
+public enum TranscriptionPrompt {
+
+    /// A style primer for each language that has one. Only Tagalog has one,
+    /// and only the CLI uses it.
+    public static func primer(for language: String) -> String? {
+        switch language {
+        case "tl":
+            return "Sige, mag-start na tayo. Na-send ko na yung email kahapon, pero hindi pa "
+                 + "na-approve ng client. I-check natin mamaya kung okay na ang design, tapos "
+                 + "mag-schedule tayo ng follow-up meeting next week."
+        default:
+            return nil
+        }
+    }
+
+    /// The prompt for one decode: the primer for the language, when wanted,
+    /// followed by the names and terms the user typed. Nil when there is
+    /// nothing to say, so the decoder runs with no prompt at all.
+    public static func compose(language: String, usePrimer: Bool,
+                               vocabulary: String?) -> String? {
+        var parts: [String] = []
+        if usePrimer, let primer = primer(for: language) { parts.append(primer) }
+        if let vocabulary {
+            let trimmed = vocabulary.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty { parts.append(trimmed) }
+        }
+        return parts.isEmpty ? nil : parts.joined(separator: " ")
+    }
+}

--- a/app/Sources/TranscriberCore/ReferenceSet.swift
+++ b/app/Sources/TranscriberCore/ReferenceSet.swift
@@ -1,0 +1,168 @@
+import Foundation
+
+/// Corrected transcripts as a reference set for the evaluation harness.
+///
+/// Every edit a person makes is stored beside the raw model text
+/// (`Segment.text` against `Segment.textClean`). A recording with edits is
+/// therefore a scored pair: the raw text is the hypothesis, the edited text
+/// is the reference, and the audio is on disk. The project had no real Taglish
+/// references before this: the synthetic clip and one 25-second excerpt. The
+/// folder this describes is what `eval/compare_language.py --manifest` reads,
+/// so each tuning decision can be measured on the user's own meetings.
+///
+/// The reference is the whole transcript with the edits applied, and not the
+/// edited lines alone. A line the person left alone is a line they accepted.
+public enum ReferenceSet {
+
+    /// One recording in `manifest.json`. The keys `id`, `audio`, `ref` and
+    /// `category` are what the harness reads; the rest is for the reader.
+    public struct Entry: Codable, Equatable, Sendable {
+        public var id: String
+        public var audio: String
+        public var ref: String
+        public var category: String
+        public var raw: String
+        public var edits: String
+        public var title: String
+        public var durationMs: Int
+
+        public init(id: String, audio: String, ref: String, category: String = "own",
+                    raw: String, edits: String, title: String, durationMs: Int) {
+            self.id = id
+            self.audio = audio
+            self.ref = ref
+            self.category = category
+            self.raw = raw
+            self.edits = edits
+            self.title = title
+            self.durationMs = durationMs
+        }
+    }
+
+    /// One recording in `summary.md`, with the number that needs no decode:
+    /// the raw model text scored against the corrections.
+    public struct Summary: Equatable, Sendable {
+        public var title: String
+        public var durationMs: Int
+        public var segments: Int
+        public var correctedSegments: Int
+        public var referenceWords: Int
+        public var rawWER: Double
+    }
+
+    /// A row counts as corrected when the edit differs from the raw text. An
+    /// edit that restored the raw text is not a correction.
+    public static func isCorrected(_ segment: Segment) -> Bool {
+        guard let clean = segment.textClean else { return false }
+        return clean.trimmingCharacters(in: .whitespacesAndNewlines)
+            != segment.text.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    public static func hasCorrections(_ segments: [Segment]) -> Bool {
+        segments.contains(where: isCorrected)
+    }
+
+    /// The transcript with the edits applied, one row per line.
+    public static func referenceText(_ segments: [Segment]) -> String {
+        lines(segments.map(\.displayText))
+    }
+
+    /// The transcript as the model wrote it, one row per line.
+    public static func rawText(_ segments: [Segment]) -> String {
+        lines(segments.map(\.text))
+    }
+
+    /// The corrected rows only, as tab-separated `startMs`, raw, corrected.
+    /// For a reader who wants to see what kind of error the model makes.
+    public static func editsTSV(_ segments: [Segment]) -> String {
+        var out = ["startMs\traw\tcorrected"]
+        for segment in segments.sorted(by: { $0.startMs < $1.startMs }) where isCorrected(segment) {
+            out.append([String(segment.startMs), flat(segment.text), flat(segment.textClean ?? "")]
+                .joined(separator: "\t"))
+        }
+        return out.joined(separator: "\n") + "\n"
+    }
+
+    public static func summary(title: String, durationMs: Int, segments: [Segment]) -> Summary {
+        let reference = referenceText(segments)
+        return Summary(
+            title: title,
+            durationMs: durationMs,
+            segments: segments.count,
+            correctedSegments: segments.filter(isCorrected).count,
+            referenceWords: WordErrorRate.words(reference).count,
+            rawWER: WordErrorRate.score(reference: reference, hypothesis: rawText(segments))
+        )
+    }
+
+    public static func manifestJSON(_ entries: [Entry]) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return try encoder.encode(entries)
+    }
+
+    /// The table a reader opens first. The pooled row weights each recording
+    /// by its reference words, as the harness does.
+    public static func summaryMarkdown(_ summaries: [Summary]) -> String {
+        var out = [
+            "# Corrections as references",
+            "",
+            "Raw WER is the model text scored against your corrections, with no new decode.",
+            "",
+            "| Recording | Length | Rows | Corrected rows | Reference words | Raw WER |",
+            "| --- | ---: | ---: | ---: | ---: | ---: |",
+        ]
+        var words = 0
+        var errors = 0.0
+        for summary in summaries {
+            out.append("| \(summary.title.replacingOccurrences(of: "|", with: "/")) "
+                       + "| \(TimeFormat.duration(ms: summary.durationMs)) "
+                       + "| \(summary.segments) | \(summary.correctedSegments) "
+                       + "| \(summary.referenceWords) "
+                       + "| \(String(format: "%.1f%%", summary.rawWER * 100)) |")
+            words += summary.referenceWords
+            errors += summary.rawWER * Double(summary.referenceWords)
+        }
+        if words > 0 {
+            out.append("| **All** | | | | \(words) | **\(String(format: "%.1f%%", errors / Double(words) * 100))** |")
+        }
+        return out.joined(separator: "\n") + "\n"
+    }
+
+    /// What to run. Written into the folder so the reader does not have to
+    /// find the documentation first.
+    public static func readme(count: Int) -> String {
+        """
+        # Reference set from your corrections
+
+        \(count) recording\(count == 1 ? "" : "s") with corrected lines. For each one:
+
+        - `audio/<id>.<ext>`: a copy of the recording.
+        - `refs/<id>.txt`: the transcript with your edits applied, one row per line. The reference.
+        - `raw/<id>.txt`: the transcript as the model wrote it, one row per line.
+        - `edits/<id>.tsv`: the corrected rows only, with the raw text beside each.
+
+        `manifest.json` lists the pairs for the evaluation harness. `summary.md` scores the raw
+        text against your corrections, with no new decode.
+
+        To score a configuration against these references, from the repository root:
+
+            python3 eval/compare_language.py --manifest <this folder>/manifest.json \\
+                --bin app/.build/release/transcribe --models models --arms tl
+
+        These files hold real meetings. Do not attach them to a public issue.
+        """
+    }
+
+    private static func lines(_ rows: [String]) -> String {
+        rows.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: "\n") + "\n"
+    }
+
+    private static func flat(_ text: String) -> String {
+        text.replacingOccurrences(of: "\t", with: " ")
+            .replacingOccurrences(of: "\n", with: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/app/Sources/TranscriberEngine/AudioCapture.swift
+++ b/app/Sources/TranscriberEngine/AudioCapture.swift
@@ -55,6 +55,7 @@ public final class AudioCapture: @unchecked Sendable {
     private var archive: ArchiveWriter?
     private var onAudio: (@Sendable (CapturedAudio) -> Void)?
     private var _isMuted = false
+    private var _isPaused = false
     private var _gain: Float = 1
     private var _roomMode = false
     private var _onNotice: (@Sendable (CaptureNotice) -> Void)?
@@ -67,6 +68,19 @@ public final class AudioCapture: @unchecked Sendable {
     public var isMuted: Bool {
         get { stateLock.withLock { _isMuted } }
         set { stateLock.withLock { _isMuted = newValue } }
+    }
+
+    /// Paused capture drops the frames: nothing reaches the archive, the
+    /// working copy or the decoder, and the clock of the recording stands
+    /// still. The opposite of mute, on purpose. Mute keeps the timeline on
+    /// the wall clock and puts silence in the file; pause takes the time out
+    /// of the recording, the way a tape recorder does, so a ten-minute break
+    /// is not ten minutes of silence to scroll past. The input keeps running,
+    /// so resume is instant and a device change during the pause is still
+    /// handled.
+    public var isPaused: Bool {
+        get { stateLock.withLock { _isPaused } }
+        set { stateLock.withLock { _isPaused = newValue } }
     }
 
     /// Input gain in decibels, applied to both the archive and the inference
@@ -230,10 +244,11 @@ public final class AudioCapture: @unchecked Sendable {
         let onAudio = self.onAudio
         let archive = self.archive
         let muted = _isMuted
+        let paused = _isPaused
         let gain = _gain
         let roomMode = _roomMode
         stateLock.unlock()
-        guard let onAudio, !chains.isEmpty else { return }
+        guard let onAudio, !chains.isEmpty, !paused else { return }
 
         var peaks: [CaptureLane: Float] = [:]
         var pcm: [CaptureLane: Data] = [:]
@@ -307,8 +322,11 @@ public final class AudioCapture: @unchecked Sendable {
         let chains = self.chains
         let onAudio = self.onAudio
         let archive = self.archive
+        let paused = _isPaused
         stateLock.unlock()
-        guard let onAudio, frames > 0 else { return }
+        // A gap during a pause is part of the pause: nothing was going to be
+        // recorded in that time anyway.
+        guard let onAudio, frames > 0, !paused else { return }
 
         var buffers: [CaptureLane: AVAudioPCMBuffer] = [:]
         for lane in lanes {

--- a/app/Sources/TranscriberEngine/LiveDecoder.swift
+++ b/app/Sources/TranscriberEngine/LiveDecoder.swift
@@ -79,6 +79,20 @@ public final class LiveDecoder {
     /// as a detached task so a reading can never be misattributed.
     private var clearSpeechPending = false
 
+    /// Pauses the VAD has confirmed, on the session timeline, each at least
+    /// `silenceBoundaryMs` long. A word the model places inside one was read
+    /// out of silence -- Whisper's habit is to say the last phrase again -- and
+    /// is dropped from every hypothesis, not only from the final decode. The
+    /// final already drops its own tail past the pause; this catches the copy
+    /// a *hop* produced, which survived when speech resumed before the final
+    /// returned and the next two hops then agreed on it (FINDINGS §11).
+    /// Pruned to what a window can still contain.
+    private var silences: [Range<Int>] = []
+    /// One VAD frame of slack when deciding whether a reading extends the
+    /// pause already recorded or starts a new one: the frame count and the
+    /// sample count round differently at a batch edge.
+    private static let silenceStartSlackMs = 300
+
     public init(config: SessionConfig, recognizer: any SpeechRecognizing,
                 vad: any VoiceActivityDetecting) {
         self.config = config
@@ -170,6 +184,7 @@ public final class LiveDecoder {
         guard let reading = try? await vad.push(samples) else { return }
         let previous = lastReading
         lastReading = reading
+        noteSilence(reading, heardThrough: fedThroughMs)
         guard !finishing else { return }
 
         // Re-arm when the silence counter reset, not when it reads zero: one
@@ -182,6 +197,33 @@ public final class LiveDecoder {
             speechEndMs = fedThroughMs - reading.trailingSilenceMs
             armFinalization()
         }
+    }
+
+    /// Records or extends a confirmed pause. Only pauses long enough to end an
+    /// utterance count; shorter gaps are breath, and the model's word timings
+    /// drift by more than their width.
+    private func noteSilence(_ reading: VoiceActivityReading, heardThrough endMs: Int) {
+        guard reading.trailingSilenceMs >= config.silenceBoundaryMs else { return }
+        let startMs = endMs - reading.trailingSilenceMs
+        if let last = silences.last, abs(last.lowerBound - startMs) <= Self.silenceStartSlackMs {
+            silences[silences.count - 1] = Swift.min(last.lowerBound, startMs)..<Swift.max(last.upperBound, endMs)
+        } else {
+            silences.append(startMs..<endMs)
+        }
+        // Nothing before the commit can be committed again, so a pause that
+        // ended before it has nothing left to protect.
+        let floor = commit.committedEndMs
+        silences.removeAll { $0.upperBound <= floor }
+    }
+
+    /// Whether a word that starts here was read out of a confirmed pause. The
+    /// slack either side is the same drift the padding filter allows: a word
+    /// that starts just inside a pause may be the last word of the utterance
+    /// with its onset late, and one just before its end may be the first word
+    /// after it with its onset early.
+    private func startsInConfirmedSilence(_ startMs: Int) -> Bool {
+        let slack = OfflinePipeline.paddingToleranceMs
+        return silences.contains { startMs >= $0.lowerBound + slack && startMs < $0.upperBound - slack }
     }
 
     private func armFinalization() {
@@ -285,7 +327,8 @@ public final class LiveDecoder {
             absolute.reserveCapacity(output.tokens.count)
             for token in output.tokens {
                 let start = windowStartMs + token.startMs
-                guard start < audioEndMs, start < silentFromMs else {
+                guard start < audioEndMs, start < silentFromMs,
+                      !startsInConfirmedSilence(start) else {
                     stats.hallucinationsDropped += 1
                     continue
                 }

--- a/app/Sources/TranscriberEngine/LiveSession.swift
+++ b/app/Sources/TranscriberEngine/LiveSession.swift
@@ -100,6 +100,22 @@ public final class LiveSession {
     public var config = SessionConfig()
     public var isMuted = false { didSet { capture?.isMuted = isMuted } }
 
+    /// Paused: the clock, the file and the live text all stop, and resume
+    /// continues on the same timeline with no gap. Refer to
+    /// `AudioCapture.isPaused`. Cleared at `start` and at `stop`, so a
+    /// recording never begins paused because the last one ended that way.
+    public var isPaused = false {
+        didSet {
+            capture?.isPaused = isPaused
+            if isPaused {
+                // The meter would otherwise hold the last level for the
+                // length of the break.
+                level = 0
+                laneLevels = [:]
+            }
+        }
+    }
+
     /// Which lanes to record. Read at `start`; changing it mid-session does
     /// nothing, because the archive's channel count is fixed when the file is
     /// created.
@@ -232,6 +248,7 @@ public final class LiveSession {
 
         recordingId = id
         self.archiveFileName = archiveFileName
+        isPaused = false
         segments = []
         partial = ""
         lanes = captureSource.lanes
@@ -371,6 +388,7 @@ public final class LiveSession {
             notices: notices
         )
         recordingId = nil
+        isPaused = false
         state = .ready
         return result
     }

--- a/app/Sources/TranscriberEngine/MicrophoneAccess.swift
+++ b/app/Sources/TranscriberEngine/MicrophoneAccess.swift
@@ -58,16 +58,16 @@ public enum MicrophoneAccess: String, Sendable, CaseIterable {
     public var detail: String {
         switch self {
         case .granted:
-            return "Recording will capture audio."
+            return "A recording captures audio."
         case .notDetermined:
-            return "macOS will ask the first time you record. Granting it here "
-                 + "instead means a meeting never starts with a permission dialog."
+            return "macOS asks the first time you record. Give the permission here, "
+                 + "and a meeting never starts with a permission dialog."
         case .denied:
-            return "Recording will produce silence rather than an error. macOS only "
-                 + "asks once, so this has to be changed in System Settings."
+            return "A recording gives silence and no error. macOS asks one time only, "
+                 + "thus you must change this in System Settings."
         case .restricted:
-            return "A configuration profile or parental controls prevent microphone "
-                 + "access. Recording will produce silence."
+            return "A configuration profile or parental controls block the microphone. "
+                 + "A recording gives silence."
         }
     }
 

--- a/app/Sources/TranscriberEngine/Pipeline.swift
+++ b/app/Sources/TranscriberEngine/Pipeline.swift
@@ -315,6 +315,69 @@ public enum OfflinePipeline {
         )
     }
 
+    /// What a second pass over one stretch of the recording produced.
+    public struct RangeDecodeReport: Sendable {
+        /// Words inside the range, on the file's timeline.
+        public var tokens: [Token]
+        public var windowCount: Int
+        public var retriedWindows: Int
+        public var droppedWindows: Int
+    }
+
+    /// Decodes one stretch of a recording again, for the one turn the model
+    /// got wrong in a long meeting. Four hours of audio must not be decoded
+    /// again to fix forty seconds of it.
+    ///
+    /// The range is the caller's word that speech is there, so its edges are
+    /// the edges of the decode: the first window starts at the start of the
+    /// range and the last ends at its end, whatever the voice detector heard.
+    /// Measured on a real turn, the detector placed the first region 600 ms
+    /// after the turn began and the first word of the turn was lost. The
+    /// detector still chooses the cut points inside a range longer than one
+    /// window, so those fall in pauses as they do for the whole file. The
+    /// windows reach `padMs` past each edge so an onset is not clipped, and
+    /// the model stamps the first word of a window at the window's start:
+    /// with the floor at the turn's own start, that word was dropped every
+    /// time. A word therefore stays when its midpoint is inside the range. A
+    /// word that lies mostly before the range belongs to the neighbour, which
+    /// already has it.
+    public static func transcribeRange(
+        _ range: SpeechRegion,
+        in source: any PCMSource,
+        using vad: any VoiceActivityDetecting,
+        asr: any SpeechRecognizing,
+        language: String,
+        prompt: String?,
+        progress: (@Sendable (Double) -> Void)? = nil
+    ) async throws -> RangeDecodeReport {
+        let from = max(0, range.startMs)
+        let to = min(source.durationMs, range.endMs)
+        guard to > from else {
+            return RangeDecodeReport(tokens: [], windowCount: 0, retriedWindows: 0, droppedWindows: 0)
+        }
+        var regions = try await vad.regions(in: source.floats(msRange: from..<to)).map {
+            SpeechRegion(startMs: $0.startMs + from, endMs: $0.endMs + from)
+        }
+        if regions.isEmpty {
+            regions = [SpeechRegion(startMs: from, endMs: to)]
+        } else {
+            regions[0].startMs = from
+            regions[regions.count - 1].endMs = to
+        }
+        let decodeWindows = windows(for: regions, durationMs: source.durationMs)
+        let report = try await transcribe(
+            source: source, windows: decodeWindows, using: asr,
+            language: language, prompt: prompt, progress: progress,
+            initialFloorMs: max(0, from - padMs)
+        )
+        return RangeDecodeReport(
+            tokens: report.tokens.filter { ($0.startMs + $0.endMs) / 2 >= from && $0.startMs < to },
+            windowCount: decodeWindows.count,
+            retriedWindows: report.retriedWindows,
+            droppedWindows: report.droppedWindows
+        )
+    }
+
     struct Outcome {
         var tokens: [Token]
         var language: String?

--- a/app/Sources/TranscriberEngine/SystemAudioAccess.swift
+++ b/app/Sources/TranscriberEngine/SystemAudioAccess.swift
@@ -76,18 +76,18 @@ public enum SystemAudioAccess: String, Sendable, CaseIterable {
     public var detail: String {
         switch self {
         case .granted:
-            return "Recording will capture what this Mac plays."
+            return "A recording captures what this Mac plays."
         case .notDetermined:
-            return "macOS will ask the first time you record this Mac's audio. "
-                 + "Granting it here instead means a meeting never starts with a "
+            return "macOS asks the first time you record the audio of this Mac. "
+                 + "Give the permission here, and a meeting never starts with a "
                  + "permission dialog."
         case .denied:
-            return "The call side of a meeting will be missing, and nothing will "
-                 + "say so while recording. macOS only asks once, so this has to "
-                 + "be changed in System Settings."
+            return "The call side of a meeting is missing, and nothing says so "
+                 + "during the recording. macOS asks one time only, thus you must "
+                 + "change this in System Settings."
         case .unknown:
-            return "This version of macOS does not report the answer. Recording "
-                 + "will ask if it needs to."
+            return "This version of macOS does not report the answer. The recording "
+                 + "asks when necessary."
         }
     }
 

--- a/app/Sources/TranscriberEngine/TranscriptionQueue.swift
+++ b/app/Sources/TranscriberEngine/TranscriptionQueue.swift
@@ -9,6 +9,25 @@ public struct TranscriptionJob: Sendable, Identifiable, Equatable {
         /// Audio is already transcribed -- the live path did it. Only identify
         /// speakers and stamp them onto the segments that exist.
         case diarizeOnly
+        /// Decode one stretch again and replace the rows in it. The rest of
+        /// the transcript is not touched.
+        case range(RangeRequest)
+    }
+
+    /// One turn to decode again: its bounds on the recording's timeline, and
+    /// the speaker its new rows get. The speaker is carried rather than found
+    /// again, because one turn is one speaker and the diarizer would need the
+    /// whole recording to say more.
+    public struct RangeRequest: Sendable, Equatable {
+        public var fromMs: Int
+        public var toMs: Int
+        public var speakerId: String?
+
+        public init(fromMs: Int, toMs: Int, speakerId: String?) {
+            self.fromMs = fromMs
+            self.toMs = toMs
+            self.speakerId = speakerId
+        }
     }
 
     public var id: UUID
@@ -103,6 +122,9 @@ public enum JobEvent: Sendable {
     /// pass. `coveredMs` is how far into the audio the decode has reached.
     case partial(id: UUID, segments: [Segment], coveredMs: Int)
     case transcribed(id: UUID, payload: TranscriptionPayload)
+    /// One stretch decoded again. The rows between the bounds are replaced
+    /// by these; `modelId` is the model that produced them.
+    case rangeTranscribed(id: UUID, fromMs: Int, toMs: Int, segments: [Segment], modelId: String)
     case diarized(id: UUID, spans: [SpeakerSpan], roster: [SpeakerLabel])
     case failed(id: UUID, message: String)
     /// The job finished, but not intact. Surfaced rather than swallowed: a
@@ -222,6 +244,16 @@ public actor TranscriptionQueue {
             emit(.stage(id: job.id, status: .preparing, progress: 0))
 
             let source = try await workingCopy(for: job)
+
+            // Before the envelope: a range job is a few seconds of work, and
+            // the envelope walks the whole file for a waveform that exists.
+            if case .range(let request) = job.work {
+                try await transcribeRange(job, request: request,
+                                          source: job.roomMode ? HighPassPCM(source) : source)
+                if job.discardCacheWhenDone { try? FileManager.default.removeItem(at: job.cacheURL) }
+                return
+            }
+
             let waveform = WaveformAnalyzer.envelope(of: source)
             let durationMs = source.durationMs
             emit(.prepared(id: job.id, durationMs: durationMs, waveform: waveform))
@@ -417,6 +449,39 @@ public actor TranscriptionQueue {
             emit(.failed(id: job.id, message: error.localizedDescription))
             emit(.stage(id: job.id, status: .failed, progress: 0))
         }
+    }
+
+    /// One turn again, on the model the job names. The speaker of the turn is
+    /// stamped on the new rows; nothing else in the transcript changes.
+    private func transcribeRange(_ job: TranscriptionJob, request: TranscriptionJob.RangeRequest,
+                                 source: any PCMSource) async throws {
+        try await engines.loadModel(job.modelId) { _, fraction in
+            if let fraction {
+                self.emit(.stage(id: job.id, status: .preparing, progress: fraction))
+            }
+        }
+        emit(.stage(id: job.id, status: .transcribing, progress: 0))
+        try? await engines.prepareVAD(progress: nil)
+        let vad = await engines.voiceActivity
+        let asr = await engines.recognizer
+        let report = try await OfflinePipeline.transcribeRange(
+            SpeechRegion(startMs: request.fromMs, endMs: request.toMs),
+            in: source, using: vad, asr: asr,
+            language: job.language, prompt: job.prompt
+        ) { fraction in
+            self.emit(.stage(id: job.id, status: .transcribing, progress: fraction))
+        }
+        try Task.checkCancellation()
+        if report.droppedWindows > 0 {
+            emit(.warning(id: job.id, message:
+                "\(report.droppedWindows) window\(report.droppedWindows == 1 ? "" : "s") of the "
+                + "turn could not be decoded again. The old text of that part is gone."))
+        }
+        var segments = SegmentMerger.segments(from: report.tokens)
+        for index in segments.indices { segments[index].speakerId = request.speakerId }
+        emit(.rangeTranscribed(id: job.id, fromMs: request.fromMs, toMs: request.toMs,
+                               segments: segments, modelId: job.modelId))
+        emit(.stage(id: job.id, status: .completed, progress: 1))
     }
 
     private func diarizeOnly(_ job: TranscriptionJob, source: MappedPCM) async throws {

--- a/app/Sources/TranscriberStore/Schema.swift
+++ b/app/Sources/TranscriberStore/Schema.swift
@@ -166,8 +166,24 @@ public final class StoredTranscript {
     /// Deleted rows drop out at once rather than at the next save: a line the
     /// user just removed must not reappear in the reindex or the export that
     /// follows in the same breath.
+    ///
+    /// One indexed fetch rather than a walk of the relationship. The
+    /// relationship hands back a fault for each row and the sort fires every
+    /// one of them, which on a long meeting is thousands of round trips to
+    /// SQLite. The relationship is the fallback for a row that has no context
+    /// yet, which only a test constructs.
     public var orderedSegments: [StoredSegment] {
-        (segments ?? []).filter { !$0.isDeleted }.sorted { $0.startMs < $1.startMs }
+        if let context = modelContext {
+            let id = self.id
+            let descriptor = FetchDescriptor<StoredSegment>(
+                predicate: #Predicate { $0.transcript?.id == id },
+                sortBy: [SortDescriptor(\.startMs)]
+            )
+            if let rows = try? context.fetch(descriptor) {
+                return rows.filter { !$0.isDeleted }
+            }
+        }
+        return (segments ?? []).filter { !$0.isDeleted }.sorted { $0.startMs < $1.startMs }
     }
 }
 

--- a/app/Sources/TranscriberStore/TranscriptReader.swift
+++ b/app/Sources/TranscriberStore/TranscriptReader.swift
@@ -28,6 +28,34 @@ public actor TranscriptReader {
         TranscriptGrouping.blocks(from: try segments(ofTranscript: id))
     }
 
+    /// Every recording whose latest transcript has at least one corrected
+    /// row, with that transcript's rows. What the reference-set export reads.
+    ///
+    /// One query finds the edited rows; the recordings come from them, so a
+    /// library of hundreds of untouched meetings costs nothing here.
+    public func correctedTranscripts() throws -> [CorrectedTranscript] {
+        let edited = try modelContext.fetch(FetchDescriptor<StoredSegment>(
+            predicate: #Predicate { $0.textClean != nil }
+        ))
+        var seen: Set<UUID> = []
+        var out: [CorrectedTranscript] = []
+        for row in edited {
+            guard let transcript = row.transcript, let recording = transcript.recording,
+                  recording.transcript?.id == transcript.id,
+                  !seen.contains(transcript.id) else { continue }
+            seen.insert(transcript.id)
+            let segments = try Self.segments(ofTranscript: transcript.id, in: modelContext)
+            guard ReferenceSet.hasCorrections(segments) else { continue }
+            out.append(CorrectedTranscript(
+                recordingId: recording.id, title: recording.title,
+                createdAt: recording.createdAt, durationMs: recording.durationMs,
+                audioURL: recording.audioURL, language: transcript.language,
+                modelId: transcript.modelId, segments: segments
+            ))
+        }
+        return out.sorted { $0.createdAt < $1.createdAt }
+    }
+
     /// The same fetch on any context, for a caller that is already on the
     /// main actor and must answer at once.
     public static func segments(ofTranscript id: UUID, in context: ModelContext) throws -> [Segment] {
@@ -60,6 +88,18 @@ public actor TranscriptReader {
         descriptor.fetchLimit = 1
         return try context.fetch(descriptor).first
     }
+}
+
+/// A recording with corrected rows, as the reference-set export needs it.
+public struct CorrectedTranscript: Sendable {
+    public var recordingId: UUID
+    public var title: String
+    public var createdAt: Date
+    public var durationMs: Int
+    public var audioURL: URL?
+    public var language: String
+    public var modelId: String
+    public var segments: [Segment]
 }
 
 public extension Segment {

--- a/app/Sources/TranscriberStore/TranscriptReader.swift
+++ b/app/Sources/TranscriberStore/TranscriptReader.swift
@@ -1,0 +1,72 @@
+import Foundation
+import SwiftData
+import TranscriberCore
+
+/// Reads a transcript's rows as value types, off the main actor.
+///
+/// Walking `StoredTranscript.segments` costs one round trip to SQLite for
+/// each row, because every row comes back as a fault and the sort fires them
+/// all. A four-hour meeting has four thousand rows, thus a selection in the
+/// sidebar paid four thousand fetches on the main thread before the first
+/// line could draw. One fetch with a predicate and a sort descriptor returns
+/// the same rows in one query, in order, and a `@ModelActor` runs it on its
+/// own context so the window never waits for it.
+///
+/// Make a new reader for each read. A long-lived context keeps the row values
+/// it has already loaded, and a fetch does not refresh them, thus an edit
+/// saved on the main context could be read back stale.
+@ModelActor
+public actor TranscriptReader {
+
+    /// The rows of one transcript, in time order.
+    public func segments(ofTranscript id: UUID) throws -> [Segment] {
+        try Self.segments(ofTranscript: id, in: modelContext)
+    }
+
+    /// The rows grouped into speaker turns, ready for the transcript view.
+    public func blocks(ofTranscript id: UUID) throws -> [TranscriptBlock] {
+        TranscriptGrouping.blocks(from: try segments(ofTranscript: id))
+    }
+
+    /// The same fetch on any context, for a caller that is already on the
+    /// main actor and must answer at once.
+    public static func segments(ofTranscript id: UUID, in context: ModelContext) throws -> [Segment] {
+        try segmentRows(ofTranscript: id, in: context).map(Segment.init)
+    }
+
+    /// The stored rows themselves, in time order, for a caller that must
+    /// change them.
+    public static func segmentRows(ofTranscript id: UUID, in context: ModelContext) throws -> [StoredSegment] {
+        let descriptor = FetchDescriptor<StoredSegment>(
+            predicate: #Predicate { $0.transcript?.id == id },
+            sortBy: [SortDescriptor(\.startMs)]
+        )
+        return try context.fetch(descriptor)
+    }
+
+    /// The stored rows with these ids, in time order.
+    public static func segmentRows(ids: [UUID], in context: ModelContext) throws -> [StoredSegment] {
+        guard !ids.isEmpty else { return [] }
+        let descriptor = FetchDescriptor<StoredSegment>(
+            predicate: #Predicate { ids.contains($0.id) },
+            sortBy: [SortDescriptor(\.startMs)]
+        )
+        return try context.fetch(descriptor)
+    }
+
+    /// One stored row, or nil.
+    public static func segmentRow(id: UUID, in context: ModelContext) throws -> StoredSegment? {
+        var descriptor = FetchDescriptor<StoredSegment>(predicate: #Predicate { $0.id == id })
+        descriptor.fetchLimit = 1
+        return try context.fetch(descriptor).first
+    }
+}
+
+public extension Segment {
+    /// The value form of a stored row.
+    init(_ row: StoredSegment) {
+        self.init(id: row.id, index: row.index, startMs: row.startMs, endMs: row.endMs,
+                  text: row.text, textClean: row.textClean, speakerId: row.speakerId,
+                  confidence: row.confidence)
+    }
+}

--- a/app/Sources/TranscriberStore/TranscriptWriter.swift
+++ b/app/Sources/TranscriberStore/TranscriptWriter.swift
@@ -159,6 +159,37 @@ public actor TranscriptWriter {
         return transcript.revision
     }
 
+    /// Replaces the rows of the latest transcript that start inside a range
+    /// with new rows, in place. For one turn decoded again on another model:
+    /// a new revision for forty seconds of a four-hour meeting would copy
+    /// every row and break every note that points at one.
+    ///
+    /// The rows are renumbered afterwards, so `index` stays the order.
+    /// Returns how many rows went out.
+    @discardableResult
+    public func replaceSegments(fromMs: Int, toMs: Int, with segments: [Segment],
+                                for id: UUID) throws -> Int {
+        guard let recording = try find(id), let transcript = recording.transcript else { return 0 }
+        let rows = try TranscriptReader.segmentRows(ofTranscript: transcript.id, in: modelContext)
+        var removed = 0
+        for row in rows where row.startMs >= fromMs && row.startMs < toMs {
+            modelContext.delete(row)
+            removed += 1
+        }
+        // Saved before the inserts, so the renumbering below walks only the
+        // rows that stay.
+        try modelContext.save()
+        insert(segments, into: transcript)
+        for (index, row) in try TranscriptReader.segmentRows(ofTranscript: transcript.id,
+                                                              in: modelContext).enumerated() {
+            row.index = index
+        }
+        recording.updatedAt = Date()
+        RecordingStore.reindexOffMain(recording)
+        try modelContext.save()
+        return removed
+    }
+
     private func insert(_ segments: [Segment], into transcript: StoredTranscript) {
         for segment in segments {
             let row = StoredSegment(

--- a/app/Tests/TranscriberCoreTests/PromptingTests.swift
+++ b/app/Tests/TranscriberCoreTests/PromptingTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import TranscriberCore
+
+final class PromptingTests: XCTestCase {
+
+    func testNothingToSayIsNil() {
+        XCTAssertNil(TranscriptionPrompt.compose(language: "tl", usePrimer: false, vocabulary: nil))
+        XCTAssertNil(TranscriptionPrompt.compose(language: "tl", usePrimer: false, vocabulary: "  \n"))
+        XCTAssertNil(TranscriptionPrompt.compose(language: "en", usePrimer: true, vocabulary: nil),
+                     "English has no primer")
+    }
+
+    func testVocabularyAloneIsTrimmed() {
+        XCTAssertEqual(TranscriptionPrompt.compose(language: "tl", usePrimer: false,
+                                                   vocabulary: " Maria, Jose "),
+                       "Maria, Jose")
+    }
+
+    func testPrimerComesFirst() throws {
+        let primer = try XCTUnwrap(TranscriptionPrompt.primer(for: "tl"))
+        let composed = try XCTUnwrap(TranscriptionPrompt.compose(language: "tl", usePrimer: true,
+                                                                 vocabulary: "Maria"))
+        XCTAssertTrue(composed.hasPrefix(primer))
+        XCTAssertTrue(composed.hasSuffix(" Maria"))
+    }
+
+    /// The primer must not contain the content words of the synthetic fixture,
+    /// or a measurement against that fixture would flatter it.
+    func testPrimerDoesNotLeakTheFixture() throws {
+        let primer = try XCTUnwrap(TranscriptionPrompt.primer(for: "tl")).lowercased()
+        for word in ["attendance", "agenda", "timeline", "budget", "deployment", "staging",
+                     "release", "quarter", "testing"] {
+            XCTAssertFalse(primer.contains(word), "primer contains fixture word \(word)")
+        }
+    }
+}

--- a/app/Tests/TranscriberCoreTests/ReferenceSetTests.swift
+++ b/app/Tests/TranscriberCoreTests/ReferenceSetTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+@testable import TranscriberCore
+
+final class ReferenceSetTests: XCTestCase {
+
+    private func segment(_ index: Int, _ text: String, clean: String? = nil) -> Segment {
+        Segment(index: index, startMs: index * 3_000, endMs: index * 3_000 + 2_500,
+                text: text, textClean: clean)
+    }
+
+    func testOnlyARealEditCountsAsACorrection() {
+        XCTAssertFalse(ReferenceSet.isCorrected(segment(0, "Sige na")))
+        XCTAssertFalse(ReferenceSet.isCorrected(segment(0, "Sige na", clean: "Sige na ")),
+                       "an edit that restored the raw text is not a correction")
+        XCTAssertTrue(ReferenceSet.isCorrected(segment(0, "Sigue na", clean: "Sige na")))
+        XCTAssertFalse(ReferenceSet.hasCorrections([segment(0, "a"), segment(1, "b")]))
+        XCTAssertTrue(ReferenceSet.hasCorrections([segment(0, "a"), segment(1, "b", clean: "c")]))
+    }
+
+    func testReferenceIsTheWholeTranscriptWithEditsApplied() {
+        let rows = [segment(0, "Kumusta kayong lahat."),
+                    segment(1, "Bisa report ni Maria", clean: "Base sa report ni Maria"),
+                    segment(2, "  ")]
+        XCTAssertEqual(ReferenceSet.referenceText(rows),
+                       "Kumusta kayong lahat.\nBase sa report ni Maria\n")
+        XCTAssertEqual(ReferenceSet.rawText(rows),
+                       "Kumusta kayong lahat.\nBisa report ni Maria\n")
+    }
+
+    func testEditsTableHoldsTheCorrectedRowsOnly() {
+        let rows = [segment(0, "ok"),
+                    segment(1, "Bisa\treport", clean: "Base sa report")]
+        XCTAssertEqual(ReferenceSet.editsTSV(rows),
+                       "startMs\traw\tcorrected\n3000\tBisa report\tBase sa report\n")
+    }
+
+    func testSummaryScoresRawAgainstTheCorrections() {
+        let rows = [segment(0, "Kumusta kayong lahat"),
+                    segment(1, "Bisa report ni Maria", clean: "Base sa report ni Maria")]
+        let summary = ReferenceSet.summary(title: "Standup", durationMs: 6_000, segments: rows)
+        XCTAssertEqual(summary.segments, 2)
+        XCTAssertEqual(summary.correctedSegments, 1)
+        XCTAssertEqual(summary.referenceWords, 8)
+        // "Bisa" -> "Base" is one substitution and "sa" one insertion in the
+        // reference: two edits over eight reference words.
+        XCTAssertEqual(summary.rawWER, 0.25, accuracy: 0.001)
+    }
+
+    func testManifestKeepsTheKeysTheHarnessReads() throws {
+        let entry = ReferenceSet.Entry(id: "abc", audio: "audio/abc.m4a", ref: "refs/abc.txt",
+                                       raw: "raw/abc.txt", edits: "edits/abc.tsv",
+                                       title: "Standup", durationMs: 1_000)
+        let data = try ReferenceSet.manifestJSON([entry])
+        let decoded = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [[String: Any]])
+        XCTAssertEqual(decoded.count, 1)
+        XCTAssertEqual(decoded[0]["id"] as? String, "abc")
+        XCTAssertEqual(decoded[0]["audio"] as? String, "audio/abc.m4a")
+        XCTAssertEqual(decoded[0]["ref"] as? String, "refs/abc.txt")
+        XCTAssertEqual(decoded[0]["category"] as? String, "own")
+    }
+
+    func testSummaryMarkdownPoolsByReferenceWords() {
+        let table = ReferenceSet.summaryMarkdown([
+            ReferenceSet.Summary(title: "A | B", durationMs: 60_000, segments: 10,
+                                 correctedSegments: 2, referenceWords: 100, rawWER: 0.10),
+            ReferenceSet.Summary(title: "C", durationMs: 60_000, segments: 10,
+                                 correctedSegments: 1, referenceWords: 300, rawWER: 0.30),
+        ])
+        XCTAssertTrue(table.contains("| A / B |"), "a pipe in a title must not break the table")
+        XCTAssertTrue(table.contains("| **All** | | | | 400 | **25.0%** |"))
+    }
+}

--- a/app/Tests/TranscriberEngineTests/InputGainSessionTests.swift
+++ b/app/Tests/TranscriberEngineTests/InputGainSessionTests.swift
@@ -52,6 +52,26 @@ final class InputGainSessionTests: XCTestCase {
         XCTAssertEqual(session.inputGainDb, InputGain.minDb)
     }
 
+    /// Pause is a flag the audio callback reads per buffer, like gain. A
+    /// session that ends paused must not leave the next one paused.
+    func testPauseRoundTripsAndClearsTheMeter() throws {
+        let session = makeSession()
+        XCTAssertFalse(session.isPaused)
+        session.isPaused = true
+        XCTAssertTrue(session.isPaused)
+        XCTAssertEqual(session.level, 0)
+        XCTAssertTrue(session.laneLevels.isEmpty)
+        session.isPaused = false
+        XCTAssertFalse(session.isPaused)
+
+        let capture = try XCTUnwrap(AudioCapture())
+        XCTAssertFalse(capture.isPaused)
+        capture.isPaused = true
+        XCTAssertTrue(capture.isPaused)
+        capture.isMuted = true
+        XCTAssertTrue(capture.isMuted, "mute and pause are separate switches")
+    }
+
     /// The capture object applies gain per buffer, so the value set before a
     /// session starts has to survive to the tap rather than being reset to 0 dB.
     func testCaptureCarriesTheGain() throws {

--- a/app/Tests/TranscriberEngineTests/LiveDecoderTests.swift
+++ b/app/Tests/TranscriberEngineTests/LiveDecoderTests.swift
@@ -252,6 +252,41 @@ final class LiveDecoderTests: XCTestCase {
         XCTAssertEqual(decoder.stats.unagreedTailCommits, 2, "\"na ulit\" against a stale \"???\"")
     }
 
+    /// The phrase Whisper reads out of a pause used to survive one way: a hop
+    /// heard it, the final decode dropped it, speech resumed before that final
+    /// returned so the boundary was abandoned, and the next two hops -- which
+    /// still covered the pause -- agreed on it. Now the confirmed pause itself
+    /// is what drops it, on every hop.
+    func testAWordReadOutOfAConfirmedPauseNeverCommitsEvenWhenTheFinalIsAbandoned() async throws {
+        let (decoder, asr, _, out) = make(
+            words: [word("sige", 200, 600), word("na", 600, 1_000),
+                    word("ulit", 2_500, 2_900), word("po", 2_900, 3_300)],
+            speech: [200..<1_000, 2_500..<3_300]
+        )
+        await asr.setPhantoms([word("thank", 1_300, 1_500)])
+        var clock = 0
+        await feed(decoder, &clock, to: 1_500)                       // hop: "sige na thank"
+        await asr.hold()
+        await feed(decoder, &clock, to: 1_800, settle: .vadOnly)     // final starts, hangs
+        // The VAD is batched about every 300 ms, so the speech at 2.5 s is
+        // heard by the 2.7 s batch; the final returns to a room that is
+        // talking again.
+        await feed(decoder, &clock, to: 2_800, settle: .vadOnly)
+        await asr.release()
+        await decoder.drain()
+        XCTAssertEqual(decoder.stats.finalizationsAbandoned, 1)
+        XCTAssertEqual(out.committed.joinedText, "sige na")
+        let partialsBefore = out.partials.count
+
+        // Two more hops cover the pause. Without the filter they agree on
+        // "thank" and commit it; the final pause then closes the utterance.
+        await feed(decoder, &clock, to: 5_000)
+        XCTAssertEqual(out.committed.joinedText, "sige na ulit po")
+        XCTAssertFalse(out.partials.dropFirst(partialsBefore).joined().contains("thank"),
+                       "the phantom must not even be shown as provisional once the pause is confirmed")
+        XCTAssertGreaterThanOrEqual(decoder.stats.hallucinationsDropped, 2)
+    }
+
     func testAContinuedPauseIsNotFinalizedTwice() async throws {
         let (decoder, asr, _, _) = make(words: [word("sige", 200, 600)], speech: [200..<600])
         var clock = 0

--- a/app/Tests/TranscriberEngineTests/PipelineTests.swift
+++ b/app/Tests/TranscriberEngineTests/PipelineTests.swift
@@ -332,6 +332,83 @@ extension PipelineDecodeTests {
     }
 }
 
+/// One stretch decoded again: only words inside it come back, on the file's
+/// timeline, and a quiet range is still decoded as one window.
+final class RangeDecodeTests: XCTestCase {
+
+    private actor SilentVAD: VoiceActivityDetecting {
+        func prepare(progress: ProgressReport?) async throws {}
+        func push(_ samples: [Float]) async throws -> VoiceActivityReading {
+            VoiceActivityReading(isSpeech: false, probability: 0, trailingSilenceMs: 0, speechMs: 0)
+        }
+        func clearSpeechCounter() {}
+        func reset() {}
+        func regions(in samples: [Float]) async throws -> [SpeechRegion] { [] }
+    }
+
+    func testOnlyWordsInsideTheRangeComeBackOnTheFileTimeline() async throws {
+        // Two minutes of audio; the fake says one word per second of window.
+        let source = ArrayPCM([Float](repeating: 0.1, count: Audio.sampleRate * 120))
+        let report = try await OfflinePipeline.transcribeRange(
+            SpeechRegion(startMs: 60_000, endMs: 70_000),
+            in: source, using: SilentVAD(), asr: FakeRecognizer(),
+            language: "tl", prompt: nil
+        )
+        XCTAssertEqual(report.windowCount, 1, "a quiet range is decoded as one window")
+        XCTAssertEqual(report.droppedWindows, 0)
+        XCTAssertFalse(report.tokens.isEmpty)
+        for token in report.tokens {
+            // The first word may start in the 200 ms of padding before the
+            // range, as the model stamps it; its midpoint is inside.
+            XCTAssertGreaterThanOrEqual(token.startMs, 60_000 - OfflinePipeline.padMs)
+            XCTAssertGreaterThanOrEqual((token.startMs + token.endMs) / 2, 60_000)
+            XCTAssertLessThan(token.startMs, 70_000)
+        }
+        XCTAssertFalse(report.tokens.contains { $0.text.contains("hallucinated") })
+    }
+
+    /// The detector hears the turn start late. The decode must not.
+    private actor LateVAD: VoiceActivityDetecting {
+        func prepare(progress: ProgressReport?) async throws {}
+        func push(_ samples: [Float]) async throws -> VoiceActivityReading {
+            VoiceActivityReading(isSpeech: false, probability: 0, trailingSilenceMs: 0, speechMs: 0)
+        }
+        func clearSpeechCounter() {}
+        func reset() {}
+        func regions(in samples: [Float]) async throws -> [SpeechRegion] {
+            let ms = samples.count * 1000 / Audio.sampleRate
+            return [SpeechRegion(startMs: 3_000, endMs: ms - 2_000)]
+        }
+    }
+
+    func testTheRangeEdgesAreTheDecodeEdgesWhateverTheDetectorHeard() async throws {
+        let source = ArrayPCM([Float](repeating: 0.1, count: Audio.sampleRate * 120))
+        let report = try await OfflinePipeline.transcribeRange(
+            SpeechRegion(startMs: 60_000, endMs: 70_000),
+            in: source, using: LateVAD(), asr: FakeRecognizer(),
+            language: "tl", prompt: nil
+        )
+        let first = try XCTUnwrap(report.tokens.first)
+        let last = try XCTUnwrap(report.tokens.last)
+        // The fake speaks one word per second from the window's start, which
+        // is 200 ms before the range: that first word is kept, because most
+        // of it lies inside the range.
+        XCTAssertEqual(first.startMs, 60_000 - OfflinePipeline.padMs, "the first word of the turn was decoded")
+        XCTAssertGreaterThan(last.startMs, 68_000, "the last seconds of the turn were decoded")
+    }
+
+    func testAnEmptyRangeDecodesNothing() async throws {
+        let source = ArrayPCM([Float](repeating: 0.1, count: Audio.sampleRate * 10))
+        let report = try await OfflinePipeline.transcribeRange(
+            SpeechRegion(startMs: 5_000, endMs: 5_000),
+            in: source, using: SilentVAD(), asr: FakeRecognizer(),
+            language: "tl", prompt: nil
+        )
+        XCTAssertEqual(report.windowCount, 0)
+        XCTAssertTrue(report.tokens.isEmpty)
+    }
+}
+
 final class TranscriptionQueueCancellationTests: XCTestCase {
     func testCancellingAQueuedJobEmitsCancelledAndFinished() async throws {
         let scratch = FileManager.default.temporaryDirectory

--- a/app/Tests/TranscriberStoreTests/TranscriptReaderTests.swift
+++ b/app/Tests/TranscriberStoreTests/TranscriptReaderTests.swift
@@ -1,0 +1,152 @@
+import SwiftData
+import XCTest
+import TranscriberCore
+@testable import TranscriberStore
+
+/// The one-query transcript read that the view and the exports use.
+@MainActor
+final class TranscriptReaderTests: XCTestCase {
+
+    private var container: ModelContainer!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        container = try StoreContainer.ephemeral()
+    }
+
+    override func tearDown() async throws {
+        container = nil
+        try await super.tearDown()
+    }
+
+    /// Rows inserted out of time order, on two transcripts, so a read that
+    /// forgot the predicate or the sort would show.
+    private func seed(rows: Int, in context: ModelContext) throws -> (StoredRecording, StoredTranscript) {
+        let recording = try RecordingStore.create(kind: .meeting, title: "Long one", in: context)
+        let transcript = StoredTranscript(modelId: "turbo", language: "tl")
+        transcript.recording = recording
+        context.insert(transcript)
+        let other = StoredTranscript(revision: 0, modelId: "turbo", language: "tl")
+        other.recording = recording
+        context.insert(other)
+        for index in (0..<rows).reversed() {
+            let row = StoredSegment(index: index, startMs: index * 3_000,
+                                    endMs: index * 3_000 + 2_500, text: "line \(index)",
+                                    speakerId: index.isMultiple(of: 2) ? "S1" : "S2")
+            row.transcript = transcript
+            context.insert(row)
+        }
+        let stray = StoredSegment(index: 0, startMs: 10, endMs: 20, text: "other revision")
+        stray.transcript = other
+        context.insert(stray)
+        try context.save()
+        return (recording, transcript)
+    }
+
+    func testReadsOneTranscriptInTimeOrder() async throws {
+        let context = container.mainContext
+        let (_, transcript) = try seed(rows: 50, in: context)
+
+        let reader = TranscriptReader(modelContainer: container)
+        let segments = try await reader.segments(ofTranscript: transcript.id)
+
+        XCTAssertEqual(segments.count, 50)
+        XCTAssertEqual(segments.map(\.startMs), (0..<50).map { $0 * 3_000 })
+        XCTAssertFalse(segments.contains { $0.text == "other revision" })
+        XCTAssertEqual(segments.first?.speakerId, "S1")
+
+        let blocks = try await reader.blocks(ofTranscript: transcript.id)
+        // Speakers alternate every row, so every row is its own turn.
+        XCTAssertEqual(blocks.count, 50)
+        XCTAssertEqual(blocks.first?.id, segments.first?.id)
+    }
+
+    func testOrderedSegmentsMatchesTheFetch() throws {
+        let context = container.mainContext
+        let (_, transcript) = try seed(rows: 30, in: context)
+
+        let fetched = try TranscriptReader.segments(ofTranscript: transcript.id, in: context)
+        XCTAssertEqual(transcript.orderedSegments.map(\.id), fetched.map(\.id))
+    }
+
+    func testADeletedRowLeavesAtOnce() throws {
+        let context = container.mainContext
+        let (_, transcript) = try seed(rows: 5, in: context)
+        let victim = transcript.orderedSegments[2]
+        context.delete(victim)
+
+        XCTAssertEqual(transcript.orderedSegments.count, 4, "before the save")
+        XCTAssertFalse(transcript.orderedSegments.contains { $0.id == victim.id })
+        try context.save()
+        XCTAssertEqual(try TranscriptReader.segments(ofTranscript: transcript.id, in: context).count, 4)
+    }
+
+    func testRowsByIdComeBackInTimeOrder() throws {
+        let context = container.mainContext
+        let (_, transcript) = try seed(rows: 10, in: context)
+        let all = transcript.orderedSegments
+        let picked = [all[7].id, all[2].id, all[5].id]
+
+        let rows = try TranscriptReader.segmentRows(ids: picked, in: context)
+        XCTAssertEqual(rows.map(\.startMs), [6_000, 15_000, 21_000])
+        XCTAssertEqual(try TranscriptReader.segmentRow(id: all[3].id, in: context)?.text, "line 3")
+        XCTAssertNil(try TranscriptReader.segmentRow(id: UUID(), in: context))
+        XCTAssertEqual(try TranscriptReader.segmentRows(ids: [], in: context).count, 0)
+    }
+
+    /// The two ways to read a long transcript, on a store on disk, so the
+    /// numbers mean what the app sees. The walk of the relationship faults
+    /// every row on the way to the sort; the fetch is one query. Printed, not
+    /// asserted against a bound: machines differ. The one assertion is that
+    /// the fetch is not slower than the walk.
+    func testTheFetchBeatsTheRelationshipWalkOnDisk() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("reader-\(UUID().uuidString).store")
+        defer {
+            for suffix in ["", "-wal", "-shm"] {
+                try? FileManager.default.removeItem(atPath: url.path + suffix)
+            }
+        }
+        let schema = Schema(TranscriberSchema.models)
+        let disk = try ModelContainer(for: schema,
+                                      configurations: [ModelConfiguration(schema: schema, url: url)])
+        let context = disk.mainContext
+        let (_, transcript) = try seed(rows: 4_000, in: context)
+
+        // A fresh context, as a selection in the sidebar would see it.
+        let cold = ModelContext(disk)
+        let walkStarted = Date()
+        let walked = try cold.fetch(FetchDescriptor<StoredTranscript>()).first { $0.id == transcript.id }
+        let walkedRows = (walked?.segments ?? []).sorted { $0.startMs < $1.startMs }
+        let walkedWords = walkedRows.reduce(0) { $0 + $1.displayText.split(separator: " ").count }
+        let walkMs = Date().timeIntervalSince(walkStarted) * 1000
+
+        let reader = TranscriptReader(modelContainer: disk)
+        let fetchStarted = Date()
+        let fetched = try await reader.segments(ofTranscript: transcript.id)
+        let fetchedWords = fetched.reduce(0) { $0 + $1.displayText.split(separator: " ").count }
+        let fetchMs = Date().timeIntervalSince(fetchStarted) * 1000
+
+        XCTAssertEqual(fetched.count, 4_000)
+        XCTAssertEqual(fetchedWords, walkedWords)
+        print(String(format: "TranscriptReader on disk: walk %.0f ms, fetch %.0f ms for 4000 rows",
+                     walkMs, fetchMs))
+        XCTAssertLessThanOrEqual(fetchMs, walkMs * 1.5)
+    }
+
+    /// Not an assertion on time -- machines differ -- but the read of a long
+    /// transcript must not scale like the relationship walk did. Printed so a
+    /// regression is visible in the log.
+    func testALongTranscriptReadsInOneQuery() async throws {
+        let context = container.mainContext
+        let (_, transcript) = try seed(rows: 4_000, in: context)
+
+        let reader = TranscriptReader(modelContainer: container)
+        let started = Date()
+        let segments = try await reader.segments(ofTranscript: transcript.id)
+        let fetchMs = Int(Date().timeIntervalSince(started) * 1000)
+        XCTAssertEqual(segments.count, 4_000)
+        print("TranscriptReader: 4000 rows in \(fetchMs) ms")
+        XCTAssertLessThan(fetchMs, 5_000)
+    }
+}

--- a/app/Tests/TranscriberStoreTests/TranscriptReaderTests.swift
+++ b/app/Tests/TranscriberStoreTests/TranscriptReaderTests.swift
@@ -94,6 +94,56 @@ final class TranscriptReaderTests: XCTestCase {
         XCTAssertEqual(try TranscriptReader.segmentRows(ids: [], in: context).count, 0)
     }
 
+    func testReplacingARangeKeepsTheRestAndRenumbers() async throws {
+        let context = container.mainContext
+        let (recording, transcript) = try seed(rows: 10, in: context)
+        let writer = TranscriptWriter(modelContainer: container)
+
+        // Rows 3, 4 and 5 start at 9, 12 and 15 s. Replace 9 s ..< 18 s.
+        let removed = try await writer.replaceSegments(
+            fromMs: 9_000, toMs: 18_000,
+            with: [Segment(index: 0, startMs: 9_100, endMs: 13_000, text: "better", speakerId: "S9"),
+                   Segment(index: 0, startMs: 13_100, endMs: 17_500, text: "words", speakerId: "S9")],
+            for: recording.id
+        )
+        XCTAssertEqual(removed, 3)
+
+        let rows = try TranscriptReader.segments(ofTranscript: transcript.id, in: context)
+        XCTAssertEqual(rows.count, 9)
+        XCTAssertEqual(rows.map(\.index), Array(0..<9), "renumbered in time order")
+        XCTAssertEqual(rows[3].text, "better")
+        XCTAssertEqual(rows[4].text, "words")
+        XCTAssertEqual(rows[4].speakerId, "S9")
+        XCTAssertEqual(rows[2].text, "line 2")
+        XCTAssertEqual(rows[5].text, "line 6")
+        // The search index is rebuilt on the writer's context; read it back
+        // from the store rather than from the row this context still holds.
+        let id = recording.id
+        let fresh = try ModelContext(container).fetch(FetchDescriptor<StoredRecording>(
+            predicate: #Predicate { $0.id == id }
+        )).first
+        let index = try XCTUnwrap(fresh?.searchText)
+        XCTAssertTrue(index.contains("better"), index)
+        XCTAssertTrue(index.contains("words"), index)
+        XCTAssertFalse(index.contains("line 4"), "the replaced row left the index")
+    }
+
+    func testCorrectedTranscriptsFindsOnlyRecordingsWithARealEdit() async throws {
+        let context = container.mainContext
+        let (edited, transcript) = try seed(rows: 4, in: context)
+        let (_, untouched) = try seed(rows: 4, in: context)
+        let (_, restored) = try seed(rows: 4, in: context)
+        transcript.orderedSegments[1].textClean = "a correction"
+        restored.orderedSegments[0].textClean = restored.orderedSegments[0].text
+        _ = untouched
+        try context.save()
+
+        let found = try await TranscriptReader(modelContainer: container).correctedTranscripts()
+        XCTAssertEqual(found.map(\.recordingId), [edited.id])
+        XCTAssertEqual(found.first?.segments.count, 4)
+        XCTAssertEqual(found.first?.segments[1].displayText, "a correction")
+    }
+
     /// The two ways to read a long transcript, on a store on disk, so the
     /// numbers mean what the app sees. The walk of the relationship faults
     /// every row on the way to the sort; the fetch is one query. Printed, not

--- a/app/scripts/click.swift
+++ b/app/scripts/click.swift
@@ -35,7 +35,7 @@ switch mode {
 case "right":
     post(.rightMouseDown, .right); usleep(40_000); post(.rightMouseUp, .right)
 case "double":
-    post(.leftMouseDown, .left); usleep(30_000); post(.leftMouseUp, .left); usleep(60_000)
+    post(.leftMouseDown, .left); usleep(30_000); post(.leftMouseUp, .left); usleep(140_000)
     post(.leftMouseDown, .left, clicks: 2); usleep(30_000); post(.leftMouseUp, .left, clicks: 2)
 default:
     post(.leftMouseDown, .left); usleep(40_000); post(.leftMouseUp, .left)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -278,6 +278,18 @@ A new `TranscriptReader` for each read, on purpose. A context keeps the values
 it has loaded, and a fetch does not refresh them, thus a long-lived reader
 would return an edit that the main context saved a moment ago in its old form.
 
+## One turn again
+
+`TranscriptionJob.Work.range` decodes one stretch of a recording again.
+`OfflinePipeline.transcribeRange` runs the voice detector over the stretch,
+packs the windows as the whole-file pass does, decodes them with the retry
+ladder, and keeps only the words that start inside the stretch. The queue
+stamps the speaker of the turn on the new rows, and
+`TranscriptWriter.replaceSegments` deletes the rows that start inside the
+stretch, inserts the new rows and renumbers the transcript. The rows change in
+place, in the latest revision: a new revision for forty seconds of a four-hour
+meeting would copy every row and break every note that points at one.
+
 ## Transcript revisions
 
 A transcript is a revision and not a mutable document. `StoredRecording` holds

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -151,6 +151,16 @@ Three rules govern the schedule:
   still silent when the decode returns. The agreed prefix commits as usual. The
   remainder commits from the final hypothesis at that confirmed boundary. If a
   person started to speak again during the decode, nothing commits unagreed.
+- **A confirmed pause is silence in every hypothesis.** The decoder records
+  each pause that the voice detector confirms at 700 ms or longer. The decoder
+  drops a word that the model places inside one, with 250 ms of slack at each
+  edge, from a hop as well as from a final decode. Finding 12 in
+  [FINDINGS.md](FINDINGS.md) gives the failure this stops: a phrase read out of
+  a pause by a hop, kept when speech resumed before the final decode returned,
+  and committed when the next two hops agreed on it.
+
+Live text is off by default. `AppSettings.liveTranscription` is false unless
+the user turns it on, and the app then loads no model at the start.
 
 `SessionConfig` holds the measured defaults:
 
@@ -240,6 +250,26 @@ person who opened the meeting is Speaker 1.
 
 A job can carry `expectedSpeakers`, which is the number of people that the user
 says were in the room. It is a target for the clustering and never a cap.
+
+## How the app reads a transcript
+
+`TranscriptReader` in `TranscriberStore` reads the rows of one transcript as
+value types: one fetch with a predicate on the transcript and a sort descriptor
+on `startMs`, on a `@ModelActor` with its own context. `StoredTranscript.
+orderedSegments` runs the same fetch on the context of the row. Before this,
+each reader walked the `segments` relationship, which returned a fault for
+each row and fired every fault in the sort. A 4000-row transcript took 278 ms
+on disk that way, on the main thread, and the transcript view did it again on
+each redraw. The fetch takes 50 ms, and the view runs it off the main thread.
+
+The view reads again only when the rows change. `StoredRecording.updatedAt`
+moves on each write from the user interface. `AppState.transcriptTicks` moves
+on each write from a job: a batch of partial rows, the final rows, the speaker
+labels. The view does not count the rows.
+
+A new `TranscriptReader` for each read, on purpose. A context keeps the values
+it has loaded, and a fetch does not refresh them, thus a long-lived reader
+would return an edit that the main context saved a moment ago in its old form.
 
 ## Transcript revisions
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -127,6 +127,13 @@ recording, the capture restarts on the device that is available, converts its
 samples to the rate of the archive, writes the lost time as silence, and
 reports the change to the recording screen.
 
+**Mute and pause are two switches on `AudioCapture`.** Mute writes silence:
+the timeline stays on the wall clock, and the transcript stays in step with
+the file. Pause drops the frames: nothing reaches the archive, the working copy
+or the decoder, the clock of the recording stands still, and resume continues
+on the same timeline with no gap. The input keeps running during a pause, thus
+resume is immediate, and the app still handles a device change during the pause.
+
 ## Live transcription
 
 `LiveDecoder` owns everything between a chunk of PCM and a committed token.

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -278,6 +278,19 @@ of commits for each stream falls by approximately one third.
 
 ## Measure your own audio
 
+**Your corrections are the best references you have.** In Advanced mode,
+**File › Export Corrections as References…** writes a folder with a copy of
+each recording that has edits, the edited transcript as the reference, and a
+`manifest.json`. Point the harness at it:
+
+```bash
+python3 eval/compare_language.py --manifest FOLDER/manifest.json \
+    --bin app/.build/release/transcribe --models models --arms tl
+```
+
+The folder's `summary.md` also gives the raw model text scored against your
+corrections, with no new decode. That number is the error rate you experience.
+
 In the app, press ⇧⌘K for the model benchmark. It measures the three tiers on
 your own audio and recommends the slowest tier that stays at real-time speed.
 **It ranks the tiers by decode time, and it does not measure accuracy.**

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -134,6 +134,37 @@ a 15-second context, scored with the command-line scorer:
 each commit boundary was costing six WER points. Real-time pacing dropped 4 of
 38 hops, which is 11%.
 
+### The pause filter
+
+The paused synthetic clip (87 s, 25 pauses of 1.2 s) exercises the utterance
+boundary. On 2026-09-06 the decoder started to drop, from each hypothesis, a
+word that starts inside a pause that the voice detector found. Every decode
+awaited, Balanced tier:
+
+| Paused clip, live replay | WER | Words | Tail words committed unagreed | Deduplicated by text |
+| --- | ---: | ---: | ---: | ---: |
+| before the filter | 51.6% | 122 | 59 | 14 |
+| **with the filter** | **39.1%** | 127 | 46 | 17 |
+
+The clips with no pause of 700 ms do not change. Finding 12 in
+[FINDINGS.md](FINDINGS.md) gives the mechanism.
+
+### A style primer in the prompt
+
+A sentence of Taglish before each window, as a hint for the spelling. Measured
+on 2026-09-06 with `transcribe --style-hint`, Balanced tier:
+
+| Clip | Path | No primer | Primer |
+| --- | --- | ---: | ---: |
+| synthetic | offline | 24.2% | 44.5% |
+| synthetic | live | 27.3% | 96.1% |
+| meeting01 | offline | 71.7% | 65.0% |
+| meeting01 | live | 63.3% | 280.0% |
+
+**The app does not send the primer.** On the live path the model repeats the
+primer instead of the room. The Names and terms field of the app is a short
+list, and this measurement does not cover short prompts.
+
 ### The adaptive hop
 
 Under real-time pacing:

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -25,7 +25,8 @@ The binary is at `app/.build/release/transcribe`.
 ```
 transcribe --audio FILE [--reference FILE] [--models DIR]
            [--model ID | --tier fast|balanced|accurate]
-           [--language tl] [--fast-diarize | --no-diarize] [--room-mode]
+           [--language tl] [--prompt "Maria, Jose"] [--style-hint]
+           [--fast-diarize | --no-diarize] [--room-mode]
            [--format txt|markdown|srt|vtt|json] [--out FILE] [--json FILE]
            [--live [--realtime] [--hop MS] [--pre-roll MS] [--context MS] [--adaptive-hop]]
 transcribe --audio FILE --lane room|remote
@@ -77,6 +78,8 @@ Replay a file through the live path at wall-clock speed:
 | `--model ID` | Use this WhisperKit model. It overrides `--tier`. [MODELS.md](MODELS.md) lists the ids. |
 | `--tier fast\|balanced\|accurate` | Use the default model for this tier. The default is `balanced`. |
 | `--language CODE` | Force this language. The default is `tl`. `auto` selects automatic detection. |
+| `--prompt TEXT` | Names and terms for the decoder, as the Names and terms field of the app. |
+| `--style-hint` | Put the Taglish style primer of `TranscriptionPrompt` in front of the prompt. **The app does not do this.** Finding 12 in [FINDINGS.md](FINDINGS.md) gives the measurement: the primer made the live path worse. The flag exists to repeat that measurement. |
 | `--fast-diarize` | Do one speaker pass only. |
 | `--no-diarize` | Do no speaker identification. |
 | `--room-mode` | Apply the high-pass filter for far-field room audio. |

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -63,7 +63,7 @@ catalogue and the storage layout.
 cd app && swift test
 ```
 
-There are 278 tests: 250 XCTest tests and 28 swift-testing tests. **They need
+There are 289 tests: 261 XCTest tests and 28 swift-testing tests. **They need
 no model weights, no microphone and no network.** This property is deliberate,
 and you must keep it. The four-layer split in
 [ARCHITECTURE.md](ARCHITECTURE.md) is what makes it possible.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -63,7 +63,7 @@ catalogue and the storage layout.
 cd app && swift test
 ```
 
-There are 289 tests: 261 XCTest tests and 28 swift-testing tests. **They need
+There are 301 tests: 273 XCTest tests and 28 swift-testing tests. **They need
 no model weights, no microphone and no network.** This property is deliberate,
 and you must keep it. The four-layer split in
 [ARCHITECTURE.md](ARCHITECTURE.md) is what makes it possible.

--- a/docs/FINDINGS.md
+++ b/docs/FINDINGS.md
@@ -490,6 +490,58 @@ references before revisiting this. (WER here is `langscore`'s, which keeps
 intra-word hyphens so "i-send" stays one Filipino word; the CLI's own WER
 splits it and reads 27.3% for the same transcript.)
 
+## 12. A confirmed pause drops what a hop read out of it; a style primer does not help (2026-09-06)
+
+Finding 11 left one hallucination standing on the paused clip: a phrase a *hop*
+had read out of a pause survived because speech resumed before the final
+decode returned, the boundary was abandoned, and the next two hops -- whose
+windows still covered the pause -- agreed on the phrase and committed it. The
+final decode's own filter (`speechEndMs + 250 ms`) never saw those hops.
+
+`LiveDecoder` now records every pause the VAD confirms at `silenceBoundaryMs`
+or longer, on the session timeline, and drops from *every* hypothesis a word
+that starts inside one (250 ms of slack at each edge, the same drift the padding
+filter allows). Pauses that end before the commit are pruned. Measured on the
+paused synthetic clip (87 s, 25 inserted pauses of 1.2 s), every decode awaited,
+Balanced tier, today's baseline against today's build:
+
+| Paused clip, live replay | WER | Words | Tail words committed unagreed | Deduplicated by text |
+|---|---:|---:|---:|---:|
+| before | 51.6% | 122 | 59 | 14 |
+| **confirmed-pause filter** | **39.1%** | 127 | 46 | 17 |
+
+Twelve and a half points, and thirteen fewer unagreed tail words: the phrases
+that used to be committed from a pause were exactly the ones no second pass had
+agreed with. The unpaused clips are unchanged (no pause on them reaches 700 ms),
+which is the expected null result. A test reproduces the abandoned-final
+sequence with a scripted VAD and a phantom word and asserts the phantom never
+reaches a partial once the pause is confirmed
+(`LiveDecoderTests.testAWordReadOutOfAConfirmedPauseNeverCommitsEvenWhenTheFinalIsAbandoned`).
+
+**A Taglish style primer in the prompt makes the live path collapse.** The idea
+was to hand Whisper one sentence of ordinary Taglish as the "previous
+transcript" before each window, so it would spell English words in English and
+keep the hyphen in "i-send". The primer names none of the fixture's content
+words, and `TranscriptionPrompt` carries it so the measurement can be repeated
+(`transcribe --style-hint`). Measured, Balanced tier:
+
+| Clip | Path | No primer | Primer |
+|---|---|---:|---:|
+| synthetic | offline | 24.2% | 44.5% |
+| synthetic | live | 27.3% | **96.1%** |
+| meeting01 | offline | 71.7% | 65.0% |
+| meeting01 | live | 63.3% | **280.0%** |
+
+On the live path the model repeats the primer into the hypotheses: 153 and 195
+decoded words against 123 and 51 without it, and the unagreed tail counts go
+from 37 to 5 and from 4 to 38, which is agreement on invented text. Offline it
+is worse on the clip with the trustworthy reference and better on the one whose
+reference is too poor to weigh. The primer is not sent by the app. The user's
+own Names and terms field still goes through, unchanged: it is a short list,
+and this measurement says nothing about short prompts. `suppressBlank` was
+measured in the same run (25.8% / 27.3% / 58.3% against 24.2% / 27.3% / 71.7%)
+and left at WhisperKit's default.
+
 ## Caveat: the audio was synthetic
 
 macOS ships no Filipino voice, so the fixture uses the Indonesian one reading a

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -145,12 +145,39 @@ Press ⌘B to bookmark the moment during a recording or during playback.
 
 ## Edit the transcript
 
+**Transcribe one turn again.** Right-click a turn and select **Transcribe
+This Turn Again**. The app decodes only that turn, on the Accurate tier in
+Simple mode and on the tier that you select in Advanced mode, and replaces the
+lines of the turn. The rest of the transcript does not change, and the turn
+keeps its speaker. A four-hour meeting with one bad window is therefore fixed
+in seconds. The first run on the Accurate tier downloads its model.
+
 Double-click a turn to edit it line by line. The app keeps the raw model output
 below your edit. The search index and the exports read the edited text.
 
 You can restore a line, delete it, or move it to a different speaker. Press ⌘Z
 to undo all edits to one turn in one step. A menu in the info bar shows the
 earlier revisions.
+
+## Your corrections as references
+
+Each edit that you make is stored beside the raw model text. A recording with
+edits is therefore a scored pair: the raw text is the hypothesis, and your
+edited transcript is the reference. In Advanced mode, select **File › Export
+Corrections as References…** and select a folder. The app writes a dated
+folder with a copy of each corrected recording, its reference text, the raw
+text, the corrected lines with the raw text beside each, `manifest.json` for
+the evaluation harness, and `summary.md`. The summary scores the raw text
+against your corrections with no new decode.
+
+To score a configuration against the folder, from the repository root:
+
+```bash
+python3 eval/compare_language.py --manifest FOLDER/manifest.json \
+    --bin app/.build/release/transcribe --models models --arms tl
+```
+
+**The folder holds real meetings.** Do not attach it to a public issue.
 
 ## Find it again
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -5,10 +5,26 @@ What each part of the app does. For the build, read
 [ARCHITECTURE.md](ARCHITECTURE.md). For the command-line tool, read
 [CLI.md](CLI.md).
 
+## Simple and Advanced
+
+The app has two modes. **Simple** is the default. It shows the recordings, a
+button to record, a button to transcribe a file, the transcript and the notes.
+The app selects the model and the audio settings. **Advanced** adds the model
+tiers, the audio controls, the benchmark, the decode statistics and the
+transcript revisions.
+
+To change the mode, click the mode name at the bottom of the sidebar, or
+select **View › Advanced Mode** (⌥⌘A), or go to **Settings › General › Mode**.
+The two modes use the same library and the same pipeline.
+
+This document describes the Advanced mode. A setting that this document names
+is not on the screen in Simple mode.
+
 ## Record or import
 
-**Record.** The app records from the microphone and writes two files from one
-audio tap. The first file is a 64 kbps AAC archive at the hardware sample rate.
+**Record.** Click **Record** in the toolbar, or press ⌘R. The app asks for the
+microphone permission at the first recording, and not before. The app records
+from the microphone and writes two files from one audio tap. The first file is a 64 kbps AAC archive at the hardware sample rate.
 The second file is a 16 kHz mono working copy for the models. Both files come
 from the same tap, thus their samples stay aligned.
 
@@ -41,17 +57,27 @@ device disconnects during a recording, the recording continues on the default
 input of macOS and shows a message. The recording keeps the message as a
 warning.
 
-**Import.** Drop an MP3, WAV, M4A, MP4 or MOV file on the window, or on the
-Dock icon. The app copies the file into the library and adds it to the queue.
+**Transcribe a file.** Drop an MP3, WAV, M4A, AIFF, MP4 or MOV file on the
+window or on the Dock icon. You can also click **Transcribe a File** (⌘O), or
+select **Open With › Notero** in the Finder. The window shows a frame while a
+file is over it. The app copies the file into the library and adds it to the
+queue. If a file with the same size is already in the library, the app asks
+before it imports a second copy.
 
 ## Transcribe
 
-**Live transcription** runs while you record. It decodes a 15-second context
-every 1.5 seconds and applies LocalAgreement-2. **Committed text never changes
-later.** Each decode also reads 1.5 seconds of committed audio in front of the
-active region, thus the model does not start cold at a commit boundary. When
-the voice detector hears 700 ms of silence, the app decodes the audio up to
-that pause and closes the utterance.
+**Live text is off by default.** The app records only, and it makes the
+transcript when you stop. Nothing runs on the Mac during the meeting, and the
+app loads no model at the start. To see text during a recording, turn on
+**Settings › General › Show text while you record**.
+
+**Live text**, when it is on, decodes a 15-second context every 1.5 seconds and
+applies LocalAgreement-2. **Committed text never changes later.** Each decode
+also reads 1.5 seconds of committed audio in front of the active region, thus
+the model does not start cold at a commit boundary. When the voice detector
+hears 700 ms of silence, the app decodes the audio up to that pause and closes
+the utterance. The app drops a word that the model places inside such a pause,
+because the model read it out of silence.
 
 **Whole-file transcription** runs after a recording, and on each import. It
 finds the speech, packs it into windows that end in silence, and decodes each
@@ -134,9 +160,11 @@ You can also export selected speakers only, or one time range only.
 
 | Keys | Function |
 | --- | --- |
-| ⌘R, ⇧⌘M, ⌘N | New recording, meeting or note |
+| ⌘R | Record. In Advanced mode, ⇧⌘M makes a meeting and ⌘N makes a note |
 | ⌘. | Stop the recording |
-| ⌘O, ⌘E | Import, export |
+| ⌘O | Transcribe a file |
+| ⌘E | Export |
+| ⌥⌘A | Advanced mode on or off |
 | ⌘F | Find in this transcript |
 | ⇧⌘F | Search all recordings |
 | ⌘B | Bookmark this moment |

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -34,6 +34,14 @@ the transcript continues with no gap. **Mute** is different: the clock
 continues, and the file gets silence for the length of the mute. A time of day
 in the transcript does not count the paused time.
 
+**The menu bar.** Notero puts an item in the menu bar. Click it to record,
+pause, resume or stop from any application, and to add a bookmark. During a
+recording, macOS draws its orange microphone indicator on the item. Open the
+menu to see the clock and the paused state. Two shortcuts work in every application
+while the item is on: ⌃⌥R starts or stops a recording, and ⌃⌥P pauses or
+resumes it. To hide the item, turn off **Settings › General › Show Notero in
+the menu bar**. This also removes the two shortcuts.
+
 **Select the input.** Go to **Settings › Audio › Record**. There are three
 inputs:
 
@@ -169,6 +177,8 @@ You can also export selected speakers only, or one time range only.
 | ⌘R | Record. In Advanced mode, ⇧⌘M makes a meeting and ⌘N makes a note |
 | ⇧⌘P | Pause or resume the recording |
 | ⌘. | Stop the recording |
+| ⌃⌥R | Start or stop a recording, from any application |
+| ⌃⌥P | Pause or resume the recording, from any application |
 | ⌘O | Transcribe a file |
 | ⌘E | Export |
 | ⌥⌘A | Advanced mode on or off |

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -28,6 +28,12 @@ from the microphone and writes two files from one audio tap. The first file is a
 The second file is a 16 kHz mono working copy for the models. Both files come
 from the same tap, thus their samples stay aligned.
 
+**Pause.** Click **Pause** (⇧⌘P) to stop the clock and the file during a
+break. Click **Resume** to continue. The break is not in the recording, and
+the transcript continues with no gap. **Mute** is different: the clock
+continues, and the file gets silence for the length of the mute. A time of day
+in the transcript does not count the paused time.
+
 **Select the input.** Go to **Settings › Audio › Record**. There are three
 inputs:
 
@@ -161,6 +167,7 @@ You can also export selected speakers only, or one time range only.
 | Keys | Function |
 | --- | --- |
 | ⌘R | Record. In Advanced mode, ⇧⌘M makes a meeting and ⌘N makes a note |
+| ⇧⌘P | Pause or resume the recording |
 | ⌘. | Stop the recording |
 | ⌘O | Transcribe a file |
 | ⌘E | Export |


### PR DESCRIPTION
## What this changes

### Simple and Advanced modes
- **Simple** is the default: a Record button, a Transcribe a File button, the transcript and the notes. **Advanced** shows every control (tiers, gain, room mode, decode statistics, revisions, benchmark, Models and Storage panes). The switch is in the sidebar footer, View › Advanced Mode (⌥⌘A) and Settings › General › Mode.
- Live text is off by default. The app records only and transcribes when you stop. It loads no model at launch when live text is off, and Simple mode asks for the microphone at the first recording, not on the first-run card.
- The empty detail column is a drop zone with two buttons and three steps. The whole window shows a frame while a file is dragged over it. A drop on the Dock icon, Finder "Open With" and `open -a Notero file` import the file (the app declared the types since 1.0.0 but had no handler).
- Labels, messages and help texts follow ASD-STE100. Status names are nouns.

### Recording
- **Pause** (⇧⌘P): the clock, the file and the live text stop; Resume continues on the same timeline with no gap. Mute stays the other switch (silence in the file, clock on the wall clock).
- **Menu bar item** with Record, Pause, Resume, Stop and Add a Bookmark from any application. ⌃⌥R and ⌃⌥P are global shortcuts through the Carbon hot-key API, so no accessibility permission. Settings › General turns the item and the shortcuts off together.

### Transcripts
- **Fast loads.** `TranscriptReader` reads a transcript in one indexed query on a background context. The old code faulted every row on the main thread and did it again on every redraw. On disk, 4000 rows: 266–278 ms → 48–50 ms. In the app, a 3909-row, 3 h 51 min meeting is on screen in 0.3–0.7 s off the main thread. The editor no longer walks every row per keystroke; the notes column no longer forces a second load on appear.
- **Transcribe This Turn Again.** Right-click a turn; the app decodes only that turn (Accurate in Simple mode, chosen tier in Advanced) and replaces its rows in place with the speaker kept. The range's own edges bound the decode and a word stays by its midpoint, otherwise the model's first word, stamped at the window start, was dropped. Verified end to end on a 25 s clip.
- **Export Corrections as References…** (Advanced) writes a folder with a copy of each recording that has edited rows, the edited transcript as the reference, the raw text, the corrected rows beside the raw ones, a `manifest.json` that `eval/compare_language.py --manifest` reads, and a `summary.md` that scores the raw text against the corrections with no decode. Verified: the harness scored an exported folder.
- The words of a turn are no longer selectable text: selection swallowed double-click (edit) and right-click (turn menu).

### Live text
- A word the model places inside a pause the VAD confirmed is dropped from every hypothesis, not only the final decode. Paused synthetic clip: **51.6% → 39.1% WER**, 13 fewer words committed without agreement (finding 12).
- Measured and not shipped: a Taglish style primer in the prompt made the live path repeat the primer (27% → 96% WER); `suppressBlank` was noise. `transcribe --prompt` and `--style-hint` repeat the measurement.

## Verification
- `swift build` at zero warnings on a forced recompile; `swift test`: 273 XCTest + 28 swift-testing (was 250 + 28).
- Driven in the real app against a throwaway library: Simple/Advanced screens, Dock/Finder open, whole-file transcription, record → pause → resume → stop, menu bar item and global shortcuts from Finder, one-turn Accurate redo, reference export scored by the harness.
- Docs updated in STE: README, CHANGELOG, USAGE, ARCHITECTURE, BENCHMARKS, CLI, DEVELOPMENT, CONTRIBUTING; finding 12 added to FINDINGS.

## Notes for the reviewer
- macOS draws its orange microphone indicator over the menu bar item during a recording, so the clock beside the icon is hidden there; it is in the menu.
- A time of day in a transcript does not count paused time.
- Two-lane recordings decode a turn from the mixed working copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
