### PR TITLE
Refactor: SwiftUI hot paths and a testable TranscriberFlow layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,24 @@
   path repeat the primer (27% to 96% WER), and `suppressBlank` was noise.
   `transcribe --style-hint` and `--prompt` repeat the measurement.
 
+### Under the hood
+
+- A new layer, `TranscriberFlow`, holds the decisions of the app with no
+  window: the job coordinator, the display status of a recording and the stop
+  plan. Each has tests. Before, these were private methods and internal
+  dictionaries on the app state, and no test reached them. The live session's
+  failure warning is now saved; before, it was in memory only unless a device
+  notice followed it.
+- The speaker roster sync and the search index exist one time each, for both
+  the main actor and the writer actor. They were byte-identical copies.
+- The live session takes its six settings as one value. Four call sites copied
+  them one by one, and the launch path copied four of the six.
+- The recording screen and the player bar are split by rate of change, thus a
+  meter tick or a playhead tick re-runs one small view and not the screen. The
+  transcript rows read one playing-turn value in place of the raw playhead.
+- The interface mode is an environment value with one `advancedOnly()`
+  modifier, in place of a read of the settings at each control.
+
 ### The audio input
 
 - When the room listens through speakers, the microphone also hears the persons

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,18 +39,18 @@ cd .. && python3 -m venv .venv
 ```
 
 Neither test suite needs model weights, a microphone or a network. This is
-deliberate, and you must keep this property. Refer to "The four layers".
+deliberate, and you must keep this property. Refer to "The five layers".
 
 ## Before you open a pull request
 
 Run each command that applies to your change:
 
 ```bash
-cd app && swift build && swift test    # 301 tests, and 0 warnings
+cd app && swift build && swift test    # 327 tests, and 0 warnings
 ./.venv/bin/python -m pytest           # 75 tests
 ```
 
-The 301 tests are 273 XCTest tests and 28 swift-testing tests. Keep
+The 327 tests are 299 XCTest tests and 28 swift-testing tests. Keep
 `swift build` at **zero warnings**. There is no linter and no formatter for
 either language. Write code in the style of the code around it.
 `.editorconfig` gives the indentation.
@@ -59,9 +59,9 @@ CI (`.github/workflows/app.yml`) builds the app, runs `swift test`, and
 assembles the release bundle. It does this on each push and each pull request
 that touches `app/`. CI needs no secrets, thus it also runs on a fork.
 
-## The four layers
+## The five layers
 
-`app/Sources/` has four layers. Each layer must build and be testable without
+`app/Sources/` has five layers. Each layer must build and be testable without
 the layer above it:
 
 | Layer | Can depend on | Must not touch |
@@ -69,7 +69,12 @@ the layer above it:
 | `TranscriberCore` | nothing | AVFoundation, CoreML, SwiftUI, SwiftData, models |
 | `TranscriberStore` | Core | inference of any kind |
 | `TranscriberEngine` | Core | SwiftUI |
-| `Transcriber` | Core, Store, Engine | — |
+| `TranscriberFlow` | Core, Store, Engine | SwiftUI, AppKit |
+| `Transcriber` | Core, Store, Engine, Flow | — |
+
+Put a decision of the app in `TranscriberFlow` with a test, and not in a view
+or in `AppState`. `JobCoordinator`, `RecordingDisplayStatus` and `StopPlan` are
+the pattern.
 
 This split lets you test the commit policy, the segment merger, the exporters
 and the search index on a Mac that has no microphone and no model weights.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ development workflow.
 ```
 SwiftUI              the window, the library and the transcript view
   ↓
+TranscriberFlow      the decisions of the app: jobs, status, the stop of a recording
+  ↓
 TranscriberStore     the SwiftData schema and the queries
   ↓
 TranscriberCore      the commit policy, the merger, the exports and the search
@@ -94,7 +96,7 @@ TranscriberEngine    the audio, the models and the job queue
   └── FluidAudio     voice activity detection and speaker identification
 ```
 
-There are four layers. Each layer builds and tests without the layer above it.
+There are five layers. Each layer builds and tests without the layer above it.
 Three protocols hide the engines, thus you can replace a backend without a
 change to the user interface.
 
@@ -140,7 +142,7 @@ encryption of its own, thus FileVault is the only protection.
 | Document | Contents |
 | --- | --- |
 | [docs/USAGE.md](docs/USAGE.md) | What each part of the app does, and the keyboard |
-| [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) | The four layers, the pipelines and the algorithms |
+| [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) | The five layers, the pipelines and the algorithms |
 | [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) | Build, tests, CI, scripts and the workflow |
 | [docs/MODELS.md](docs/MODELS.md) | The three tiers, the model IDs and the naming trap |
 | [docs/CLI.md](docs/CLI.md) | The `transcribe` command-line tool |

--- a/app/Package.swift
+++ b/app/Package.swift
@@ -6,6 +6,8 @@ import PackageDescription
 //   TranscriberCore    pure logic. No AV, no CoreML, no UI, no models.
 //   TranscriberStore   SwiftData schema + queries. No inference.
 //   TranscriberEngine  audio I/O and the ASR/VAD/diarization backends.
+//   TranscriberFlow    the app's decisions with no window: the job coordinator,
+//                      the display status of a recording, the stop plan.
 //   Transcriber        the SwiftUI app.
 //
 // The split is what keeps the commit policy, the merger and the exporters
@@ -44,9 +46,19 @@ let package = Package(
             ],
             swiftSettings: [.swiftLanguageMode(.v6)]
         ),
+        .target(
+            name: "TranscriberFlow",
+            dependencies: ["TranscriberCore", "TranscriberStore", "TranscriberEngine"],
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                // The same isolation as the app: what lives here drives the
+                // views and is observed by them.
+                .defaultIsolation(MainActor.self),
+            ]
+        ),
         .executableTarget(
             name: "Transcriber",
-            dependencies: ["TranscriberCore", "TranscriberStore", "TranscriberEngine"],
+            dependencies: ["TranscriberCore", "TranscriberStore", "TranscriberEngine", "TranscriberFlow"],
             swiftSettings: [
                 .swiftLanguageMode(.v6),
                 // SwiftUI views, @Observable app state and SwiftData contexts are
@@ -72,6 +84,11 @@ let package = Package(
         .testTarget(
             name: "TranscriberStoreTests",
             dependencies: ["TranscriberStore", "TranscriberCore"],
+            swiftSettings: [.swiftLanguageMode(.v6)]
+        ),
+        .testTarget(
+            name: "TranscriberFlowTests",
+            dependencies: ["TranscriberFlow", "TranscriberCore", "TranscriberStore", "TranscriberEngine"],
             swiftSettings: [.swiftLanguageMode(.v6)]
         ),
     ]

--- a/app/Sources/Transcriber/AppCommands.swift
+++ b/app/Sources/Transcriber/AppCommands.swift
@@ -25,7 +25,7 @@ struct AppCommands: Commands {
             // ⌘R records in both modes. Simple mode makes a meeting, which
             // opens with the notes beside the transcript.
             Button(state.settings.isAdvanced ? "New Recording" : "Record") {
-                state.newItem(state.settings.isAdvanced ? .recording : .meeting)
+                state.newItem(state.newRecordingKind)
             }
             .keyboardShortcut("r")
             if state.settings.isAdvanced {

--- a/app/Sources/Transcriber/AppState+Library.swift
+++ b/app/Sources/Transcriber/AppState+Library.swift
@@ -3,6 +3,7 @@ import SwiftData
 import SwiftUI
 import TranscriberCore
 import TranscriberEngine
+import TranscriberFlow
 import TranscriberStore
 import UniformTypeIdentifiers
 
@@ -100,7 +101,8 @@ extension AppState {
                               modelId: String? = nil,
                               diarizationMode: DiarizationMode? = nil) {
         guard let name = recording.audioFileName else { return }
-        warnings[recording.id] = nil
+        // The row's stored warning goes at once; the coordinator clears its own
+        // copy when it takes the job.
         recording.warningMessage = nil
         let job = TranscriptionJob(
             id: recording.id,
@@ -117,9 +119,7 @@ extension AppState {
             expectedSpeakers: recording.expectedSpeakers,
             lanes: recording.lanes
         )
-        progress[recording.id] = JobProgress(status: .pending, fraction: 0)
-        queuedJobs[recording.id] = job
-        Task { await queue.enqueue(job) }
+        jobs.enqueue(job)
     }
 
     /// Decode again, optionally on a named tier. Nil means the tier Settings
@@ -136,7 +136,7 @@ extension AppState {
     /// with the turn's speaker on them.
     func retranscribe(_ recording: StoredRecording, turn block: TranscriptBlock,
                       tier: ModelTier = .accurate) {
-        guard let name = recording.audioFileName, progress[recording.id] == nil else { return }
+        guard let name = recording.audioFileName, !jobs.isBusy(recording.id) else { return }
         let job = TranscriptionJob(
             id: recording.id,
             title: recording.title,
@@ -152,9 +152,7 @@ extension AppState {
             roomMode: settings.roomMode,
             lanes: recording.lanes
         )
-        progress[recording.id] = JobProgress(status: .pending, fraction: 0)
-        queuedJobs[recording.id] = job
-        Task { await queue.enqueue(job) }
+        jobs.enqueue(job)
     }
 
     /// Speaker identification only, over the transcript that exists. Forced on
@@ -166,7 +164,7 @@ extension AppState {
     }
 
     func cancelJob(_ id: UUID) {
-        Task { await queue.cancel(id) }
+        jobs.cancel(id)
     }
 
     // MARK: - Deleting

--- a/app/Sources/Transcriber/AppState+Models.swift
+++ b/app/Sources/Transcriber/AppState+Models.swift
@@ -78,6 +78,7 @@ extension AppState {
                                           modelsDirectory: Paths.models) else { return }
         warmup = Task { [weak self] in
             guard let self else { return }
+            live.configure(settings.liveConfiguration)
             await live.prepare(model: settings.liveModelId)
         }
     }

--- a/app/Sources/Transcriber/AppState+Recording.swift
+++ b/app/Sources/Transcriber/AppState+Recording.swift
@@ -3,6 +3,7 @@ import SwiftData
 import SwiftUI
 import TranscriberCore
 import TranscriberEngine
+import TranscriberFlow
 import TranscriberStore
 
 /// The live session from the tap on New Recording to the row it leaves behind,
@@ -96,6 +97,8 @@ extension AppState {
         }
     }
 
+    /// Stops the session and carries out the plan for what it left behind.
+    /// The decisions are `StopPlan.make`; this method is the awaits.
     func stopRecording() async {
         let finished = await live.stop()
         live.onCommitted = nil
@@ -104,36 +107,35 @@ extension AppState {
         activeRecordingId = nil
         guard let result = finished else { return }
         await engines.endLive()
-        let decodedLive = live.decodeLive
+        let id = result.recordingId
+
+        let plan = StopPlan.make(
+            result: result, decodedLive: live.decodeLive, hadPersister: persister != nil,
+            diarizationMode: settings.diarizationMode, keepWorkingCopy: settings.keepWorkingCopy,
+            shortTakeMs: Self.shortTakeMs
+        )
 
         // A thrown decode is counted, not shown, during the session -- here is
-        // where it has to surface. Without this, a backend that failed on
-        // every hop produces a completed recording with an empty transcript.
-        if decodedLive, result.stats.failedHops > 0 {
-            let detail = result.stats.lastError.map { " Last error: \($0)" } ?? ""
-            await jobs.addWarning(result.stats.hops == 0
-                ? "Live transcription failed for this entire recording "
-                  + "(\(result.stats.failedHops) decode errors).\(detail) "
-                  + "The audio was saved. Use Transcribe Again to recover it."
-                : "\(result.stats.failedHops) decode(s) failed during this "
-                  + "recording, so some words may be missing.\(detail)",
-                for: result.recordingId)
+        // where it surfaces. Without it, a backend that failed on every hop
+        // produces a completed recording with an empty transcript.
+        if let warning = plan.liveFailureWarning {
+            await jobs.addWarning(warning, for: id)
         }
 
-        if decodedLive {
+        switch plan.transcript {
+        case .completePersister:
             // The final list replaces the rows written during the recording,
-            // through the same call the whole-file job uses; with no open
-            // revision it stores a fresh one, as before.
-            if let persister {
-                _ = try? await persister.complete(segments: result.segments,
-                                                  processMs: result.stats.totalInferMs)
-            } else {
-                _ = try? await writer.storeTranscript(
-                    segments: result.segments, roster: [], modelId: result.modelId,
-                    language: result.language, processMs: result.stats.totalInferMs,
-                    didDiarize: false, for: result.recordingId
-                )
-            }
+            // through the same call the whole-file job uses.
+            _ = try? await persister?.complete(segments: result.segments,
+                                               processMs: result.stats.totalInferMs)
+        case .storeFresh:
+            _ = try? await writer.storeTranscript(
+                segments: result.segments, roster: [], modelId: result.modelId,
+                language: result.language, processMs: result.stats.totalInferMs,
+                didDiarize: false, for: id
+            )
+        case .none:
+            break
         }
         try? await writer.attachAudio(
             fileName: result.archiveFileName ?? "",
@@ -141,64 +143,45 @@ extension AppState {
             durationMs: result.durationMs,
             waveform: result.waveform.isEmpty ? nil : result.waveform,
             lanes: result.lanes,
-            for: result.recordingId
+            for: id
         )
 
-        // A two-lane recording always gets the whole-file pass, even when the
-        // live decoder already produced a transcript. Live decoding runs on
-        // the two lanes summed -- one stream, because that is what a live
-        // transcript can afford -- so what it produced has no idea which side
-        // of the meeting each line came from. Only the whole-file pass reads
-        // the channels apart, and it is the better transcript in any case.
-        if !decodedLive || result.lanes.count > 1 {
-            // Capture-only session: the whole-file pass is the transcript.
-            // The working copy it needs is the one the session just wrote.
-            if let stored = recording(result.recordingId) {
+        switch plan.followUp {
+        case .fullTranscription:
+            // The working copy the pass needs is the one the session wrote.
+            if let stored = recording(id) {
                 enqueueTranscription(stored, work: .full)
             }
-        } else if settings.diarizationMode.performsDiarization {
-            let job = TranscriptionJob(
-                id: result.recordingId,
-                title: recording(result.recordingId)?.title ?? "Recording",
+        case .diarizeOnly(let mode):
+            jobs.enqueue(TranscriptionJob(
+                id: id,
+                title: recording(id)?.title ?? "Recording",
                 sourceURL: result.archiveFileName.map { Paths.recordingURL($0) },
                 cacheURL: result.cacheURL,
                 modelId: result.modelId,
                 language: result.language,
-                diarizationMode: settings.diarizationMode,
+                diarizationMode: mode,
                 work: .diarizeOnly,
                 discardCacheWhenDone: !settings.keepWorkingCopy,
-                expectedSpeakers: recording(result.recordingId)?.expectedSpeakers
-            )
-            jobs.enqueue(job)
-        } else {
-            try? await writer.updateStatus(.completed, progress: 1, for: result.recordingId)
-            if !settings.keepWorkingCopy {
+                expectedSpeakers: recording(id)?.expectedSpeakers
+            ))
+        case .markCompleted(let discardCache):
+            try? await writer.updateStatus(.completed, progress: 1, for: id)
+            if discardCache {
                 try? FileManager.default.removeItem(at: result.cacheURL)
             }
         }
-        // What changed under the recording: a microphone that was unplugged
-        // and replaced, a default input that moved, an input that could not
-        // be restarted. Kept with the recording, because the person reading
+
+        // What changed under the recording, kept with it: the person who reads
         // the transcript tomorrow has to know why the room goes quiet at 0:41.
-        // After the enqueue above, which clears the row's warning for the job
-        // it starts; the job's own warnings are added to this one, not put in
-        // its place.
-        if !result.notices.isEmpty {
-            await jobs.addWarning(result.notices.map(\.message).joined(separator: " "),
-                                  for: result.recordingId)
+        // After the enqueue, which clears the warning for the job it starts.
+        if let notices = plan.noticesWarning {
+            await jobs.addWarning(notices, for: id)
         }
         await queue.setLiveActive(false)
 
-        if result.durationMs < Self.shortTakeMs {
-            shortTake = ShortTake(
-                id: result.recordingId,
-                durationMs: result.durationMs,
-                words: decodedLive
-                    ? result.segments.reduce(0) {
-                        $0 + $1.displayText.split(whereSeparator: \.isWhitespace).count
-                    }
-                    : nil
-            )
+        if let take = plan.shortTake {
+            shortTake = ShortTake(id: id, durationMs: take.durationMs, words: take.words)
         }
     }
 

--- a/app/Sources/Transcriber/AppState+Recording.swift
+++ b/app/Sources/Transcriber/AppState+Recording.swift
@@ -111,12 +111,13 @@ extension AppState {
         // every hop produces a completed recording with an empty transcript.
         if decodedLive, result.stats.failedHops > 0 {
             let detail = result.stats.lastError.map { " Last error: \($0)" } ?? ""
-            warnings[result.recordingId] = result.stats.hops == 0
+            await jobs.addWarning(result.stats.hops == 0
                 ? "Live transcription failed for this entire recording "
                   + "(\(result.stats.failedHops) decode errors).\(detail) "
-                  + "The audio was saved -- use Transcribe Again to recover it."
+                  + "The audio was saved. Use Transcribe Again to recover it."
                 : "\(result.stats.failedHops) decode(s) failed during this "
-                  + "recording, so some words may be missing.\(detail)"
+                  + "recording, so some words may be missing.\(detail)",
+                for: result.recordingId)
         }
 
         if decodedLive {
@@ -168,8 +169,7 @@ extension AppState {
                 discardCacheWhenDone: !settings.keepWorkingCopy,
                 expectedSpeakers: recording(result.recordingId)?.expectedSpeakers
             )
-            queuedJobs[job.id] = job
-            await queue.enqueue(job)
+            jobs.enqueue(job)
         } else {
             try? await writer.updateStatus(.completed, progress: 1, for: result.recordingId)
             if !settings.keepWorkingCopy {
@@ -184,11 +184,8 @@ extension AppState {
         // it starts; the job's own warnings are added to this one, not put in
         // its place.
         if !result.notices.isEmpty {
-            let changes = result.notices.map(\.message).joined(separator: " ")
-            let combined = [warnings[result.recordingId], changes]
-                .compactMap { $0 }.joined(separator: " ")
-            warnings[result.recordingId] = combined
-            try? await writer.setWarning(combined, for: result.recordingId)
+            await jobs.addWarning(result.notices.map(\.message).joined(separator: " "),
+                                  for: result.recordingId)
         }
         await queue.setLiveActive(false)
 

--- a/app/Sources/Transcriber/AppState+Recording.swift
+++ b/app/Sources/Transcriber/AppState+Recording.swift
@@ -53,12 +53,7 @@ extension AppState {
         recording.status = .preparing
         try? context.save()
 
-        live.config = settings.sessionConfig
-        live.inputGainDb = settings.inputGainDb
-        live.isRoomMode = settings.roomMode
-        live.decodeLive = settings.liveTranscription
-        live.captureSource = settings.captureSource
-        live.microphoneUID = settings.microphoneUID
+        live.configure(settings.liveConfiguration)
 
         // The tap is global -- it has to be, or it stops delivering whenever
         // this app is the only thing playing -- so anything Notero plays goes

--- a/app/Sources/Transcriber/AppState.swift
+++ b/app/Sources/Transcriber/AppState.swift
@@ -253,6 +253,13 @@ final class AppState {
 
     // MARK: - Creating
 
+    /// What Record makes. Simple mode makes a meeting, which opens with the
+    /// notes beside the transcript; Advanced mode makes a plain recording and
+    /// offers the meeting as its own command.
+    var newRecordingKind: RecordingKind {
+        settings.isAdvanced ? .recording : .meeting
+    }
+
     @discardableResult
     func newItem(_ kind: RecordingKind) -> StoredRecording? {
         do {

--- a/app/Sources/Transcriber/AppState.swift
+++ b/app/Sources/Transcriber/AppState.swift
@@ -119,16 +119,32 @@ final class AppState {
     /// split view gives the sidebar and the inspector their widths and lets
     /// the transcript overflow, cropping the window at both edges. Below
     /// `inspectorNeedsWidth` the inspector folds away instead.
-    var contentWidth: CGFloat = .infinity
+    ///
+    /// Written on every resize event. The two flags below are what the views
+    /// read, and they are stored rather than computed so that a reader
+    /// invalidates only when a threshold is crossed, not on every pixel of a
+    /// drag. `@Observable` skips the write when the value is unchanged.
+    var contentWidth: CGFloat = .infinity {
+        didSet {
+            isCompact = contentWidth < Self.sidebarNeedsWidth
+            hasRoomForInspector = contentWidth >= Self.inspectorNeedsWidth
+        }
+    }
     /// Sidebar at its ideal (268), a readable transcript (~450) and the
     /// inspector at its ideal (320), with slack for the dividers.
     static let inspectorNeedsWidth: CGFloat = 1_060
-    var hasRoomForInspector: Bool { contentWidth >= Self.inspectorNeedsWidth }
+    private(set) var hasRoomForInspector = true
     /// Sidebar at its minimum (200) plus a transcript column worth reading.
     /// Below this the sidebar folds and the detail has the window to itself;
     /// the toolbar toggle still brings it back on request.
     static let sidebarNeedsWidth: CGFloat = 800
-    var isCompact: Bool { contentWidth < Self.sidebarNeedsWidth }
+    private(set) var isCompact = false
+
+    /// The transcript turn under the playhead, or nil between turns. Set by
+    /// the transcript view's follower, which is the one view that reads the
+    /// raw playhead. The rows read this instead: it changes when the turn
+    /// changes, not twenty times a second.
+    var playingBlockId: UUID?
 
     /// Per-recording pipeline progress, keyed by recording id.
     var progress: [UUID: JobProgress] = [:]

--- a/app/Sources/Transcriber/AppState.swift
+++ b/app/Sources/Transcriber/AppState.swift
@@ -220,6 +220,22 @@ final class AppState {
     /// Pending questions, asked one at a time.
     var duplicateImports: [DuplicateImport] = []
 
+    // MARK: - Display status
+
+    /// The one ladder for a recording's row, header and empty transcript. The
+    /// warning has one source here: the stored one, else the coordinator's.
+    func displayStatus(for recording: StoredRecording) -> RecordingDisplayStatus {
+        RecordingDisplayStatus.make(
+            status: recording.status,
+            progress: jobs.progress(for: recording.id),
+            isLive: isLive(recording.id),
+            isPaused: isPaused,
+            warning: recording.warningMessage ?? jobs.warning(for: recording.id),
+            hasAudio: recording.hasAudio,
+            errorMessage: recording.errorMessage
+        )
+    }
+
     // MARK: - Lookup
 
     func recording(_ id: UUID) -> StoredRecording? {

--- a/app/Sources/Transcriber/AppState.swift
+++ b/app/Sources/Transcriber/AppState.swift
@@ -4,6 +4,7 @@ import SwiftData
 import SwiftUI
 import TranscriberCore
 import TranscriberEngine
+import TranscriberFlow
 import TranscriberStore
 
 /// Where the detail pane is pointing.
@@ -20,10 +21,12 @@ enum Route: Hashable {
 /// everything else through here.
 ///
 /// The stored state and the small view-facing helpers are here. The larger
-/// concerns each have a file: `AppState+Jobs` consumes the queue's events,
-/// `AppState+Recording` runs the live session, `AppState+Library` imports,
-/// re-runs and deletes, `AppState+Models` manages weights and memory. Members
-/// those files reach are internal rather than private for that reason.
+/// concerns each have a file: `AppState+Recording` runs the live session,
+/// `AppState+Library` imports, re-runs and deletes, `AppState+Models` manages
+/// weights and memory. The queue's events are consumed by `jobs`, a
+/// `JobCoordinator` from TranscriberFlow, which owns the progress, the
+/// warnings and the transcript ticks the views read. Members those files
+/// reach are internal rather than private for that reason.
 @Observable
 final class AppState {
 
@@ -31,6 +34,8 @@ final class AppState {
     let settings: AppSettings
     let engines: EngineHost
     let queue: TranscriptionQueue
+    /// Consumes the queue's events; owns what the views read about jobs.
+    let jobs: JobCoordinator
     let live: LiveSession
     let player = AudioPlayer()
     let writer: TranscriptWriter
@@ -146,15 +151,6 @@ final class AppState {
     /// changes, not twenty times a second.
     var playingBlockId: UUID?
 
-    /// Per-recording pipeline progress, keyed by recording id.
-    var progress: [UUID: JobProgress] = [:]
-    /// Bumped when a job writes rows into a recording's transcript: a batch of
-    /// partial rows, the final rows, the speaker labels. The transcript view
-    /// reads it instead of counting the rows, which is a query it would run
-    /// on every redraw.
-    var transcriptTicks: [UUID: Int] = [:]
-    /// Per-recording notes about work that finished imperfectly.
-    var warnings: [UUID: String] = [:]
     /// The recording the live session is working on, set the moment the user
     /// asks for one rather than when the first sample arrives. `live.recordingId`
     /// only exists once capture starts, which on a cold model is several
@@ -162,35 +158,11 @@ final class AppState {
     /// something for.
     var activeRecordingId: UUID?
 
-    var pump: Task<Void, Never>?
     var warmup: Task<Void, Never>?
 
-    /// Jobs handed to the queue, kept until they finish: `.partial` events
-    /// need the model and language the job was started with.
-    var queuedJobs: [UUID: TranscriptionJob] = [:]
-    /// The revision each running job is appending to, from its first window.
-    var openTranscripts: [UUID: UUID] = [:]
     /// Writes the live session's committed lines as they land, so a crash
     /// mid-meeting keeps everything up to the last commit.
     var livePersister: LiveTranscriptPersister?
-    /// When the current stage of each job began and the last estimate made
-    /// from it. The estimate is smoothed against this.
-    var stageClock: [UUID: StageClock] = [:]
-
-    struct StageClock {
-        var status: TranscriptionStatus
-        var since: Date
-        var remaining: TimeInterval?
-    }
-
-    struct JobProgress: Equatable {
-        var status: TranscriptionStatus
-        var fraction: Double
-        /// Seconds left in this stage, once enough of it has run to say.
-        var remaining: TimeInterval?
-        /// How far into the audio the decode has reached.
-        var coveredMs: Int = 0
-    }
 
     struct AppAlert: Identifiable {
         let id = UUID()
@@ -204,9 +176,12 @@ final class AppState {
         let engines = EngineHost(modelsDirectory: Paths.models,
                                  preferNeuralVAD: settings.neuralVAD)
         self.engines = engines
-        self.queue = TranscriptionQueue(engines: engines)
+        let queue = TranscriptionQueue(engines: engines)
+        let writer = TranscriptWriter(modelContainer: container)
+        self.queue = queue
+        self.writer = writer
+        self.jobs = JobCoordinator(queue: queue, writer: writer)
         self.live = LiveSession(engines: engines, supportDirectory: Paths.support)
-        self.writer = TranscriptWriter(modelContainer: container)
         // The whole configuration, not four of its six fields: the launch
         // warm-up asks the session whether it decodes live, and a session
         // configured by hand once loaded a 1.6 GB model at every launch for
@@ -216,7 +191,7 @@ final class AppState {
         // not survive the last quit, so anything they still claim to be working
         // on is stranded.
         _ = try? RecordingStore.recoverInterrupted(in: container.mainContext)
-        startPump()
+        jobs.start()
     }
 
     /// Persists the gain and pushes it to a session already running, so moving

--- a/app/Sources/Transcriber/AppState.swift
+++ b/app/Sources/Transcriber/AppState.swift
@@ -207,14 +207,11 @@ final class AppState {
         self.queue = TranscriptionQueue(engines: engines)
         self.live = LiveSession(engines: engines, supportDirectory: Paths.support)
         self.writer = TranscriptWriter(modelContainer: container)
-        live.config = settings.sessionConfig
-        live.inputGainDb = settings.inputGainDb
-        live.isRoomMode = settings.roomMode
-        // Read here, not only at the first recording: the launch warm-up asks
-        // the session whether it decodes live, and the session's own default
-        // is yes. With the setting off, a 1.6 GB model loaded at every launch
-        // for a path that was never going to run.
-        live.decodeLive = settings.liveTranscription
+        // The whole configuration, not four of its six fields: the launch
+        // warm-up asks the session whether it decodes live, and a session
+        // configured by hand once loaded a 1.6 GB model at every launch for
+        // a path that was never going to run.
+        live.configure(settings.liveConfiguration)
         // Before any view reads the store: the live session and the queue did
         // not survive the last quit, so anything they still claim to be working
         // on is stranded.

--- a/app/Sources/Transcriber/MenuBar.swift
+++ b/app/Sources/Transcriber/MenuBar.swift
@@ -178,7 +178,7 @@ extension AppState {
         if isRecording {
             Task { await stopRecording() }
         } else if !isLiveBusy {
-            newItem(settings.isAdvanced ? .recording : .meeting)
+            newItem(newRecordingKind)
         }
     }
 

--- a/app/Sources/Transcriber/Settings.swift
+++ b/app/Sources/Transcriber/Settings.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Observation
 import TranscriberCore
+import TranscriberEngine
 
 /// How much of the app is on show.
 ///
@@ -215,6 +216,14 @@ final class AppSettings {
 
     var sessionConfig: SessionConfig {
         SessionConfig(language: language, prompt: promptOrNil, useNeuralVAD: neuralVAD)
+    }
+
+    /// Everything the live session reads from Settings, in one value. The one
+    /// place the six fields meet; the session takes it whole.
+    var liveConfiguration: LiveConfiguration {
+        LiveConfiguration(session: sessionConfig, decodeLive: liveTranscription,
+                          captureSource: captureSource, microphoneUID: microphoneUID,
+                          inputGainDb: inputGainDb, isRoomMode: roomMode)
     }
 
     // MARK: - Benchmark

--- a/app/Sources/Transcriber/TranscriberApp.swift
+++ b/app/Sources/Transcriber/TranscriberApp.swift
@@ -74,6 +74,7 @@ struct TranscriberApp: App {
         WindowGroup("Notero", id: "main") {
             ContentView()
                 .environment(state)
+                .environment(\.interfaceMode, state.settings.interfaceMode)
                 .modelContainer(state.container)
                 // Small enough to sit beside another window. Below ~700 pt the
                 // sidebar folds, below ~1060 the inspector does; every row in
@@ -105,6 +106,7 @@ struct TranscriberApp: App {
         Settings {
             SettingsView()
                 .environment(state)
+                .environment(\.interfaceMode, state.settings.interfaceMode)
                 .modelContainer(state.container)
         }
 

--- a/app/Sources/Transcriber/Views/Components/InterfaceModeEnvironment.swift
+++ b/app/Sources/Transcriber/Views/Components/InterfaceModeEnvironment.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+extension EnvironmentValues {
+    /// Simple or Advanced, for the views. Set once at the root of each scene
+    /// from Settings; the views read it here rather than reaching into
+    /// `AppState.settings`. The default is a stable enum case, so a reader
+    /// that falls back to it does not invalidate on unrelated writes.
+    @Entry var interfaceMode: InterfaceMode = .simple
+}
+
+extension View {
+    /// Shown in Advanced mode only. The one modifier for the controls that
+    /// Simple mode hides, in place of an `if` at each of them.
+    func advancedOnly() -> some View {
+        modifier(AdvancedOnly())
+    }
+}
+
+private struct AdvancedOnly: ViewModifier {
+    @Environment(\.interfaceMode) private var mode
+
+    func body(content: Content) -> some View {
+        if mode == .advanced {
+            content
+        }
+    }
+}

--- a/app/Sources/Transcriber/Views/Components/PlayerBar.swift
+++ b/app/Sources/Transcriber/Views/Components/PlayerBar.swift
@@ -3,41 +3,21 @@ import TranscriberCore
 import TranscriberStore
 
 /// Transport, scrubber and waveform for a finished recording.
+///
+/// Three views inside read the playhead, which moves twenty times a second:
+/// the waveform's playhead line, the clock, and nothing else. They are their
+/// own view types, so a tick re-runs those two bodies and not the bar with
+/// its buttons, menu and bookmark targets. The bar itself depends on the
+/// recording and on the loaded duration, which change on selection.
 struct PlayerBar: View {
     @Environment(AppState.self) private var state
     let recording: StoredRecording
 
     var body: some View {
-        @Bindable var state = state
-
         VStack(spacing: 8) {
-            WaveformView(
-                samples: recording.waveform ?? [],
-                progress: fraction,
-                bookmarks: bookmarkFractions,
-                showsPlayhead: true,
-                onScrub: { value in
-                    state.seek(to: Int(value * Double(max(1, duration))), in: recording)
-                }
-            )
-            .frame(height: 52)
-            .overlay {
-                // A hover target over each bookmark tick, so the label shows
-                // and a click lands exactly on the moment rather than a few
-                // hundred milliseconds off it.
-                GeometryReader { geometry in
-                    ForEach(sortedBookmarks) { bookmark in
-                        let x = geometry.size.width
-                            * CGFloat(Double(bookmark.atMs) / Double(max(1, duration)))
-                        Color.clear
-                            .frame(width: 10, height: geometry.size.height)
-                            .contentShape(Rectangle())
-                            .help("\(bookmark.displayLabel) · \(TimeFormat.short(ms: bookmark.atMs))")
-                            .onTapGesture { state.seek(to: bookmark.atMs, in: recording) }
-                            .position(x: x, y: geometry.size.height / 2)
-                    }
-                }
-            }
+            PlayheadWaveform(recording: recording, durationMs: duration,
+                             bookmarks: sortedBookmarks)
+                .frame(height: 52)
 
             HStack(spacing: 14) {
                 // Skip buttons go first when the column is narrow; play and
@@ -75,6 +55,7 @@ struct PlayerBar: View {
                 } label: {
                     Image(systemName: "gobackward.10")
                 }
+                .help("Back 10 seconds")
             }
             Button {
                 ensureLoaded()
@@ -85,18 +66,17 @@ struct PlayerBar: View {
                     .frame(width: 26)
             }
             .keyboardShortcut(.return, modifiers: [])
+            .help(state.player.isPlaying ? "Pause" : "Play")
             if withSkips {
                 Button {
                     state.player.skip(seconds: 10)
                 } label: {
                     Image(systemName: "goforward.10")
                 }
+                .help("Forward 10 seconds")
             }
 
-            Text("\(TimeFormat.short(ms: state.player.currentMs)) / \(TimeFormat.short(ms: duration))")
-                .font(.system(.caption, design: .monospaced))
-                .foregroundStyle(.secondary)
-                .monospacedDigit()
+            PlaybackClock(durationMs: duration)
         }
         .fixedSize()
     }
@@ -117,7 +97,7 @@ struct PlayerBar: View {
                 Label("Follow", systemImage: "text.line.first.and.arrowtriangle.forward")
             }
             .toggleStyle(.button)
-            .help("Keep the playing line in view. Scrolling by hand turns this off.")
+            .help("Keep the line that plays in view. A scroll by hand turns this off.")
 
             Button {
                 _ = state.addBookmark()
@@ -147,21 +127,80 @@ struct PlayerBar: View {
         max(state.player.durationMs, recording.durationMs)
     }
 
-    private var fraction: Double {
-        duration > 0 ? Double(state.player.currentMs) / Double(duration) : 0
-    }
-
     private var sortedBookmarks: [StoredBookmark] {
         (recording.bookmarks ?? []).sorted { $0.atMs < $1.atMs }
-    }
-
-    private var bookmarkFractions: [Double] {
-        guard duration > 0 else { return [] }
-        return sortedBookmarks.map { Double($0.atMs) / Double(duration) }
     }
 
     private func ensureLoaded() {
         guard let url = recording.audioURL, state.player.loadedURL != url else { return }
         _ = state.player.load(url)
+    }
+}
+
+/// "0:42 / 1:15". The one text that changes with every tick.
+private struct PlaybackClock: View {
+    @Environment(AppState.self) private var state
+    let durationMs: Int
+
+    var body: some View {
+        Text("\(TimeFormat.short(ms: state.player.currentMs)) / \(TimeFormat.short(ms: durationMs))")
+            .font(.system(.caption, design: .monospaced))
+            .foregroundStyle(.secondary)
+            .monospacedDigit()
+    }
+}
+
+/// The waveform with the playhead line over it, and one target on each
+/// bookmark tick. The playhead is why this view reads the player; the
+/// targets are a separate view again so their layout does not re-run with it.
+private struct PlayheadWaveform: View {
+    @Environment(AppState.self) private var state
+    let recording: StoredRecording
+    let durationMs: Int
+    let bookmarks: [StoredBookmark]
+
+    var body: some View {
+        WaveformView(
+            samples: recording.waveform ?? [],
+            progress: durationMs > 0 ? Double(state.player.currentMs) / Double(durationMs) : 0,
+            bookmarks: bookmarks.map { Double($0.atMs) / Double(max(1, durationMs)) },
+            showsPlayhead: true,
+            onScrub: { value in
+                state.seek(to: Int(value * Double(max(1, durationMs))), in: recording)
+            }
+        )
+        .overlay {
+            BookmarkTargets(recording: recording, durationMs: durationMs, bookmarks: bookmarks)
+        }
+    }
+}
+
+/// A hover target over each bookmark tick, so the label shows and a click
+/// lands exactly on the moment rather than a few hundred milliseconds off it.
+/// Buttons, not tap gestures: they carry the label for assistive technology.
+private struct BookmarkTargets: View {
+    @Environment(AppState.self) private var state
+    let recording: StoredRecording
+    let durationMs: Int
+    let bookmarks: [StoredBookmark]
+
+    var body: some View {
+        GeometryReader { geometry in
+            ForEach(bookmarks) { bookmark in
+                let x = geometry.size.width
+                    * CGFloat(Double(bookmark.atMs) / Double(max(1, durationMs)))
+                Button {
+                    state.seek(to: bookmark.atMs, in: recording)
+                } label: {
+                    Color.clear
+                        .frame(width: 10, height: geometry.size.height)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .help("\(bookmark.displayLabel) · \(TimeFormat.short(ms: bookmark.atMs))")
+                .accessibilityLabel(bookmark.displayLabel)
+                .position(x: x, y: geometry.size.height / 2)
+            }
+        }
     }
 }

--- a/app/Sources/Transcriber/Views/Components/PlayerBar.swift
+++ b/app/Sources/Transcriber/Views/Components/PlayerBar.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import TranscriberCore
+import TranscriberEngine
 import TranscriberStore
 
 /// Transport, scrubber and waveform for a finished recording.
@@ -15,7 +16,7 @@ struct PlayerBar: View {
 
     var body: some View {
         VStack(spacing: 8) {
-            PlayheadWaveform(recording: recording, durationMs: duration,
+            PlayheadWaveform(player: state.player, recording: recording, durationMs: duration,
                              bookmarks: sortedBookmarks)
                 .frame(height: 52)
 
@@ -76,7 +77,7 @@ struct PlayerBar: View {
                 .help("Forward 10 seconds")
             }
 
-            PlaybackClock(durationMs: duration)
+            PlaybackClock(player: state.player, durationMs: duration)
         }
         .fixedSize()
     }
@@ -139,11 +140,11 @@ struct PlayerBar: View {
 
 /// "0:42 / 1:15". The one text that changes with every tick.
 private struct PlaybackClock: View {
-    @Environment(AppState.self) private var state
+    let player: AudioPlayer
     let durationMs: Int
 
     var body: some View {
-        Text("\(TimeFormat.short(ms: state.player.currentMs)) / \(TimeFormat.short(ms: durationMs))")
+        Text("\(TimeFormat.short(ms: player.currentMs)) / \(TimeFormat.short(ms: durationMs))")
             .font(.system(.caption, design: .monospaced))
             .foregroundStyle(.secondary)
             .monospacedDigit()
@@ -155,6 +156,7 @@ private struct PlaybackClock: View {
 /// targets are a separate view again so their layout does not re-run with it.
 private struct PlayheadWaveform: View {
     @Environment(AppState.self) private var state
+    let player: AudioPlayer
     let recording: StoredRecording
     let durationMs: Int
     let bookmarks: [StoredBookmark]
@@ -162,7 +164,7 @@ private struct PlayheadWaveform: View {
     var body: some View {
         WaveformView(
             samples: recording.waveform ?? [],
-            progress: durationMs > 0 ? Double(state.player.currentMs) / Double(durationMs) : 0,
+            progress: durationMs > 0 ? Double(player.currentMs) / Double(durationMs) : 0,
             bookmarks: bookmarks.map { Double($0.atMs) / Double(max(1, durationMs)) },
             showsPlayhead: true,
             onScrub: { value in

--- a/app/Sources/Transcriber/Views/Components/RecordingInfoBar.swift
+++ b/app/Sources/Transcriber/Views/Components/RecordingInfoBar.swift
@@ -11,6 +11,7 @@ import TranscriberStore
 /// out is an expensive way to answer it.
 struct RecordingInfoBar: View {
     @Environment(AppState.self) private var state
+    @Environment(\.interfaceMode) private var mode
     let recording: StoredRecording
     /// The revision on show in the transcript. Nil is the latest.
     @Binding var revision: Int?
@@ -39,13 +40,13 @@ struct RecordingInfoBar: View {
          String(recording.updatedAt.timeIntervalSinceReferenceDate),
          recording.statusRaw,
          String(recording.durationMs),
-         state.settings.interfaceMode.rawValue].joined(separator: "|")
+         mode.rawValue].joined(separator: "|")
     }
 
     /// The model, the decode cost and the revisions are for the Advanced
     /// mode. In Simple mode the bar gives the date, the length, the language
     /// and the word count.
-    private var technical: Bool { state.settings.isAdvanced }
+    private var technical: Bool { mode == .advanced }
 
     var body: some View {
         HStack(spacing: 6) {

--- a/app/Sources/Transcriber/Views/Components/RecordingInfoBar.swift
+++ b/app/Sources/Transcriber/Views/Components/RecordingInfoBar.swift
@@ -35,7 +35,7 @@ struct RecordingInfoBar: View {
          shown?.id.uuidString ?? "-",
          // Rows arrive in batches while a job runs; the word count follows
          // them. The tick moves with each batch, and it costs no query.
-         String(state.transcriptTicks[recording.id] ?? 0),
+         String(state.jobs.tick(for: recording.id)),
          String(recording.updatedAt.timeIntervalSinceReferenceDate),
          recording.statusRaw,
          String(recording.durationMs),

--- a/app/Sources/Transcriber/Views/ContentView.swift
+++ b/app/Sources/Transcriber/Views/ContentView.swift
@@ -7,6 +7,7 @@ import UniformTypeIdentifiers
 
 struct ContentView: View {
     @Environment(AppState.self) private var state
+    @Environment(\.interfaceMode) private var mode
     @State private var columnVisibility = NavigationSplitViewVisibility.all
     /// What the user last chose while there was room, restored on widening.
     @State private var wideVisibility = NavigationSplitViewVisibility.all
@@ -210,7 +211,7 @@ struct ContentView: View {
 
     @ToolbarContentBuilder
     private var toolbar: some ToolbarContent {
-        if state.settings.isAdvanced {
+        if mode == .advanced {
             ToolbarItem(placement: .primaryAction) {
                 Menu {
                     Button("Recording", systemImage: RecordingKind.recording.symbol) {

--- a/app/Sources/Transcriber/Views/ContentView.swift
+++ b/app/Sources/Transcriber/Views/ContentView.swift
@@ -7,7 +7,6 @@ import UniformTypeIdentifiers
 
 struct ContentView: View {
     @Environment(AppState.self) private var state
-    @Environment(\.modelContext) private var context
     @State private var columnVisibility = NavigationSplitViewVisibility.all
     /// What the user last chose while there was room, restored on widening.
     @State private var wideVisibility = NavigationSplitViewVisibility.all

--- a/app/Sources/Transcriber/Views/DetailView.swift
+++ b/app/Sources/Transcriber/Views/DetailView.swift
@@ -420,33 +420,27 @@ struct RecordingDetailView: View {
 
     @ViewBuilder
     private var headerControls: some View {
+        let display = state.displayStatus(for: recording)
         HStack(alignment: .firstTextBaseline, spacing: 12) {
-            if let progress = state.jobs.progress(for: recording.id) {
-                StatusChip(status: progress.status, fraction: progress.fraction,
-                           remaining: progress.remaining)
-                Button("Cancel") { state.cancelJob(recording.id) }
-                    .buttonStyle(.borderless)
-                    .font(.caption)
-            } else if recording.status.isBusy {
-                // Live work never reaches the queue, so it has no progress
-                // entry. Without this fallback the preparing and recording
-                // phases show no chip at all.
-                StatusChip(status: recording.status)
-            } else if recording.status == .failed {
-                StatusChip(status: .failed)
-                if recording.hasAudio { rerun("Retry") }
-            } else if recording.status == .cancelled {
-                StatusChip(status: .cancelled)
-                if recording.hasAudio { rerun("Transcribe") }
-            } else if let warning = recording.warningMessage ?? state.jobs.warning(for: recording.id) {
+            if let chip = display.chip {
+                StatusChip(status: chip.status, fraction: chip.fraction, remaining: chip.remaining)
+            }
+            if let warning = display.warning, !display.isBusy {
                 Label(warning, systemImage: "exclamationmark.triangle.fill")
                     .font(.caption)
                     .foregroundStyle(.orange)
                     .lineLimit(2)
                     .help(warning)
-                if recording.hasAudio { rerun("Transcribe Again") }
-            } else if recording.hasAudio {
-                rerun("Transcribe Again")
+            }
+            switch display.action {
+            case .cancel:
+                Button("Cancel") { state.cancelJob(recording.id) }
+                    .buttonStyle(.borderless)
+                    .font(.caption)
+            case .retry: rerun("Retry")
+            case .transcribe: rerun("Transcribe")
+            case .transcribeAgain: rerun("Transcribe Again")
+            case nil: EmptyView()
             }
 
             // Click exports; the arrow offers the clipboard. Copy is the more

--- a/app/Sources/Transcriber/Views/DetailView.swift
+++ b/app/Sources/Transcriber/Views/DetailView.swift
@@ -421,7 +421,7 @@ struct RecordingDetailView: View {
     @ViewBuilder
     private var headerControls: some View {
         HStack(alignment: .firstTextBaseline, spacing: 12) {
-            if let progress = state.progress[recording.id] {
+            if let progress = state.jobs.progress(for: recording.id) {
                 StatusChip(status: progress.status, fraction: progress.fraction,
                            remaining: progress.remaining)
                 Button("Cancel") { state.cancelJob(recording.id) }
@@ -438,7 +438,7 @@ struct RecordingDetailView: View {
             } else if recording.status == .cancelled {
                 StatusChip(status: .cancelled)
                 if recording.hasAudio { rerun("Transcribe") }
-            } else if let warning = recording.warningMessage ?? state.warnings[recording.id] {
+            } else if let warning = recording.warningMessage ?? state.jobs.warning(for: recording.id) {
                 Label(warning, systemImage: "exclamationmark.triangle.fill")
                     .font(.caption)
                     .foregroundStyle(.orange)

--- a/app/Sources/Transcriber/Views/DetailView.swift
+++ b/app/Sources/Transcriber/Views/DetailView.swift
@@ -46,6 +46,7 @@ struct DetailView: View {
 /// that a drop is possible at all.
 struct HomeView: View {
     @Environment(AppState.self) private var state
+    @Environment(\.interfaceMode) private var mode
 
     var body: some View {
         VStack(spacing: 24) {
@@ -72,7 +73,7 @@ struct HomeView: View {
                 .keyboardShortcut(.defaultAction)
 
                 Button {
-                    state.newItem(state.settings.isAdvanced ? .recording : .meeting)
+                    state.newItem(state.newRecordingKind)
                 } label: {
                     Label("Record", systemImage: "record.circle")
                         .frame(minWidth: 130)
@@ -80,7 +81,7 @@ struct HomeView: View {
                 .controlSize(.large)
             }
 
-            if state.settings.isAdvanced {
+            if mode == .advanced {
                 HStack(spacing: 16) {
                     Button("New Meeting") { state.newItem(.meeting) }
                     Button("New Note") { state.newItem(.note) }
@@ -145,6 +146,7 @@ struct HomeView: View {
 /// files is never asked.
 struct WelcomeCard: View {
     @Environment(AppState.self) private var state
+    @Environment(\.interfaceMode) private var mode
 
     /// Called when a button has answered the card. Recording that it was seen
     /// is the card's; taking it off the screen is the caller's.
@@ -168,7 +170,7 @@ struct WelcomeCard: View {
 
             GroupBox {
                 VStack(alignment: .leading, spacing: 14) {
-                    if state.settings.isAdvanced {
+                    if mode == .advanced {
                         MicrophonePermissionRow()
                         Divider()
                     }
@@ -208,7 +210,7 @@ struct WelcomeCard: View {
                     .help("Close this card. Everything on it is also in Settings.")
                 Button("Record") {
                     answered()
-                    state.newItem(state.settings.isAdvanced ? .recording : .meeting)
+                    state.newItem(state.newRecordingKind)
                 }
                 .buttonStyle(.borderedProminent)
                 .keyboardShortcut(.defaultAction)
@@ -277,6 +279,7 @@ struct WelcomeCard: View {
 /// meeting workspace on the right when there is one.
 struct RecordingDetailView: View {
     @Environment(AppState.self) private var state
+    @Environment(\.interfaceMode) private var mode
     @Environment(\.modelContext) private var context
     let recording: StoredRecording
 
@@ -471,7 +474,7 @@ struct RecordingDetailView: View {
     /// one button that uses the tier from Settings.
     @ViewBuilder
     private func rerun(_ label: String) -> some View {
-        if state.settings.isAdvanced {
+        if mode == .advanced {
             RerunButton(recording: recording, label: label)
                 .help("Transcribe again on another tier, or identify the speakers again")
         } else {

--- a/app/Sources/Transcriber/Views/MeetingPanes.swift
+++ b/app/Sources/Transcriber/Views/MeetingPanes.swift
@@ -309,7 +309,7 @@ struct SpeakersPane: View {
                 ContentUnavailableView {
                     Label("No speakers yet", systemImage: "person.2")
                 } description: {
-                    Text(state.progress[recording.id]?.status == .diarizing
+                    Text(state.jobs.progress(for: recording.id)?.status == .diarizing
                          ? "Speaker identification in progress…"
                          : "The app identifies the speakers after the transcription.")
                 }
@@ -360,7 +360,7 @@ struct SpeakersPane: View {
                 }
                 .font(.callout)
                 Spacer()
-                if recording.hasAudio, state.progress[recording.id] == nil {
+                if recording.hasAudio, !state.jobs.isBusy(recording.id) {
                     Button("Identify Again") { state.rediarize(recording) }
                         .controlSize(.small)
                         .help("Run the speaker identification again, with this count as the target")

--- a/app/Sources/Transcriber/Views/RecordingView.swift
+++ b/app/Sources/Transcriber/Views/RecordingView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import TranscriberCore
+import TranscriberEngine
 import TranscriberStore
 
 /// The live screen. Everything on it is transient except the committed text.
@@ -13,8 +14,13 @@ import TranscriberStore
 /// Simple mode shows the clock, the meter, the buttons and the text.
 /// Advanced mode adds the gain slider, room mode, the model and the decode
 /// statistics.
+///
+/// The session is an explicit input of every subview here, not something
+/// reached through the app state. What a subview reads is in its
+/// declaration; the app state is asked for actions only.
 struct RecordingView: View {
     @Environment(AppState.self) private var state
+    @Environment(\.interfaceMode) private var mode
     let recording: StoredRecording
 
     /// The model is still loading. Capture has not started, so there is no
@@ -22,56 +28,69 @@ struct RecordingView: View {
     /// much something to say.
     private var isPreparing: Bool { !state.live.state.isRecording }
 
+    /// "large-v3-turbo · 1.6 GB · English".
+    private var modelSummary: String {
+        let id = state.settings.liveModelId
+        let model = ModelCatalogue.option(id)
+        return [model?.label ?? id, model?.sizeLabel, languageLabel]
+            .compactMap { $0 }
+            .joined(separator: " · ")
+    }
+
+    private var languageLabel: String {
+        let code = state.settings.language
+        return code == "auto" ? "Automatic language" : (LanguageCatalogue.option(code)?.label ?? code)
+    }
+
     var body: some View {
+        let live = state.live
+        let advanced = mode == .advanced
         VStack(spacing: 0) {
             if isPreparing {
-                RecordingPreparingHeader()
+                RecordingPreparingHeader(live: live, modelSummary: advanced ? modelSummary : nil)
             } else {
-                RecordingHeader()
+                RecordingHeader(live: live, advanced: advanced)
             }
             Divider()
-            LiveTranscript(isPreparing: isPreparing)
+            LiveTranscript(live: live, isPreparing: isPreparing)
             Divider()
-            RecordingFooter()
+            RecordingFooter(
+                live: live, languageLabel: languageLabel,
+                liveModel: advanced ? ModelCatalogue.option(state.settings.liveModelId) : nil,
+                offlineModelLabel: advanced
+                    ? (ModelCatalogue.option(state.settings.offlineModelId)?.label ?? state.settings.offlineModelId)
+                    : nil
+            )
         }
     }
 }
 
 /// The model load, which is seconds cold. Reads the session state only.
 private struct RecordingPreparingHeader: View {
-    @Environment(AppState.self) private var state
-
-    private var advanced: Bool { state.settings.isAdvanced }
+    let live: LiveSession
+    /// The model and the language, in Advanced mode; nil hides the line.
+    let modelSummary: String?
 
     /// Specifically the model load, as opposed to `.finishing`, which uses the
     /// same header on the way out and should not be told the model loads once.
     private var isLoadingModel: Bool {
-        if case .preparing = state.live.state { return true }
+        if case .preparing = live.state { return true }
         return false
-    }
-
-    /// "large-v3-turbo · 1.6 GB · English".
-    private var modelSummary: String {
-        let id = state.settings.liveModelId
-        let model = ModelCatalogue.option(id)
-        return [model?.label ?? id, model?.sizeLabel, RecordingLabels.language(state.settings.language)]
-            .compactMap { $0 }
-            .joined(separator: " · ")
     }
 
     var body: some View {
         VStack(spacing: 12) {
             HStack(spacing: 10) {
-                if state.live.state.fraction == nil {
+                if live.state.fraction == nil {
                     ProgressView()
                         .controlSize(.small)
                 }
                 // WhisperKit's own message: "Loading large-v3-turbo…", or the
                 // download and its size when the model is not on disk yet.
-                Text(state.live.state.label)
+                Text(live.state.label)
                     .font(.headline)
             }
-            if let fraction = state.live.state.fraction {
+            if let fraction = live.state.fraction {
                 // A download has a length; a spinner over 1.6 GB reads as a hang.
                 HStack(spacing: 10) {
                     ProgressView(value: fraction)
@@ -84,7 +103,7 @@ private struct RecordingPreparingHeader: View {
                 }
             }
             if isLoadingModel {
-                if advanced {
+                if let modelSummary {
                     // Named here rather than left to WhisperKit's progress
                     // string, which only says "Loading" once the file is found.
                     Text(modelSummary)
@@ -105,16 +124,17 @@ private struct RecordingPreparingHeader: View {
 }
 
 /// The clock, the meter and the transport. The one view here whose body runs
-/// on every audio chunk.
+/// on every audio chunk. The app state is asked for the two live knobs.
 private struct RecordingHeader: View {
     @Environment(AppState.self) private var state
+    let live: LiveSession
+    let advanced: Bool
 
-    private var advanced: Bool { state.settings.isAdvanced }
-    private var isPaused: Bool { state.live.isPaused }
+    private var isPaused: Bool { live.isPaused }
 
     private var title: String {
         if isPaused { return "Paused" }
-        return state.live.isMuted ? "Muted" : "Recording"
+        return live.isMuted ? "Muted" : "Recording"
     }
 
     var body: some View {
@@ -123,25 +143,25 @@ private struct RecordingHeader: View {
                 Circle()
                     .fill(isPaused ? Color.secondary : Color.red)
                     .frame(width: 10, height: 10)
-                    .opacity(state.live.isMuted && !isPaused ? 0.3 : 1)
+                    .opacity(live.isMuted && !isPaused ? 0.3 : 1)
                     .symbolEffect(.pulse, isActive: !isPaused)
                 Text(title)
                     .font(.headline)
                     .contentTransition(.identity)
             }
 
-            Text(TimeFormat.short(ms: state.live.elapsedMs))
+            Text(TimeFormat.short(ms: live.elapsedMs))
                 .font(.system(size: 46, weight: .light, design: .rounded))
                 .monospacedDigit()
                 .contentTransition(.numericText())
 
-            LevelMeter(samples: state.live.meter, level: state.live.level)
+            LevelMeter(samples: live.meter, level: live.level)
                 .frame(height: 64)
                 .padding(.horizontal, 40)
 
             // The microphone changed under this recording. Said here, while
             // there is still time to plug it back in or stop.
-            if let notice = state.live.notices.last {
+            if let notice = live.notices.last {
                 Label(notice.message, systemImage: "exclamationmark.triangle.fill")
                     .font(.caption)
                     .foregroundStyle(.orange)
@@ -153,7 +173,7 @@ private struct RecordingHeader: View {
                 InputGainSlider(gainDb: Binding(
                     get: { state.settings.inputGainDb },
                     set: { state.setInputGain($0) }
-                ), isClipping: InputGain.isClipping(state.live.level))
+                ), isClipping: InputGain.isClipping(live.level))
                 .padding(.horizontal, 40)
 
                 Toggle(isOn: Binding(
@@ -170,8 +190,8 @@ private struct RecordingHeader: View {
 
             // Words on the buttons while there is room, icons in a narrow window.
             ViewThatFits(in: .horizontal) {
-                RecordingTransport().fixedSize()
-                RecordingTransport().labelStyle(.iconOnly).fixedSize()
+                RecordingTransport(live: live).fixedSize()
+                RecordingTransport(live: live).labelStyle(.iconOnly).fixedSize()
             }
         }
         .padding(.vertical, 24)
@@ -184,18 +204,19 @@ private struct RecordingHeader: View {
 /// clock does not rebuild the buttons.
 private struct RecordingTransport: View {
     @Environment(AppState.self) private var state
+    let live: LiveSession
 
-    private var isPaused: Bool { state.live.isPaused }
+    private var isPaused: Bool { live.isPaused }
 
     var body: some View {
         HStack(spacing: 16) {
             Button {
-                state.live.isMuted.toggle()
+                live.isMuted.toggle()
             } label: {
-                Label(state.live.isMuted ? "Unmute" : "Mute",
-                      systemImage: state.live.isMuted ? "mic.slash.fill" : "mic.fill")
+                Label(live.isMuted ? "Unmute" : "Mute",
+                      systemImage: live.isMuted ? "mic.slash.fill" : "mic.fill")
             }
-            .help(state.live.isMuted
+            .help(live.isMuted
                   ? "Unmute the microphone"
                   : "Mute the microphone. The clock continues, and the file gets silence.")
 
@@ -239,27 +260,27 @@ private struct RecordingTransport: View {
 /// The committed lines and the provisional tail. Reads them and the two
 /// flags that decide the empty state; not the clock.
 private struct LiveTranscript: View {
-    @Environment(AppState.self) private var state
+    let live: LiveSession
     let isPreparing: Bool
 
-    private var isPaused: Bool { state.live.isPaused }
+    private var isPaused: Bool { live.isPaused }
 
     var body: some View {
         ScrollViewReader { proxy in
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 10) {
-                    ForEach(state.live.segments) { segment in
+                    ForEach(live.segments) { segment in
                         LiveSegmentRow(startMs: segment.startMs, text: segment.displayText)
                             .id(segment.id)
                     }
 
-                    if !state.live.partial.isEmpty {
+                    if !live.partial.isEmpty {
                         HStack(alignment: .firstTextBaseline, spacing: 10) {
                             Color.clear
                                 .frame(width: 52, height: 1)
                             // Provisional. It may be rewritten by the next pass;
                             // committed text above it never will be.
-                            Text(state.live.partial)
+                            Text(live.partial)
                                 .foregroundStyle(.secondary)
                                 .italic()
                         }
@@ -273,11 +294,11 @@ private struct LiveTranscript: View {
                             .frame(maxWidth: .infinity)
                     }
 
-                    if state.live.segments.isEmpty && state.live.partial.isEmpty && !isPaused {
+                    if live.segments.isEmpty && live.partial.isEmpty && !isPaused {
                         VStack(spacing: 6) {
                             Text(isPreparing ? "The recording has not started."
-                                 : (state.live.decodeLive ? "The app listens. Text comes here." : "Recording"))
-                            if !isPreparing, !state.live.decodeLive {
+                                 : (live.decodeLive ? "The app listens. Text comes here." : "Recording"))
+                            if !isPreparing, !live.decodeLive {
                                 Text("The transcript comes after you stop. To see text during "
                                      + "a recording, turn on “Show text while you record” in Settings.")
                                     .font(.caption)
@@ -293,9 +314,9 @@ private struct LiveTranscript: View {
                 .padding(20)
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
-            .onChange(of: state.live.segments.count) { _, _ in
+            .onChange(of: live.segments.count) { _, _ in
                 withAnimation(.easeOut(duration: 0.2)) {
-                    proxy.scrollTo(state.live.segments.last?.id ?? "partial" as AnyHashable,
+                    proxy.scrollTo(live.segments.last?.id ?? "partial" as AnyHashable,
                                    anchor: .bottom)
                 }
             }
@@ -321,12 +342,14 @@ private struct LiveSegmentRow: View {
     }
 }
 
-/// The model, the language and the decode statistics.
+/// The model, the language and the decode statistics. The model labels are
+/// nil in Simple mode, which is how the footer knows to keep quiet.
 private struct RecordingFooter: View {
-    @Environment(AppState.self) private var state
+    let live: LiveSession
+    let languageLabel: String
+    let liveModel: ModelOption?
+    let offlineModelLabel: String?
     @State private var showStats = false
-
-    private var advanced: Bool { state.settings.isAdvanced }
 
     var body: some View {
         HStack(spacing: 14) {
@@ -335,7 +358,7 @@ private struct RecordingFooter: View {
                 leading.labelStyle(.iconOnly).fixedSize()
             }
             Spacer()
-            Text(RecordingLabels.language(state.settings.language))
+            Text(languageLabel)
                 .lineLimit(1)
         }
         .font(.caption)
@@ -348,34 +371,31 @@ private struct RecordingFooter: View {
     @ViewBuilder
     private var leading: some View {
         HStack(spacing: 14) {
-            if !state.live.decodeLive {
-                if advanced {
-                    Label("The transcript comes after you stop, on "
-                          + "\(ModelCatalogue.option(state.settings.offlineModelId)?.label ?? state.settings.offlineModelId)",
+            if !live.decodeLive {
+                if let offlineModelLabel {
+                    Label("The transcript comes after you stop, on \(offlineModelLabel)",
                           systemImage: "clock")
                 } else {
                     Label("The transcript comes after you stop", systemImage: "clock")
                 }
-            } else if advanced {
+            } else if let liveModel {
                 // Which model is decoding: the first thing anyone wants to know
                 // when the live text reads oddly.
-                Label(ModelCatalogue.option(state.settings.liveModelId)?.label
-                      ?? state.settings.liveModelId,
-                      systemImage: "cpu")
-                    .help(ModelCatalogue.option(state.settings.liveModelId)?.detail ?? "")
+                Label(liveModel.label, systemImage: "cpu")
+                    .help(liveModel.detail)
                 // The engineering numbers live behind a button. They were the
                 // whole footer, and nobody in a meeting needs the RTF -- but
                 // the dropped-window count is a warning and stays in sight.
                 Button {
                     showStats.toggle()
                 } label: {
-                    Label("Statistics", systemImage: state.live.stats.droppedHops > 0
+                    Label("Statistics", systemImage: live.stats.droppedHops > 0
                           ? "exclamationmark.circle" : "info.circle")
                 }
                 .buttonStyle(.borderless)
-                .foregroundStyle(state.live.stats.droppedHops > 0 ? .orange : .secondary)
+                .foregroundStyle(live.stats.droppedHops > 0 ? .orange : .secondary)
                 .popover(isPresented: $showStats, arrowEdge: .top) {
-                    LiveStatsTable(stats: state.live.stats, vadBackend: state.live.vadBackend)
+                    LiveStatsTable(stats: live.stats, vadBackend: live.vadBackend)
                 }
             } else {
                 Label("Live text", systemImage: "text.bubble")
@@ -465,11 +485,3 @@ private struct LiveStatsTable: View {
     }
 }
 
-/// Labels the live screen shares between its views.
-private enum RecordingLabels {
-    static func language(_ code: String) -> String {
-        code == "auto"
-            ? "Automatic language"
-            : (LanguageCatalogue.option(code)?.label ?? code)
-    }
-}

--- a/app/Sources/Transcriber/Views/RecordingView.swift
+++ b/app/Sources/Transcriber/Views/RecordingView.swift
@@ -4,19 +4,44 @@ import TranscriberStore
 
 /// The live screen. Everything on it is transient except the committed text.
 ///
-/// Simple mode shows the clock, the meter, the three buttons and the text.
+/// Three view types, one per rate of change. The header reads the clock,
+/// the level and the meter, which move ten to twelve times a second. The
+/// transcript reads the committed lines and the partial, which move at each
+/// commit. The footer reads the statistics, which move at each decode. As
+/// one body, a meter tick re-ran the transcript list and the footer with it.
+///
+/// Simple mode shows the clock, the meter, the buttons and the text.
 /// Advanced mode adds the gain slider, room mode, the model and the decode
 /// statistics.
 struct RecordingView: View {
     @Environment(AppState.self) private var state
     let recording: StoredRecording
 
-    private var advanced: Bool { state.settings.isAdvanced }
-
     /// The model is still loading. Capture has not started, so there is no
     /// elapsed time, no level and nothing to mute yet -- but there is very
     /// much something to say.
     private var isPreparing: Bool { !state.live.state.isRecording }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if isPreparing {
+                RecordingPreparingHeader()
+            } else {
+                RecordingHeader()
+            }
+            Divider()
+            LiveTranscript(isPreparing: isPreparing)
+            Divider()
+            RecordingFooter()
+        }
+    }
+}
+
+/// The model load, which is seconds cold. Reads the session state only.
+private struct RecordingPreparingHeader: View {
+    @Environment(AppState.self) private var state
+
+    private var advanced: Bool { state.settings.isAdvanced }
 
     /// Specifically the model load, as opposed to `.finishing`, which uses the
     /// same header on the way out and should not be told the model loads once.
@@ -29,29 +54,12 @@ struct RecordingView: View {
     private var modelSummary: String {
         let id = state.settings.liveModelId
         let model = ModelCatalogue.option(id)
-        return [model?.label ?? id, model?.sizeLabel, languageLabel]
+        return [model?.label ?? id, model?.sizeLabel, RecordingLabels.language(state.settings.language)]
             .compactMap { $0 }
             .joined(separator: " · ")
     }
 
-    private var languageLabel: String {
-        state.settings.language == "auto"
-            ? "Automatic language"
-            : (LanguageCatalogue.option(state.settings.language)?.label ?? state.settings.language)
-    }
-
     var body: some View {
-        VStack(spacing: 0) {
-            if isPreparing { preparingHeader } else { recordingHeader }
-
-            Divider()
-            liveTranscript
-            Divider()
-            footer
-        }
-    }
-
-    private var preparingHeader: some View {
         VStack(spacing: 12) {
             HStack(spacing: 10) {
                 if state.live.state.fraction == nil {
@@ -94,15 +102,22 @@ struct RecordingView: View {
         .frame(maxWidth: .infinity)
         .background(.background.secondary)
     }
+}
 
+/// The clock, the meter and the transport. The one view here whose body runs
+/// on every audio chunk.
+private struct RecordingHeader: View {
+    @Environment(AppState.self) private var state
+
+    private var advanced: Bool { state.settings.isAdvanced }
     private var isPaused: Bool { state.live.isPaused }
 
-    private var headerTitle: String {
+    private var title: String {
         if isPaused { return "Paused" }
         return state.live.isMuted ? "Muted" : "Recording"
     }
 
-    private var recordingHeader: some View {
+    var body: some View {
         VStack(spacing: 14) {
             HStack(spacing: 8) {
                 Circle()
@@ -110,7 +125,7 @@ struct RecordingView: View {
                     .frame(width: 10, height: 10)
                     .opacity(state.live.isMuted && !isPaused ? 0.3 : 1)
                     .symbolEffect(.pulse, isActive: !isPaused)
-                Text(headerTitle)
+                Text(title)
                     .font(.headline)
                     .contentTransition(.identity)
             }
@@ -155,16 +170,24 @@ struct RecordingView: View {
 
             // Words on the buttons while there is room, icons in a narrow window.
             ViewThatFits(in: .horizontal) {
-                transportButtons.fixedSize()
-                transportButtons.labelStyle(.iconOnly).fixedSize()
+                RecordingTransport().fixedSize()
+                RecordingTransport().labelStyle(.iconOnly).fixedSize()
             }
         }
         .padding(.vertical, 24)
         .frame(maxWidth: .infinity)
         .background(.background.secondary)
     }
+}
 
-    private var transportButtons: some View {
+/// Mute, Pause, Stop and Bookmark. Reads the two switches only, so the
+/// clock does not rebuild the buttons.
+private struct RecordingTransport: View {
+    @Environment(AppState.self) private var state
+
+    private var isPaused: Bool { state.live.isPaused }
+
+    var body: some View {
         HStack(spacing: 16) {
             Button {
                 state.live.isMuted.toggle()
@@ -211,27 +234,29 @@ struct RecordingView: View {
             .help("Bookmark this moment (⌘B)")
         }
     }
+}
 
-    private var liveTranscript: some View {
+/// The committed lines and the provisional tail. Reads them and the two
+/// flags that decide the empty state; not the clock.
+private struct LiveTranscript: View {
+    @Environment(AppState.self) private var state
+    let isPreparing: Bool
+
+    private var isPaused: Bool { state.live.isPaused }
+
+    var body: some View {
         ScrollViewReader { proxy in
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 10) {
                     ForEach(state.live.segments) { segment in
-                        HStack(alignment: .firstTextBaseline, spacing: 10) {
-                            Text(TimeFormat.short(ms: segment.startMs))
-                                .font(.system(.caption, design: .monospaced))
-                                .foregroundStyle(.tertiary)
-                                .frame(width: 52, alignment: .trailing)
-                            Text(segment.displayText)
-                                .textSelection(.enabled)
-                        }
-                        .id(segment.id)
+                        LiveSegmentRow(startMs: segment.startMs, text: segment.displayText)
+                            .id(segment.id)
                     }
 
                     if !state.live.partial.isEmpty {
                         HStack(alignment: .firstTextBaseline, spacing: 10) {
-                            Text("")
-                                .frame(width: 52)
+                            Color.clear
+                                .frame(width: 52, height: 1)
                             // Provisional. It may be rewritten by the next pass;
                             // committed text above it never will be.
                             Text(state.live.partial)
@@ -276,17 +301,41 @@ struct RecordingView: View {
             }
         }
     }
+}
 
+/// One committed line. Plain data in, so the list skips the rows that did
+/// not change when a new one lands.
+private struct LiveSegmentRow: View {
+    let startMs: Int
+    let text: String
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 10) {
+            Text(TimeFormat.short(ms: startMs))
+                .font(.system(.caption, design: .monospaced))
+                .foregroundStyle(.tertiary)
+                .frame(width: 52, alignment: .trailing)
+            Text(text)
+                .textSelection(.enabled)
+        }
+    }
+}
+
+/// The model, the language and the decode statistics.
+private struct RecordingFooter: View {
+    @Environment(AppState.self) private var state
     @State private var showStats = false
 
-    private var footer: some View {
+    private var advanced: Bool { state.settings.isAdvanced }
+
+    var body: some View {
         HStack(spacing: 14) {
             ViewThatFits(in: .horizontal) {
-                footerLeading.fixedSize()
-                footerLeading.labelStyle(.iconOnly).fixedSize()
+                leading.fixedSize()
+                leading.labelStyle(.iconOnly).fixedSize()
             }
             Spacer()
-            Text(languageLabel)
+            Text(RecordingLabels.language(state.settings.language))
                 .lineLimit(1)
         }
         .font(.caption)
@@ -297,7 +346,7 @@ struct RecordingView: View {
     }
 
     @ViewBuilder
-    private var footerLeading: some View {
+    private var leading: some View {
         HStack(spacing: 14) {
             if !state.live.decodeLive {
                 if advanced {
@@ -325,19 +374,26 @@ struct RecordingView: View {
                 }
                 .buttonStyle(.borderless)
                 .foregroundStyle(state.live.stats.droppedHops > 0 ? .orange : .secondary)
-                .popover(isPresented: $showStats, arrowEdge: .top) { statsPopover }
+                .popover(isPresented: $showStats, arrowEdge: .top) {
+                    LiveStatsTable(stats: state.live.stats, vadBackend: state.live.vadBackend)
+                }
             } else {
                 Label("Live text", systemImage: "text.bubble")
             }
         }
     }
+}
 
-    private var statsPopover: some View {
-        let stats = state.live.stats
-        return Grid(alignment: .leadingFirstTextBaseline, horizontalSpacing: 14, verticalSpacing: 6) {
+/// The decode counters. Plain data in: the popover shows a snapshot.
+private struct LiveStatsTable: View {
+    let stats: SessionStats
+    let vadBackend: String
+
+    var body: some View {
+        Grid(alignment: .leadingFirstTextBaseline, horizontalSpacing: 14, verticalSpacing: 6) {
             GridRow {
                 Text("Voice detection").foregroundStyle(.secondary)
-                Text(state.live.vadBackend == "silero" ? "Silero (neural)" : "Energy")
+                Text(vadBackend == "silero" ? "Silero (neural)" : "Energy")
             }
             GridRow {
                 Text("Decodes").foregroundStyle(.secondary)
@@ -406,5 +462,14 @@ struct RecordingView: View {
         .font(.callout)
         .monospacedDigit()
         .padding(14)
+    }
+}
+
+/// Labels the live screen shares between its views.
+private enum RecordingLabels {
+    static func language(_ code: String) -> String {
+        code == "auto"
+            ? "Automatic language"
+            : (LanguageCatalogue.option(code)?.label ?? code)
     }
 }

--- a/app/Sources/Transcriber/Views/SettingsView.swift
+++ b/app/Sources/Transcriber/Views/SettingsView.swift
@@ -12,6 +12,7 @@ import TranscriberStore
 /// Models and Storage, and more rows in the first two.
 struct SettingsView: View {
     @Environment(AppState.self) private var state
+    @Environment(\.interfaceMode) private var mode
     @State private var pane: Pane? = .general
 
     enum Pane: String, CaseIterable, Identifiable {
@@ -39,7 +40,7 @@ struct SettingsView: View {
     }
 
     private var panes: [Pane] {
-        Pane.allCases.filter { state.settings.isAdvanced || !$0.isAdvanced }
+        Pane.allCases.filter { mode == .advanced || !$0.isAdvanced }
     }
 
     var body: some View {
@@ -61,9 +62,9 @@ struct SettingsView: View {
         }
         .navigationTitle((pane ?? .general).label)
         .frame(minWidth: 700, idealWidth: 760, minHeight: 500, idealHeight: 580)
-        .onChange(of: state.settings.isAdvanced) { _, advanced in
+        .onChange(of: mode) { _, mode in
             // A pane that just left the list must not stay on show.
-            if !advanced, pane?.isAdvanced == true { pane = .general }
+            if mode == .simple, pane?.isAdvanced == true { pane = .general }
         }
     }
 }
@@ -97,10 +98,11 @@ struct InterfaceModeSection: View {
 
 struct GeneralSettings: View {
     @Environment(AppState.self) private var state
+    @Environment(\.interfaceMode) private var mode
 
     var body: some View {
         @Bindable var settings = state.settings
-        let advanced = settings.isAdvanced
+        let advanced = mode == .advanced
 
         Form {
             InterfaceModeSection()
@@ -215,6 +217,7 @@ struct GeneralSettings: View {
 
 struct AudioSettings: View {
     @Environment(AppState.self) private var state
+    @Environment(\.interfaceMode) private var mode
 
     var body: some View {
         @Bindable var settings = state.settings
@@ -245,7 +248,7 @@ struct AudioSettings: View {
                 }
             }
 
-            if settings.isAdvanced {
+            if mode == .advanced {
                 Section("Input") {
                     InputGainSlider(gainDb: $settings.inputGainDb)
                     Text("The microphone in a laptop is 15 to 20 dB quieter than a headset at "

--- a/app/Sources/Transcriber/Views/SidebarView.swift
+++ b/app/Sources/Transcriber/Views/SidebarView.swift
@@ -5,6 +5,7 @@ import TranscriberStore
 
 struct SidebarView: View {
     @Environment(AppState.self) private var state
+    @Environment(\.interfaceMode) private var mode
     @Environment(\.modelContext) private var context
     @Query(sort: \StoredRecording.createdAt, order: .reverse)
     private var recordings: [StoredRecording]
@@ -35,7 +36,7 @@ struct SidebarView: View {
         VStack(spacing: 0) {
             // The filter is an Advanced control. Simple mode shows the whole
             // library, newest first, and nothing to select before the list.
-            if state.settings.isAdvanced {
+            if mode == .advanced {
                 filterBar
             } else {
                 simpleTopBar
@@ -54,8 +55,8 @@ struct SidebarView: View {
             if let route, !selection.contains(route) { selection = [route] }
             if route == nil { selection = [] }
         }
-        .onChange(of: state.settings.isAdvanced) { _, advanced in
-            if !advanced { filter = .all }
+        .onChange(of: mode) { _, mode in
+            if mode == .simple { filter = .all }
         }
         .onDeleteCommand { pendingDelete = selectedRecordings }
         .confirmationDialog(
@@ -212,24 +213,22 @@ struct SidebarView: View {
                 Button {
                     withAnimation(.snappy) { state.settings.isAdvanced.toggle() }
                 } label: {
-                    Label(state.settings.isAdvanced ? "Advanced" : "Simple",
-                          systemImage: "slider.horizontal.3")
+                    Label(mode.label, systemImage: "slider.horizontal.3")
                         .font(.caption)
                 }
-                .help(state.settings.isAdvanced
+                .help(mode == .advanced
                       ? "Advanced mode. Click to change to Simple mode, which has fewer controls."
                       : "Simple mode. Click to change to Advanced mode, which shows all controls.")
 
                 Spacer()
-                if state.settings.isAdvanced {
-                    Button {
-                        state.route = .benchmark
-                    } label: {
-                        Label("Benchmark", systemImage: "speedometer")
-                    }
-                    .help("Measure the model tiers on this Mac (⇧⌘K)")
-                    .labelStyle(.iconOnly)
+                Button {
+                    state.route = .benchmark
+                } label: {
+                    Label("Benchmark", systemImage: "speedometer")
                 }
+                .help("Measure the model tiers on this Mac (⇧⌘K)")
+                .labelStyle(.iconOnly)
+                .advancedOnly()
                 SettingsLink {
                     Label("Settings", systemImage: "gearshape")
                 }
@@ -252,7 +251,7 @@ struct SidebarView: View {
             try? context.save()
         }
         if recording.hasAudio {
-            if state.settings.isAdvanced {
+            if mode == .advanced {
                 RerunItems(recording: recording)
             } else {
                 Button("Transcribe Again", systemImage: "arrow.clockwise") {
@@ -263,7 +262,7 @@ struct SidebarView: View {
                 if let url = recording.audioURL { NSWorkspace.shared.activateFileViewerSelecting([url]) }
             }
         }
-        if recording.kind == .recording, state.settings.isAdvanced {
+        if recording.kind == .recording, mode == .advanced {
             Button("Make This a Meeting", systemImage: RecordingKind.meeting.symbol) {
                 recording.kind = .meeting
                 try? context.save()

--- a/app/Sources/Transcriber/Views/SidebarView.swift
+++ b/app/Sources/Transcriber/Views/SidebarView.swift
@@ -106,7 +106,7 @@ struct SidebarView: View {
         switch filter {
         case .all: return recordings
         case .active:
-            return recordings.filter { state.progress[$0.id] != nil || $0.status.isBusy }
+            return recordings.filter { state.jobs.isBusy($0.id) || $0.status.isBusy }
         case .favorites: return recordings.filter(\.isFavorite)
         case .meetings: return recordings.filter { $0.kind == .meeting }
         }
@@ -349,7 +349,7 @@ struct HistoryRow: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
 
-                if let progress = state.progress[recording.id] {
+                if let progress = state.jobs.progress(for: recording.id) {
                     StatusChip(status: progress.status, fraction: progress.fraction,
                                remaining: progress.remaining)
                 } else if state.isLive(recording.id), state.isPaused {

--- a/app/Sources/Transcriber/Views/SidebarView.swift
+++ b/app/Sources/Transcriber/Views/SidebarView.swift
@@ -297,6 +297,7 @@ struct HistoryRow: View {
     private var isRenaming: Bool { renaming == recording.id }
 
     var body: some View {
+        let display = state.displayStatus(for: recording)
         HStack(alignment: .top, spacing: 10) {
             Image(systemName: recording.kind.symbol)
                 .font(.system(size: 13))
@@ -340,7 +341,7 @@ struct HistoryRow: View {
                     if (recording.items?.isEmpty == false) {
                         Image(systemName: "note.text")
                     }
-                    if let warning = recording.warningMessage {
+                    if let warning = display.warning {
                         Image(systemName: "exclamationmark.triangle.fill")
                             .foregroundStyle(.orange)
                             .help(warning)
@@ -349,21 +350,12 @@ struct HistoryRow: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
 
-                if let progress = state.jobs.progress(for: recording.id) {
-                    StatusChip(status: progress.status, fraction: progress.fraction,
-                               remaining: progress.remaining)
-                } else if state.isLive(recording.id), state.isPaused {
+                if display.isPaused {
                     Label("Paused", systemImage: "pause.circle.fill")
                         .font(.caption2)
                         .foregroundStyle(.secondary)
-                } else if recording.status.isBusy {
-                    // Preparing and recording are live-path states; they never
-                    // get a queue entry, so they need the stored status.
-                    StatusChip(status: recording.status, fraction: 0)
-                } else if recording.status == .failed {
-                    StatusChip(status: .failed, fraction: 0)
-                } else if recording.status == .cancelled {
-                    StatusChip(status: .cancelled, fraction: 0)
+                } else if let chip = display.chip {
+                    StatusChip(status: chip.status, fraction: chip.fraction, remaining: chip.remaining)
                 }
             }
             Spacer(minLength: 0)

--- a/app/Sources/Transcriber/Views/TranscriptView.swift
+++ b/app/Sources/Transcriber/Views/TranscriptView.swift
@@ -372,47 +372,25 @@ struct TranscriptView: View {
     // MARK: - Empty
 
     private var emptyState: some View {
-        ContentUnavailableView {
-            Label(label, systemImage: icon)
+        let display = state.displayStatus(for: recording)
+        return ContentUnavailableView {
+            Label(display.emptyState.title, systemImage: display.emptyState.symbol)
         } description: {
-            Text(detail)
+            Text(display.emptyState.detail)
         } actions: {
-            if recording.hasAudio, !state.jobs.isBusy(recording.id) {
+            switch display.action {
+            case .retry, .transcribe, .transcribeAgain:
                 Button("Transcribe") { state.retranscribe(recording) }
-            } else if !recording.hasAudio, !state.jobs.isBusy(recording.id) {
+            case nil where !recording.hasAudio && !display.isBusy:
                 // Without this the row is a dead end: no audio means nothing to
                 // transcribe, and the only way out was to find it in the
                 // sidebar and work out that it should be deleted.
                 Button("Delete This Recording", role: .destructive) { state.delete(recording) }
                 Button("Transcribe a File…") { state.isImporting = true }
+            default:
+                EmptyView()
             }
         }
-    }
-
-    private var label: String {
-        if state.jobs.isBusy(recording.id) { return "Work in progress" }
-        if recording.status == .cancelled { return "Transcription cancelled" }
-        guard recording.status == .failed else { return "No transcript yet" }
-        // "Transcription failed" is wrong for a recording that never captured
-        // anything -- nothing got as far as being transcribed.
-        return recording.hasAudio ? "Transcription failed" : "The recording stopped early"
-    }
-
-    private var icon: String {
-        if recording.status == .cancelled { return "xmark.circle" }
-        return recording.status == .failed ? "exclamationmark.triangle" : "text.alignleft"
-    }
-
-    private var detail: String {
-        if let progress = state.jobs.progress(for: recording.id) {
-            guard let remaining = progress.remaining else { return progress.status.label }
-            return "\(progress.status.label) · \(TimeFormat.remaining(seconds: remaining)) left"
-        }
-        if let error = recording.errorMessage, recording.status == .failed { return error }
-        return recording.hasAudio
-            ? "The audio is on this Mac. It has no transcript yet."
-            : "The app captured no audio, thus there is nothing to transcribe. "
-              + "A file that you import becomes a new recording. You can delete this one."
     }
 
     // MARK: - Speakers

--- a/app/Sources/Transcriber/Views/TranscriptView.swift
+++ b/app/Sources/Transcriber/Views/TranscriptView.swift
@@ -240,9 +240,11 @@ struct TranscriptView: View {
                 .frame(maxWidth: .infinity)
                 .background {
                     // Lives inside the scroll view so it re-renders per player
-                    // tick on its own, not the whole list with it.
+                    // tick on its own, not the whole list with it. It is the
+                    // one view here that reads the raw playhead; it publishes
+                    // the turn under it for the rows.
                     PlaybackFollower(blocks: blocks) { blockId in
-                        guard state.followPlayback, state.player.isPlaying else { return }
+                        guard let blockId, state.followPlayback, state.player.isPlaying else { return }
                         request(blockId, anchor: .center)
                     }
                 }
@@ -429,18 +431,23 @@ struct TranscriptView: View {
 }
 
 /// Watches the playhead and names the block under it. Its body is the only
-/// thing that re-evaluates per tick.
+/// thing that re-evaluates per tick: a binary search over the blocks, and a
+/// write to `AppState.playingBlockId` that `@Observable` drops when the turn
+/// has not changed. Every visible row used to read the playhead itself and
+/// re-run its body twenty times a second; now only the row that gains or
+/// loses the highlight does.
 private struct PlaybackFollower: View {
     @Environment(AppState.self) private var state
     let blocks: [TranscriptBlock]
-    let onChange: (UUID) -> Void
+    let onChange: (UUID?) -> Void
 
     var body: some View {
         let current = TranscriptGrouping.blockIndex(at: state.player.currentMs, in: blocks)
             .map { blocks[$0].id }
         Color.clear
-            .onChange(of: current) { _, next in
-                if let next { onChange(next) }
+            .onChange(of: current, initial: true) { _, next in
+                state.playingBlockId = next
+                onChange(next)
             }
     }
 }
@@ -581,11 +588,10 @@ struct TranscriptBlockRow: View {
     /// Nil when the transcript cannot be edited right now.
     var onEdit: (() -> Void)?
 
-    /// Read here rather than passed in from the list. Observation then
-    /// invalidates only the rows, and `LazyVStack` only builds the visible
-    /// ones -- so a two-hour transcript costs the same per tick as a short one.
+    /// The coarse value from the follower, not the raw playhead: this row
+    /// invalidates when the highlight arrives or leaves, and at no other tick.
     private var isPlaying: Bool {
-        block.contains(ms: state.player.currentMs)
+        state.playingBlockId == block.id
     }
 
     private var isSelected: Bool {

--- a/app/Sources/Transcriber/Views/TranscriptView.swift
+++ b/app/Sources/Transcriber/Views/TranscriptView.swift
@@ -2,6 +2,7 @@ import OSLog
 import SwiftData
 import SwiftUI
 import TranscriberCore
+import TranscriberFlow
 import TranscriberStore
 
 /// The transcript, grouped into speaker turns, every row a seek target.
@@ -122,7 +123,7 @@ struct TranscriptView: View {
 
     /// No edits while rows are still arriving or an older revision is open.
     private var isReadOnly: Bool {
-        isViewingOlderRevision || state.progress[recording.id] != nil
+        isViewingOlderRevision || state.jobs.isBusy(recording.id)
     }
 
     /// Changes exactly when the rows do: a new revision, an edit, a batch of
@@ -133,7 +134,7 @@ struct TranscriptView: View {
         let transcript = transcript
         return [transcript?.id.uuidString ?? "-",
                 String(recording.updatedAt.timeIntervalSinceReferenceDate),
-                String(state.transcriptTicks[recording.id] ?? 0),
+                String(state.jobs.tick(for: recording.id)),
                 String(editVersion)].joined(separator: "|")
     }
 
@@ -181,7 +182,7 @@ struct TranscriptView: View {
 
     private var list: some View {
         VStack(spacing: 0) {
-            if let progress = state.progress[recording.id] {
+            if let progress = state.jobs.progress(for: recording.id) {
                 // Rows are arriving under this. Without it a growing list with
                 // no status reads as a finished transcript that is oddly short.
                 TranscriptProgressBanner(progress: progress, durationMs: recording.durationMs) {
@@ -376,9 +377,9 @@ struct TranscriptView: View {
         } description: {
             Text(detail)
         } actions: {
-            if recording.hasAudio, state.progress[recording.id] == nil {
+            if recording.hasAudio, !state.jobs.isBusy(recording.id) {
                 Button("Transcribe") { state.retranscribe(recording) }
-            } else if !recording.hasAudio, state.progress[recording.id] == nil {
+            } else if !recording.hasAudio, !state.jobs.isBusy(recording.id) {
                 // Without this the row is a dead end: no audio means nothing to
                 // transcribe, and the only way out was to find it in the
                 // sidebar and work out that it should be deleted.
@@ -389,7 +390,7 @@ struct TranscriptView: View {
     }
 
     private var label: String {
-        if state.progress[recording.id] != nil { return "Work in progress" }
+        if state.jobs.isBusy(recording.id) { return "Work in progress" }
         if recording.status == .cancelled { return "Transcription cancelled" }
         guard recording.status == .failed else { return "No transcript yet" }
         // "Transcription failed" is wrong for a recording that never captured
@@ -403,7 +404,7 @@ struct TranscriptView: View {
     }
 
     private var detail: String {
-        if let progress = state.progress[recording.id] {
+        if let progress = state.jobs.progress(for: recording.id) {
             guard let remaining = progress.remaining else { return progress.status.label }
             return "\(progress.status.label) · \(TimeFormat.remaining(seconds: remaining)) left"
         }
@@ -454,7 +455,7 @@ private struct PlaybackFollower: View {
 
 /// "Transcription · 42% · about 14 min left", over a transcript still arriving.
 struct TranscriptProgressBanner: View {
-    let progress: AppState.JobProgress
+    let progress: JobProgress
     let durationMs: Int
     let onCancel: () -> Void
 

--- a/app/Sources/Transcriber/Views/TranscriptView.swift
+++ b/app/Sources/Transcriber/Views/TranscriptView.swift
@@ -556,6 +556,7 @@ struct TranscriptFindBar: View {
 
 struct TranscriptBlockRow: View {
     @Environment(AppState.self) private var state
+    @Environment(\.interfaceMode) private var mode
     @Environment(\.modelContext) private var context
 
     let recording: StoredRecording
@@ -669,7 +670,7 @@ struct TranscriptBlockRow: View {
                     // The one bad window in a long meeting, without the other
                     // four hours. Advanced offers the tiers; Simple takes the
                     // Accurate one, which is why anyone redoes a turn.
-                    if state.settings.isAdvanced {
+                    if mode == .advanced {
                         Menu("Transcribe This Turn Again", systemImage: "arrow.clockwise") {
                             ForEach(ModelTier.allCases) { tier in
                                 Button("\(tier.label) · \(ModelCatalogue.option(state.settings.modelId(for: tier))?.label ?? "")") {

--- a/app/Sources/TranscriberEngine/LiveSession.swift
+++ b/app/Sources/TranscriberEngine/LiveSession.swift
@@ -20,6 +20,23 @@ public struct LiveSessionResult: Sendable {
     /// What changed under the recording, in order: a replaced microphone, a
     /// moved default input, a capture that could not be restarted.
     public var notices: [CaptureNotice]
+
+    public init(recordingId: UUID, segments: [Segment], durationMs: Int, archiveFileName: String?,
+                archiveSampleRate: Int, cacheURL: URL, waveform: [Float], stats: SessionStats,
+                modelId: String, language: String, lanes: [CaptureLane], notices: [CaptureNotice]) {
+        self.recordingId = recordingId
+        self.segments = segments
+        self.durationMs = durationMs
+        self.archiveFileName = archiveFileName
+        self.archiveSampleRate = archiveSampleRate
+        self.cacheURL = cacheURL
+        self.waveform = waveform
+        self.stats = stats
+        self.modelId = modelId
+        self.language = language
+        self.lanes = lanes
+        self.notices = notices
+    }
 }
 
 /// Everything a live session needs to know before it starts, in one value.

--- a/app/Sources/TranscriberEngine/LiveSession.swift
+++ b/app/Sources/TranscriberEngine/LiveSession.swift
@@ -22,6 +22,39 @@ public struct LiveSessionResult: Sendable {
     public var notices: [CaptureNotice]
 }
 
+/// Everything a live session needs to know before it starts, in one value.
+///
+/// Six settings used to be copied onto `LiveSession` one property at a time
+/// from four call sites, and the launch warm-up copied four of the six. One
+/// value cannot be half-copied: a caller either hands over a configuration or
+/// it does not. The two knobs a person turns during a recording, the gain and
+/// room mode, stay as properties as well, because they change mid-session.
+public struct LiveConfiguration: Sendable, Equatable {
+    /// The decoder's knobs: language, prompt, hop, context.
+    public var session: SessionConfig
+    /// Whether to decode while recording, or only capture.
+    public var decodeLive: Bool
+    /// Which lanes to record.
+    public var captureSource: CaptureSource
+    /// Which microphone, by UID, or nil to follow the system default.
+    public var microphoneUID: String?
+    /// Microphone boost in decibels at the start. Adjustable afterwards.
+    public var inputGainDb: Float
+    /// High-pass for a far-field room at the start. Adjustable afterwards.
+    public var isRoomMode: Bool
+
+    public init(session: SessionConfig = SessionConfig(), decodeLive: Bool = true,
+                captureSource: CaptureSource = .default, microphoneUID: String? = nil,
+                inputGainDb: Float = InputGain.defaultDb, isRoomMode: Bool = false) {
+        self.session = session
+        self.decodeLive = decodeLive
+        self.captureSource = captureSource
+        self.microphoneUID = microphoneUID
+        self.inputGainDb = inputGainDb
+        self.isRoomMode = isRoomMode
+    }
+}
+
 /// The live path: capture -> working copy -> `LiveDecoder` -> commit -> UI.
 ///
 /// The design contract this exists to keep is that committed text never
@@ -97,7 +130,8 @@ public final class LiveSession {
     public private(set) var vadBackend = "energy"
     public private(set) var recordingId: UUID?
 
-    public var config = SessionConfig()
+    /// The decoder's knobs. Set through `configure(_:)`.
+    public private(set) var config = SessionConfig()
     public var isMuted = false { didSet { capture?.isMuted = isMuted } }
 
     /// Paused: the clock, the file and the live text all stop, and resume
@@ -116,19 +150,35 @@ public final class LiveSession {
         }
     }
 
-    /// Which lanes to record. Read at `start`; changing it mid-session does
-    /// nothing, because the archive's channel count is fixed when the file is
-    /// created.
-    public var captureSource: CaptureSource = .default
+    /// Which lanes to record. Read at `start`; the archive's channel count is
+    /// fixed when the file is created. Set through `configure(_:)`.
+    public private(set) var captureSource: CaptureSource = .default
 
-    /// Which microphone, by UID, or nil to follow the system default.
-    public var microphoneUID: String?
+    /// Which microphone, by UID, or nil to follow the system default. Set
+    /// through `configure(_:)`.
+    public private(set) var microphoneUID: String?
 
     /// Whether to decode while recording. Off, the session only captures --
     /// archive and working copy -- and the whole-file pass runs at stop. That
     /// pass is the better transcript anyway, and a two-hour meeting with no
     /// model running keeps the machine cool and the fan quiet at the table.
-    public var decodeLive = true
+    /// Set through `configure(_:)`.
+    public private(set) var decodeLive = true
+
+    /// Takes every setting the next session needs, in one call. Refused while
+    /// a session is under way: the archive and the decoder are already built
+    /// on the previous values, and a change now would describe a recording
+    /// other than the one being made. The gain and room mode are the
+    /// exception and have their own properties.
+    public func configure(_ configuration: LiveConfiguration) {
+        guard !state.isBusy else { return }
+        config = configuration.session
+        decodeLive = configuration.decodeLive
+        captureSource = configuration.captureSource
+        microphoneUID = configuration.microphoneUID
+        inputGainDb = configuration.inputGainDb
+        isRoomMode = configuration.isRoomMode
+    }
 
     /// Called with each batch of newly committed segments, in order, as soon
     /// as they are committed -- during the recording, not at Stop. This is how

--- a/app/Sources/TranscriberEngine/TranscriptionQueue.swift
+++ b/app/Sources/TranscriberEngine/TranscriptionQueue.swift
@@ -109,6 +109,20 @@ public struct TranscriptionPayload: Sendable {
     public var didDiarize: Bool
     public var waveform: [Float]
     public var metrics: TranscriptionMetrics
+
+    public init(segments: [Segment], roster: [SpeakerLabel], durationMs: Int, processMs: Int,
+                modelId: String, language: String, didDiarize: Bool, waveform: [Float],
+                metrics: TranscriptionMetrics) {
+        self.segments = segments
+        self.roster = roster
+        self.durationMs = durationMs
+        self.processMs = processMs
+        self.modelId = modelId
+        self.language = language
+        self.didDiarize = didDiarize
+        self.waveform = waveform
+        self.metrics = metrics
+    }
 }
 
 public enum JobEvent: Sendable {

--- a/app/Sources/TranscriberFlow/JobCoordinator.swift
+++ b/app/Sources/TranscriberFlow/JobCoordinator.swift
@@ -5,7 +5,7 @@ import TranscriberEngine
 import TranscriberStore
 
 /// Per-recording progress of a job in the queue, as the views show it.
-public struct JobProgress: Equatable, Sendable {
+nonisolated public struct JobProgress: Equatable, Sendable {
     public var status: TranscriptionStatus
     public var fraction: Double
     /// Seconds left in this stage, once enough of it has run to say.

--- a/app/Sources/TranscriberFlow/JobCoordinator.swift
+++ b/app/Sources/TranscriberFlow/JobCoordinator.swift
@@ -1,17 +1,90 @@
 import Foundation
-import SwiftData
-import SwiftUI
+import Observation
 import TranscriberCore
 import TranscriberEngine
 import TranscriberStore
 
-/// Consuming the transcription queue: progress, partial and final transcripts,
-/// warnings, and the time-remaining estimate.
-extension AppState {
+/// Per-recording progress of a job in the queue, as the views show it.
+public struct JobProgress: Equatable, Sendable {
+    public var status: TranscriptionStatus
+    public var fraction: Double
+    /// Seconds left in this stage, once enough of it has run to say.
+    public var remaining: TimeInterval?
+    /// How far into the audio the decode has reached.
+    public var coveredMs: Int
 
-    // MARK: - Job events
+    public init(status: TranscriptionStatus, fraction: Double,
+                remaining: TimeInterval? = nil, coveredMs: Int = 0) {
+        self.status = status
+        self.fraction = fraction
+        self.remaining = remaining
+        self.coveredMs = coveredMs
+    }
+}
 
-    func startPump() {
+/// The reduction from queue events to store writes and to the three values
+/// the views read: progress, warnings and the transcript ticks.
+///
+/// This used to be a private method on the app state, with six bookkeeping
+/// dictionaries beside it that the views read directly. No test reached the
+/// method, and the dictionaries were the interface. Here the reduction owns
+/// its state, the interface is three reads and three commands, and a test
+/// feeds events and checks the store.
+@Observable
+public final class JobCoordinator {
+
+    /// Per-recording pipeline progress, while a job runs.
+    public private(set) var progress: [UUID: JobProgress] = [:]
+    /// Per-recording notes about work that finished imperfectly, kept until a
+    /// new job starts on the recording. Persisted on the row as well.
+    public private(set) var warnings: [UUID: String] = [:]
+    /// Bumped when a job writes rows into a recording's transcript: a batch
+    /// of partial rows, the final rows, the speaker labels, a redone turn.
+    /// The transcript view reads it instead of counting the rows.
+    public private(set) var transcriptTicks: [UUID: Int] = [:]
+
+    /// Jobs handed to the queue, kept until they finish: `.partial` events
+    /// need the model and language the job was started with.
+    private var queuedJobs: [UUID: TranscriptionJob] = [:]
+    /// The revision each running job is appending to, from its first window.
+    private var openTranscripts: [UUID: UUID] = [:]
+    /// When the current stage of each job began and the last estimate made
+    /// from it. The estimate is smoothed against this.
+    private var stageClock: [UUID: StageClock] = [:]
+
+    private struct StageClock {
+        var status: TranscriptionStatus
+        var since: Date
+        var remaining: TimeInterval?
+    }
+
+    private let queue: TranscriptionQueue
+    private let writer: TranscriptWriter
+    private let now: @Sendable () -> Date
+    private var pump: Task<Void, Never>?
+
+    /// - Parameter now: the clock for the time-remaining estimate. Tests
+    ///   pass their own.
+    public init(queue: TranscriptionQueue, writer: TranscriptWriter,
+                now: @escaping @Sendable () -> Date = { Date() }) {
+        self.queue = queue
+        self.writer = writer
+        self.now = now
+    }
+
+    // MARK: - Reads
+
+    public func progress(for id: UUID) -> JobProgress? { progress[id] }
+    public func warning(for id: UUID) -> String? { warnings[id] }
+    public func tick(for id: UUID) -> Int { transcriptTicks[id] ?? 0 }
+    /// Whether a job is queued or running on the recording.
+    public func isBusy(_ id: UUID) -> Bool { progress[id] != nil }
+
+    // MARK: - Commands
+
+    /// Starts consuming the queue's events. Once, at launch.
+    public func start() {
+        guard pump == nil else { return }
         pump = Task { [weak self] in
             guard let self else { return }
             for await event in self.queue.events {
@@ -20,7 +93,32 @@ extension AppState {
         }
     }
 
-    private func handle(_ event: JobEvent) async {
+    /// Hands a job to the queue. The row shows "In queue" at once, and the
+    /// warning from the previous job on the recording is cleared: the new
+    /// job's own warnings are what the row will carry.
+    public func enqueue(_ job: TranscriptionJob) {
+        warnings[job.id] = nil
+        progress[job.id] = JobProgress(status: .pending, fraction: 0)
+        queuedJobs[job.id] = job
+        Task { await queue.enqueue(job) }
+    }
+
+    public func cancel(_ id: UUID) {
+        Task { await queue.cancel(id) }
+    }
+
+    /// A warning from outside the queue, such as the live session's. Added
+    /// to what the recording already carries, never put in its place, and
+    /// persisted so it survives a relaunch.
+    public func addWarning(_ message: String, for id: UUID) async {
+        let joined = Self.join(warnings[id], message)
+        warnings[id] = joined
+        try? await writer.setWarning(joined, for: id)
+    }
+
+    // MARK: - The reduction
+
+    func handle(_ event: JobEvent) async {
         switch event {
         case .queued(let id, _):
             progress[id] = JobProgress(status: .pending, fraction: 0)
@@ -101,9 +199,7 @@ extension AppState {
             // relaunch. Added to what the row already says rather than put in
             // its place: a microphone that was replaced during the recording
             // is still true after the transcription that followed it.
-            let combined = [warnings[id], message].compactMap { $0 }
-            let joined = Array(NSOrderedSet(array: combined)).compactMap { $0 as? String }
-                .joined(separator: " ")
+            let joined = Self.join(warnings[id], message)
             warnings[id] = joined
             try? await writer.setWarning(joined, for: id)
 
@@ -115,6 +211,15 @@ extension AppState {
         }
     }
 
+    /// The existing warning plus a new one, with a repeat dropped.
+    private static func join(_ existing: String?, _ message: String) -> String {
+        var parts: [String] = []
+        for part in [existing, message].compactMap({ $0 }) where !parts.contains(part) {
+            parts.append(part)
+        }
+        return parts.joined(separator: " ")
+    }
+
     /// Seconds left in the current stage, from how long the fraction done has
     /// taken so far. Nothing until 5 % is in, since a first window's timing
     /// says little; smoothed after that so one slow window does not swing the
@@ -122,7 +227,7 @@ extension AppState {
     private func estimateRemaining(_ id: UUID, status: TranscriptionStatus,
                                    fraction: Double) -> TimeInterval? {
         guard status.isBusy else { stageClock[id] = nil; return nil }
-        let now = Date()
+        let now = now()
         guard var clock = stageClock[id], clock.status == status else {
             stageClock[id] = StageClock(status: status, since: now, remaining: nil)
             return nil

--- a/app/Sources/TranscriberFlow/RecordingDisplayStatus.swift
+++ b/app/Sources/TranscriberFlow/RecordingDisplayStatus.swift
@@ -1,0 +1,134 @@
+import Foundation
+import TranscriberCore
+
+/// What the sidebar row, the detail header and the empty transcript show
+/// about the state of one recording.
+///
+/// Three views used to rebuild the same ladder, each with its own branches,
+/// and the warning had two sources: one view read the stored one only, one
+/// read stored-or-in-memory. This is the one ladder. The caller resolves the
+/// inputs; every view reads the same answer.
+nonisolated public struct RecordingDisplayStatus: Equatable, Sendable {
+
+    /// The chip in the row and the header. Nil when the recording is complete
+    /// and quiet.
+    public struct Chip: Equatable, Sendable {
+        public var status: TranscriptionStatus
+        public var fraction: Double
+        public var remaining: TimeInterval?
+    }
+
+    /// The one button beside the chip, when there is one.
+    public enum Action: Equatable, Sendable {
+        /// A job runs; the button stops it.
+        case cancel
+        /// The last job failed and the audio is here.
+        case retry
+        /// The last job was cancelled and the audio is here.
+        case transcribe
+        /// Complete; a second pass on another tier is possible.
+        case transcribeAgain
+    }
+
+    /// What the transcript pane says when it has no rows.
+    public struct EmptyState: Equatable, Sendable {
+        public var title: String
+        public var symbol: String
+        public var detail: String
+    }
+
+    public var chip: Chip?
+    /// The live session is on this recording and paused.
+    public var isPaused: Bool
+    /// A job or the live session is on this recording: no edits now.
+    public var isBusy: Bool
+    /// The note about imperfect work, from one source.
+    public var warning: String?
+    public var action: Action?
+    public var emptyState: EmptyState
+
+    /// - Parameters:
+    ///   - status: the stored status of the recording.
+    ///   - progress: the queue's progress on it, if a job is queued or runs.
+    ///   - isLive: the live session is on this recording, in any phase.
+    ///   - isPaused: that session is paused.
+    ///   - warning: the stored warning, or the coordinator's when the row has
+    ///     none yet. The caller resolves the two sources into one.
+    ///   - hasAudio: the audio file exists.
+    ///   - errorMessage: the stored error of a failed job.
+    public static func make(
+        status: TranscriptionStatus, progress: JobProgress?,
+        isLive: Bool, isPaused: Bool, warning: String?,
+        hasAudio: Bool, errorMessage: String?
+    ) -> RecordingDisplayStatus {
+        let cleanWarning = warning.flatMap { $0.isEmpty ? nil : $0 }
+
+        if let progress {
+            let detail: String
+            if let remaining = progress.remaining {
+                detail = "\(progress.status.label) · \(TimeFormat.remaining(seconds: remaining)) left"
+            } else {
+                detail = progress.status.label
+            }
+            return RecordingDisplayStatus(
+                chip: Chip(status: progress.status, fraction: progress.fraction,
+                           remaining: progress.remaining),
+                isPaused: false, isBusy: true, warning: cleanWarning, action: .cancel,
+                emptyState: EmptyState(title: "Work in progress", symbol: "text.alignleft",
+                                       detail: detail)
+            )
+        }
+
+        if isLive {
+            // Live work never reaches the queue, so it has no progress entry;
+            // the stored status is what there is.
+            return RecordingDisplayStatus(
+                chip: isPaused ? nil : Chip(status: status, fraction: 0, remaining: nil),
+                isPaused: isPaused, isBusy: true, warning: cleanWarning, action: nil,
+                emptyState: EmptyState(title: "Recording", symbol: "waveform",
+                                       detail: "The transcript comes after you stop.")
+            )
+        }
+
+        switch status {
+        case .failed:
+            // "Transcription failed" is wrong for a recording that never
+            // captured anything -- nothing got as far as being transcribed.
+            return RecordingDisplayStatus(
+                chip: Chip(status: .failed, fraction: 0, remaining: nil),
+                isPaused: false, isBusy: false, warning: cleanWarning,
+                action: hasAudio ? .retry : nil,
+                emptyState: EmptyState(
+                    title: hasAudio ? "Transcription failed" : "The recording stopped early",
+                    symbol: "exclamationmark.triangle",
+                    detail: errorMessage ?? Self.noTranscriptDetail(hasAudio: hasAudio))
+            )
+        case .cancelled:
+            return RecordingDisplayStatus(
+                chip: Chip(status: .cancelled, fraction: 0, remaining: nil),
+                isPaused: false, isBusy: false, warning: cleanWarning,
+                action: hasAudio ? .transcribe : nil,
+                emptyState: EmptyState(title: "Transcription cancelled", symbol: "xmark.circle",
+                                       detail: Self.noTranscriptDetail(hasAudio: hasAudio))
+            )
+        default:
+            // Pending with no job, or a stale busy status the queue does not
+            // know: nothing runs. Complete is the common case.
+            return RecordingDisplayStatus(
+                chip: status.isBusy || status == .pending
+                    ? Chip(status: status, fraction: 0, remaining: nil) : nil,
+                isPaused: false, isBusy: false, warning: cleanWarning,
+                action: hasAudio ? .transcribeAgain : nil,
+                emptyState: EmptyState(title: "No transcript yet", symbol: "text.alignleft",
+                                       detail: Self.noTranscriptDetail(hasAudio: hasAudio))
+            )
+        }
+    }
+
+    private static func noTranscriptDetail(hasAudio: Bool) -> String {
+        hasAudio
+            ? "The audio is on this Mac. It has no transcript yet."
+            : "The app captured no audio, thus there is nothing to transcribe. "
+              + "A file that you import becomes a new recording. You can delete this one."
+    }
+}

--- a/app/Sources/TranscriberFlow/StopPlan.swift
+++ b/app/Sources/TranscriberFlow/StopPlan.swift
@@ -1,0 +1,110 @@
+import Foundation
+import TranscriberCore
+import TranscriberEngine
+
+/// What to do with a live session that just stopped, decided before any of
+/// it is done.
+///
+/// The method that stopped a recording was 110 lines that decided and acted
+/// in the same breath: the failure warning, the persister-or-writer choice,
+/// the three-way follow-up, the notice merging and the short-take question,
+/// each between awaited effects. None of the decisions ran without SwiftUI,
+/// a microphone and a model. This value is the decisions; the method that
+/// executes it is awaits only.
+nonisolated public struct StopPlan: Equatable, Sendable {
+
+    /// Where the live transcript, if any, goes.
+    public enum TranscriptStep: Equatable, Sendable {
+        /// The persister that wrote lines during the recording completes its
+        /// revision with the final list.
+        case completePersister
+        /// No persister was open; store the final list as a fresh revision.
+        case storeFresh
+        /// Nothing was decoded live.
+        case none
+    }
+
+    /// The job, if any, that follows the stop.
+    public enum FollowUp: Equatable, Sendable {
+        /// The whole-file pass: the transcript for a capture-only session, and
+        /// the better transcript for a two-lane one, whose live decode ran on
+        /// the lanes summed and cannot say which side a line came from.
+        case fullTranscription
+        /// The live transcript stands; identify the speakers over it.
+        case diarizeOnly(DiarizationMode)
+        /// Done. Drop the working copy unless Settings keeps it.
+        case markCompleted(discardCache: Bool)
+    }
+
+    /// "Keep this recording?" for a take that stopped almost at once.
+    public struct ShortTakeQuestion: Equatable, Sendable {
+        public var durationMs: Int
+        /// Nil when nothing was decoded live, so there is no count to give.
+        public var words: Int?
+    }
+
+    /// The live decoder threw on some or every hop.
+    public var liveFailureWarning: String?
+    public var transcript: TranscriptStep
+    public var followUp: FollowUp
+    /// What changed under the recording: a replaced microphone, a moved
+    /// default input. One string, in order.
+    public var noticesWarning: String?
+    public var shortTake: ShortTakeQuestion?
+
+    /// - Parameters:
+    ///   - result: what the session handed back.
+    ///   - decodedLive: whether the session decoded while it recorded.
+    ///   - hadPersister: whether committed lines were written during the
+    ///     recording, so a revision is already open.
+    ///   - diarizationMode: Settings › After you record.
+    ///   - keepWorkingCopy: Settings › Storage.
+    ///   - shortTakeMs: below this the take is asked about.
+    public static func make(
+        result: LiveSessionResult, decodedLive: Bool, hadPersister: Bool,
+        diarizationMode: DiarizationMode, keepWorkingCopy: Bool, shortTakeMs: Int
+    ) -> StopPlan {
+        var warning: String?
+        if decodedLive, result.stats.failedHops > 0 {
+            let detail = result.stats.lastError.map { " Last error: \($0)" } ?? ""
+            warning = result.stats.hops == 0
+                ? "Live transcription failed for this entire recording "
+                  + "(\(result.stats.failedHops) decode errors).\(detail) "
+                  + "The audio was saved. Use Transcribe Again to recover it."
+                : "\(result.stats.failedHops) decode(s) failed during this "
+                  + "recording, so some words may be missing.\(detail)"
+        }
+
+        let transcript: TranscriptStep = decodedLive
+            ? (hadPersister ? .completePersister : .storeFresh)
+            : .none
+
+        let followUp: FollowUp
+        if !decodedLive || result.lanes.count > 1 {
+            followUp = .fullTranscription
+        } else if diarizationMode.performsDiarization {
+            followUp = .diarizeOnly(diarizationMode)
+        } else {
+            followUp = .markCompleted(discardCache: !keepWorkingCopy)
+        }
+
+        let notices = result.notices.isEmpty
+            ? nil
+            : result.notices.map(\.message).joined(separator: " ")
+
+        var shortTake: ShortTakeQuestion?
+        if result.durationMs < shortTakeMs {
+            shortTake = ShortTakeQuestion(
+                durationMs: result.durationMs,
+                words: decodedLive
+                    ? result.segments.reduce(0) {
+                        $0 + $1.displayText.split(whereSeparator: \.isWhitespace).count
+                    }
+                    : nil
+            )
+        }
+
+        return StopPlan(liveFailureWarning: warning, transcript: transcript, followUp: followUp,
+                        noticesWarning: notices, shortTake: shortTake)
+    }
+}

--- a/app/Sources/TranscriberStore/GraphMutations.swift
+++ b/app/Sources/TranscriberStore/GraphMutations.swift
@@ -1,0 +1,57 @@
+import Foundation
+import SwiftData
+import TranscriberCore
+
+// Two mutations of the recording graph that both sides of the actor seam
+// make: the main-actor store when the user edits, and the writer actor when a
+// job finishes. Each used to exist twice, byte for byte, once per isolation.
+// A fix to either had to be made twice. They are `nonisolated` and take the
+// context they work on, so each caller runs them on its own actor.
+
+/// The roster: one `StoredSpeaker` row per label the diarizer produced, names
+/// the user chose left alone, labels the transcript no longer uses removed.
+public enum SpeakerSync {
+
+    /// Ensures a row exists for every label in `roster`, updates the talk time
+    /// and the colour of the rows that stay, and deletes the rows for labels
+    /// that are gone. A re-run with fewer speakers would otherwise leave
+    /// ghosts in the roster.
+    nonisolated public static func apply(_ roster: [SpeakerLabel],
+                                         to recording: StoredRecording,
+                                         in context: ModelContext) {
+        var existing = Dictionary(
+            (recording.speakers ?? []).map { ($0.speakerId, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        for (offset, label) in roster.enumerated() {
+            if let row = existing.removeValue(forKey: label.id) {
+                row.speechMs = label.speechMs
+                row.colorIndex = offset
+            } else {
+                let row = StoredSpeaker(speakerId: label.id,
+                                        displayName: label.displayName,
+                                        speechMs: label.speechMs,
+                                        colorIndex: offset)
+                row.recording = recording
+                context.insert(row)
+            }
+        }
+        for orphan in existing.values { context.delete(orphan) }
+    }
+}
+
+/// The flattened text that search reads: title, summary, notes, every
+/// transcript line as displayed, every item and every bookmark label.
+public enum SearchIndex {
+
+    /// Rebuilds `searchText`. Called after any edit to the transcript or the
+    /// notes, and once when a job finishes. It reads the transcript through
+    /// the same indexed fetch as everything else.
+    nonisolated public static func rebuild(_ recording: StoredRecording) {
+        var parts = [recording.title, recording.summary, recording.body]
+        parts.append(contentsOf: (recording.transcript?.orderedSegments ?? []).map(\.displayText))
+        parts.append(contentsOf: (recording.items ?? []).map(\.text))
+        parts.append(contentsOf: (recording.bookmarks ?? []).map(\.label))
+        recording.searchText = parts.filter { !$0.isEmpty }.joined(separator: "\n")
+    }
+}

--- a/app/Sources/TranscriberStore/RecordingStore.swift
+++ b/app/Sources/TranscriberStore/RecordingStore.swift
@@ -29,10 +29,16 @@ public enum RecordingStore {
     }
 
     public static func defaultTitle(for kind: RecordingKind, at date: Date) -> String {
+        "\(kind.label) \(titleFormatter.string(from: date))"
+    }
+
+    /// One formatter for the life of the process. `DateFormatter` is costly
+    /// to make and this is a static helper, so a fresh one per call was waste.
+    private static let titleFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "d MMM, HH:mm"
-        return "\(kind.label) \(formatter.string(from: date))"
-    }
+        return formatter
+    }()
 
     // MARK: - Deleting
 

--- a/app/Sources/TranscriberStore/RecordingStore.swift
+++ b/app/Sources/TranscriberStore/RecordingStore.swift
@@ -165,31 +165,11 @@ public enum RecordingStore {
 
     // MARK: - Speakers
 
-    /// Ensures a `StoredSpeaker` row exists for every label the diarizer used,
-    /// leaving names the user already chose alone.
+    /// The main-actor entry to `SpeakerSync.apply`.
     public static func syncSpeakers(_ roster: [SpeakerLabel],
                                     on recording: StoredRecording,
                                     in context: ModelContext) {
-        var existing = Dictionary(
-            (recording.speakers ?? []).map { ($0.speakerId, $0) },
-            uniquingKeysWith: { first, _ in first }
-        )
-        for (offset, label) in roster.enumerated() {
-            if let row = existing.removeValue(forKey: label.id) {
-                row.speechMs = label.speechMs
-                row.colorIndex = offset
-            } else {
-                let row = StoredSpeaker(speakerId: label.id,
-                                        displayName: label.displayName,
-                                        speechMs: label.speechMs,
-                                        colorIndex: offset)
-                row.recording = recording
-                context.insert(row)
-            }
-        }
-        // Labels no longer produced by the current transcript: drop them, or a
-        // re-run with fewer speakers leaves ghosts in the roster.
-        for orphan in existing.values { context.delete(orphan) }
+        SpeakerSync.apply(roster, to: recording, in: context)
     }
 
     public static func rename(_ speaker: StoredSpeaker, to name: String,
@@ -370,12 +350,9 @@ public enum RecordingStore {
         )
     }
 
-    /// Rebuilds the flattened search text. Called after any transcript or note edit.
+    /// The main-actor entry to `SearchIndex.rebuild`. Called after any
+    /// transcript or note edit.
     public static func reindex(_ recording: StoredRecording) {
-        var parts = [recording.title, recording.summary, recording.body]
-        parts.append(contentsOf: (recording.transcript?.orderedSegments ?? []).map(\.displayText))
-        parts.append(contentsOf: (recording.items ?? []).map(\.text))
-        parts.append(contentsOf: (recording.bookmarks ?? []).map(\.label))
-        recording.searchText = parts.filter { !$0.isEmpty }.joined(separator: "\n")
+        SearchIndex.rebuild(recording)
     }
 }

--- a/app/Sources/TranscriberStore/TranscriptWriter.swift
+++ b/app/Sources/TranscriberStore/TranscriptWriter.swift
@@ -77,9 +77,9 @@ public actor TranscriptWriter {
         modelContext.insert(transcript)
         insert(segments, into: transcript)
 
-        syncSpeakers(roster, on: recording)
+        SpeakerSync.apply(roster, to: recording, in: modelContext)
         recording.updatedAt = Date()
-        RecordingStore.reindexOffMain(recording)
+        SearchIndex.rebuild(recording)
         try modelContext.save()
         return revision
     }
@@ -152,9 +152,9 @@ public actor TranscriptWriter {
         transcript.didDiarize = didDiarize
         transcript.isComplete = true
 
-        syncSpeakers(roster, on: recording)
+        SpeakerSync.apply(roster, to: recording, in: modelContext)
         recording.updatedAt = Date()
-        RecordingStore.reindexOffMain(recording)
+        SearchIndex.rebuild(recording)
         try modelContext.save()
         return transcript.revision
     }
@@ -185,7 +185,7 @@ public actor TranscriptWriter {
             row.index = index
         }
         recording.updatedAt = Date()
-        RecordingStore.reindexOffMain(recording)
+        SearchIndex.rebuild(recording)
         try modelContext.save()
         return removed
     }
@@ -223,30 +223,9 @@ public actor TranscriptWriter {
             )?.speakerId
         }
         transcript.didDiarize = true
-        syncSpeakers(roster, on: recording)
+        SpeakerSync.apply(roster, to: recording, in: modelContext)
         recording.updatedAt = Date()
         try modelContext.save()
-    }
-
-    private func syncSpeakers(_ roster: [SpeakerLabel], on recording: StoredRecording) {
-        var existing = Dictionary(
-            (recording.speakers ?? []).map { ($0.speakerId, $0) },
-            uniquingKeysWith: { first, _ in first }
-        )
-        for (offset, label) in roster.enumerated() {
-            if let row = existing.removeValue(forKey: label.id) {
-                row.speechMs = label.speechMs
-                row.colorIndex = offset
-            } else {
-                let row = StoredSpeaker(speakerId: label.id,
-                                        displayName: label.displayName,
-                                        speechMs: label.speechMs,
-                                        colorIndex: offset)
-                row.recording = recording
-                modelContext.insert(row)
-            }
-        }
-        for orphan in existing.values { modelContext.delete(orphan) }
     }
 
     private func find(_ id: UUID) throws -> StoredRecording? {
@@ -255,19 +234,5 @@ public actor TranscriptWriter {
         )
         descriptor.fetchLimit = 1
         return try modelContext.fetch(descriptor).first
-    }
-}
-
-extension RecordingStore {
-    /// The same flattening as `reindex`, callable from the writer actor.
-    ///
-    /// `RecordingStore` is main-actor because it is the UI's entry point; the
-    /// background writer needs this one operation and nothing else from it.
-    nonisolated static func reindexOffMain(_ recording: StoredRecording) {
-        var parts = [recording.title, recording.summary, recording.body]
-        parts.append(contentsOf: (recording.transcript?.orderedSegments ?? []).map(\.displayText))
-        parts.append(contentsOf: (recording.items ?? []).map(\.text))
-        parts.append(contentsOf: (recording.bookmarks ?? []).map(\.label))
-        recording.searchText = parts.filter { !$0.isEmpty }.joined(separator: "\n")
     }
 }

--- a/app/Tests/TranscriberEngineTests/InputGainSessionTests.swift
+++ b/app/Tests/TranscriberEngineTests/InputGainSessionTests.swift
@@ -52,6 +52,33 @@ final class InputGainSessionTests: XCTestCase {
         XCTAssertEqual(session.inputGainDb, InputGain.minDb)
     }
 
+    /// One value carries every setting the session reads. A caller cannot
+    /// forget a field, which is how the launch warm-up once prepared a
+    /// session with four of six.
+    func testConfigureSetsEveryField() {
+        let session = makeSession()
+        let configuration = LiveConfiguration(
+            session: SessionConfig(hopMs: 1_200, language: "en"),
+            decodeLive: false, captureSource: .both, microphoneUID: "mic-42",
+            inputGainDb: 9, isRoomMode: true
+        )
+        session.configure(configuration)
+        XCTAssertEqual(session.config.hopMs, 1_200)
+        XCTAssertEqual(session.config.language, "en")
+        XCTAssertFalse(session.decodeLive)
+        XCTAssertEqual(session.captureSource, .both)
+        XCTAssertEqual(session.microphoneUID, "mic-42")
+        XCTAssertEqual(session.inputGainDb, 9)
+        XCTAssertTrue(session.isRoomMode)
+
+        // The default value is the app's default too.
+        session.configure(LiveConfiguration())
+        XCTAssertTrue(session.decodeLive)
+        XCTAssertEqual(session.captureSource, .default)
+        XCTAssertNil(session.microphoneUID)
+        XCTAssertEqual(session.inputGainDb, InputGain.defaultDb)
+    }
+
     /// Pause is a flag the audio callback reads per buffer, like gain. A
     /// session that ends paused must not leave the next one paused.
     func testPauseRoundTripsAndClearsTheMeter() throws {

--- a/app/Tests/TranscriberFlowTests/JobCoordinatorTests.swift
+++ b/app/Tests/TranscriberFlowTests/JobCoordinatorTests.swift
@@ -1,0 +1,190 @@
+import Foundation
+import SwiftData
+import XCTest
+import TranscriberCore
+import TranscriberEngine
+import TranscriberStore
+@testable import TranscriberFlow
+
+/// The reduction from queue events to the store and to what the views read,
+/// driven with events and checked against a real in-memory store.
+@MainActor
+final class JobCoordinatorTests: XCTestCase {
+
+    private var container: ModelContainer!
+    private var writer: TranscriptWriter!
+    private var clock: Date!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        container = try StoreContainer.ephemeral()
+        writer = TranscriptWriter(modelContainer: container)
+        clock = Date(timeIntervalSinceReferenceDate: 1_000)
+    }
+
+    override func tearDown() async throws {
+        writer = nil
+        container = nil
+        try await super.tearDown()
+    }
+
+    private func makeCoordinator() -> JobCoordinator {
+        let queue = TranscriptionQueue(engines: EngineHost(modelsDirectory: URL(fileURLWithPath: "/nonexistent")))
+        let clockBox = ClockBox(self.clock)
+        self.clockBox = clockBox
+        return JobCoordinator(queue: queue, writer: writer) { clockBox.now }
+    }
+
+    private final class ClockBox: @unchecked Sendable {
+        var now: Date
+        init(_ now: Date) { self.now = now }
+    }
+    private var clockBox: ClockBox!
+
+    private func advance(_ seconds: TimeInterval) {
+        clockBox.now = clockBox.now.addingTimeInterval(seconds)
+    }
+
+    private func recording() throws -> StoredRecording {
+        try RecordingStore.create(kind: .recording, title: "Job", in: container.mainContext)
+    }
+
+    private func fresh(_ id: UUID) throws -> StoredRecording? {
+        try ModelContext(container).fetch(FetchDescriptor<StoredRecording>(
+            predicate: #Predicate { $0.id == id }
+        )).first
+    }
+
+    private func job(_ id: UUID) -> TranscriptionJob {
+        TranscriptionJob(id: id, title: "Job", sourceURL: nil,
+                         cacheURL: URL(fileURLWithPath: "/tmp/x.wav"),
+                         modelId: "model", language: "tl")
+    }
+
+    func testEnqueueShowsTheQueueAtOnceAndClearsTheOldWarning() async throws {
+        let coordinator = makeCoordinator()
+        let id = try recording().id
+        await coordinator.addWarning("old", for: id)
+        XCTAssertEqual(coordinator.warning(for: id), "old")
+
+        coordinator.enqueue(job(id))
+        XCTAssertEqual(coordinator.progress(for: id)?.status, .pending)
+        XCTAssertTrue(coordinator.isBusy(id))
+        XCTAssertNil(coordinator.warning(for: id))
+    }
+
+    func testStageWritesTheStatusOnceAndTheFractionNever() async throws {
+        let coordinator = makeCoordinator()
+        let id = try recording().id
+        await coordinator.handle(.queued(id: id, title: "Job"))
+        await coordinator.handle(.stage(id: id, status: .transcribing, progress: 0))
+        await coordinator.handle(.stage(id: id, status: .transcribing, progress: 0.4))
+
+        XCTAssertEqual(coordinator.progress(for: id)?.fraction, 0.4)
+        let row = try XCTUnwrap(try fresh(id))
+        XCTAssertEqual(row.status, .transcribing)
+        XCTAssertEqual(row.progress, 0, "only the stage change reaches the store")
+    }
+
+    func testPartialRowsThenTheFinalTranscriptReachTheStore() async throws {
+        let coordinator = makeCoordinator()
+        let id = try recording().id
+        coordinator.enqueue(job(id))
+        await coordinator.handle(.queued(id: id, title: "Job"))
+        await coordinator.handle(.stage(id: id, status: .transcribing, progress: 0))
+        await coordinator.handle(.partial(id: id, segments: [
+            Segment(index: 0, startMs: 0, endMs: 900, text: "una"),
+            Segment(index: 1, startMs: 1_000, endMs: 1_900, text: "dalawa"),
+        ], coveredMs: 2_000))
+
+        XCTAssertEqual(coordinator.tick(for: id), 1)
+        XCTAssertEqual(coordinator.progress(for: id)?.coveredMs, 2_000)
+        var row = try XCTUnwrap(try fresh(id))
+        XCTAssertEqual(row.transcript?.orderedSegments.map(\.text), ["una", "dalawa"])
+        XCTAssertEqual(row.transcript?.isComplete, false)
+
+        let payload = TranscriptionPayload(
+            segments: [Segment(index: 0, startMs: 0, endMs: 1_900, text: "una dalawa", speakerId: "S1")],
+            roster: [SpeakerLabel(id: "S1", displayName: "Speaker 1", speechMs: 1_900)],
+            durationMs: 2_000, processMs: 50, modelId: "model", language: "tl",
+            didDiarize: true, waveform: [0.5], metrics: TranscriptionMetrics()
+        )
+        await coordinator.handle(.transcribed(id: id, payload: payload))
+        await coordinator.handle(.stage(id: id, status: .completed, progress: 1))
+        await coordinator.handle(.finished(id: id))
+
+        XCTAssertEqual(coordinator.tick(for: id), 2)
+        XCTAssertNil(coordinator.progress(for: id), "finished clears the progress")
+        XCTAssertFalse(coordinator.isBusy(id))
+        row = try XCTUnwrap(try fresh(id))
+        XCTAssertEqual(row.transcript?.orderedSegments.map(\.text), ["una dalawa"])
+        XCTAssertEqual(row.transcript?.isComplete, true)
+        XCTAssertEqual(row.transcript?.revision, 1, "the partial revision was completed, not replaced")
+        XCTAssertEqual(row.speakers?.count, 1)
+        XCTAssertEqual(row.durationMs, 2_000)
+        XCTAssertEqual(row.status, .completed)
+    }
+
+    func testWarningsAccumulateWithoutRepeatsAndPersist() async throws {
+        let coordinator = makeCoordinator()
+        let id = try recording().id
+        await coordinator.handle(.warning(id: id, message: "A window was dropped."))
+        await coordinator.handle(.warning(id: id, message: "A window was dropped."))
+        await coordinator.handle(.warning(id: id, message: "The microphone changed."))
+        await coordinator.addWarning("Live decoding failed.", for: id)
+
+        let expected = "A window was dropped. The microphone changed. Live decoding failed."
+        XCTAssertEqual(coordinator.warning(for: id), expected)
+        XCTAssertEqual(try fresh(id)?.warningMessage, expected)
+    }
+
+    func testFailureWritesTheMessageToTheRow() async throws {
+        let coordinator = makeCoordinator()
+        let id = try recording().id
+        await coordinator.handle(.failed(id: id, message: "no audio"))
+        let row = try XCTUnwrap(try fresh(id))
+        XCTAssertEqual(row.status, .failed)
+        XCTAssertEqual(row.errorMessage, "no audio")
+    }
+
+    func testTimeRemainingWaitsForFivePercentThenSmooths() async throws {
+        let coordinator = makeCoordinator()
+        let id = try recording().id
+        await coordinator.handle(.queued(id: id, title: "Job"))
+        await coordinator.handle(.stage(id: id, status: .transcribing, progress: 0))
+        XCTAssertNil(coordinator.progress(for: id)?.remaining, "the stage has only just begun")
+
+        advance(10)
+        await coordinator.handle(.stage(id: id, status: .transcribing, progress: 0.5))
+        XCTAssertEqual(coordinator.progress(for: id)?.remaining ?? -1, 10, accuracy: 0.01,
+                       "half in ten seconds means ten more")
+
+        advance(10)
+        await coordinator.handle(.stage(id: id, status: .transcribing, progress: 0.75))
+        // Raw: 20 s for 75 % leaves 6.67 s. Smoothed 70/30 against the 10 s.
+        XCTAssertEqual(coordinator.progress(for: id)?.remaining ?? -1, 9.0, accuracy: 0.01)
+
+        // A new stage starts its own clock.
+        await coordinator.handle(.stage(id: id, status: .diarizing, progress: 0))
+        XCTAssertNil(coordinator.progress(for: id)?.remaining)
+    }
+
+    func testARedoneTurnBumpsTheTickAndReplacesRows() async throws {
+        let coordinator = makeCoordinator()
+        let rec = try recording()
+        let id = rec.id
+        _ = try await writer.storeTranscript(
+            segments: [Segment(index: 0, startMs: 0, endMs: 900, text: "a"),
+                       Segment(index: 1, startMs: 5_000, endMs: 5_900, text: "bad"),
+                       Segment(index: 2, startMs: 9_000, endMs: 9_900, text: "c")],
+            roster: [], modelId: "m", language: "tl", processMs: 1, didDiarize: false, for: id
+        )
+        await coordinator.handle(.rangeTranscribed(
+            id: id, fromMs: 5_000, toMs: 6_000,
+            segments: [Segment(index: 0, startMs: 5_100, endMs: 5_800, text: "good")],
+            modelId: "accurate"
+        ))
+        XCTAssertEqual(coordinator.tick(for: id), 1)
+        XCTAssertEqual(try fresh(id)?.transcript?.orderedSegments.map(\.text), ["a", "good", "c"])
+    }
+}

--- a/app/Tests/TranscriberFlowTests/RecordingDisplayStatusTests.swift
+++ b/app/Tests/TranscriberFlowTests/RecordingDisplayStatusTests.swift
@@ -1,0 +1,81 @@
+import XCTest
+import TranscriberCore
+@testable import TranscriberFlow
+
+final class RecordingDisplayStatusTests: XCTestCase {
+
+    private func make(status: TranscriptionStatus = .completed, progress: JobProgress? = nil,
+                      isLive: Bool = false, isPaused: Bool = false, warning: String? = nil,
+                      hasAudio: Bool = true, error: String? = nil) -> RecordingDisplayStatus {
+        RecordingDisplayStatus.make(status: status, progress: progress, isLive: isLive,
+                                    isPaused: isPaused, warning: warning, hasAudio: hasAudio,
+                                    errorMessage: error)
+    }
+
+    func testAJobInProgressShowsItsChipAndACancelButton() {
+        let display = make(status: .transcribing,
+                           progress: JobProgress(status: .transcribing, fraction: 0.4, remaining: 90))
+        XCTAssertEqual(display.chip, .init(status: .transcribing, fraction: 0.4, remaining: 90))
+        XCTAssertEqual(display.action, .cancel)
+        XCTAssertTrue(display.isBusy)
+        XCTAssertEqual(display.emptyState.title, "Work in progress")
+        XCTAssertEqual(display.emptyState.detail,
+                       "Transcription · \(TimeFormat.remaining(seconds: 90)) left")
+    }
+
+    func testTheLiveSessionIsBusyWithNoActionAndPausedHasNoChip() {
+        let recording = make(status: .recording, isLive: true)
+        XCTAssertEqual(recording.chip?.status, .recording)
+        XCTAssertNil(recording.action)
+        XCTAssertTrue(recording.isBusy)
+        XCTAssertFalse(recording.isPaused)
+
+        let paused = make(status: .recording, isLive: true, isPaused: true)
+        XCTAssertNil(paused.chip, "the row shows Paused in the chip's place")
+        XCTAssertTrue(paused.isPaused)
+        XCTAssertTrue(paused.isBusy)
+    }
+
+    func testFailedOffersRetryOnlyWhenThereIsAudio() {
+        let withAudio = make(status: .failed, hasAudio: true, error: "The model refused a window.")
+        XCTAssertEqual(withAudio.action, .retry)
+        XCTAssertEqual(withAudio.emptyState.title, "Transcription failed")
+        XCTAssertEqual(withAudio.emptyState.detail, "The model refused a window.")
+
+        let noAudio = make(status: .failed, hasAudio: false)
+        XCTAssertNil(noAudio.action)
+        XCTAssertEqual(noAudio.emptyState.title, "The recording stopped early")
+        XCTAssertTrue(noAudio.emptyState.detail.contains("captured no audio"))
+    }
+
+    func testCancelledOffersTranscribe() {
+        let display = make(status: .cancelled)
+        XCTAssertEqual(display.chip?.status, .cancelled)
+        XCTAssertEqual(display.action, .transcribe)
+        XCTAssertEqual(display.emptyState.symbol, "xmark.circle")
+    }
+
+    func testCompleteIsQuietWithTranscribeAgain() {
+        let display = make(status: .completed)
+        XCTAssertNil(display.chip)
+        XCTAssertEqual(display.action, .transcribeAgain)
+        XCTAssertFalse(display.isBusy)
+        XCTAssertNil(display.warning)
+        XCTAssertEqual(display.emptyState.title, "No transcript yet")
+    }
+
+    func testTheWarningComesThroughFromOneSourceAndBlankIsNone() {
+        XCTAssertEqual(make(warning: "A window was dropped.").warning, "A window was dropped.")
+        XCTAssertNil(make(warning: "").warning)
+        // A warning does not change the action: the recording is complete.
+        XCTAssertEqual(make(warning: "x").action, .transcribeAgain)
+    }
+
+    func testAPendingRowWithNoJobStillShowsItsStoredChip() {
+        // An import that has not reached the queue yet, or a row a relaunch
+        // found pending: the stored status is shown until the queue reports.
+        let display = make(status: .pending)
+        XCTAssertEqual(display.chip?.status, .pending)
+        XCTAssertFalse(display.isBusy)
+    }
+}

--- a/app/Tests/TranscriberFlowTests/StopPlanTests.swift
+++ b/app/Tests/TranscriberFlowTests/StopPlanTests.swift
@@ -1,0 +1,90 @@
+import XCTest
+import TranscriberCore
+import TranscriberEngine
+@testable import TranscriberFlow
+
+final class StopPlanTests: XCTestCase {
+
+    private func result(durationMs: Int = 60_000, lanes: [CaptureLane] = [.room],
+                        segments: [Segment] = [], stats: SessionStats = SessionStats(),
+                        notices: [CaptureNotice] = []) -> LiveSessionResult {
+        LiveSessionResult(recordingId: UUID(), segments: segments, durationMs: durationMs,
+                          archiveFileName: "a.m4a", archiveSampleRate: 48_000,
+                          cacheURL: URL(fileURLWithPath: "/tmp/c.wav"), waveform: [],
+                          stats: stats, modelId: "m", language: "tl", lanes: lanes,
+                          notices: notices)
+    }
+
+    private func plan(_ result: LiveSessionResult, decodedLive: Bool = true, hadPersister: Bool = true,
+                      diarization: DiarizationMode = .accurate, keep: Bool = false) -> StopPlan {
+        StopPlan.make(result: result, decodedLive: decodedLive, hadPersister: hadPersister,
+                      diarizationMode: diarization, keepWorkingCopy: keep, shortTakeMs: 10_000)
+    }
+
+    func testCaptureOnlyGetsTheWholeFilePassAndNoLiveTranscript() {
+        let plan = plan(result(), decodedLive: false, hadPersister: false)
+        XCTAssertEqual(plan.transcript, .none)
+        XCTAssertEqual(plan.followUp, .fullTranscription)
+        XCTAssertNil(plan.liveFailureWarning)
+    }
+
+    func testLiveWithSpeakersCompletesThePersisterThenIdentifiesSpeakers() {
+        let plan = plan(result(), diarization: .fast)
+        XCTAssertEqual(plan.transcript, .completePersister)
+        XCTAssertEqual(plan.followUp, .diarizeOnly(.fast))
+    }
+
+    func testLiveWithoutAPersisterStoresAFreshRevision() {
+        XCTAssertEqual(plan(result(), hadPersister: false).transcript, .storeFresh)
+    }
+
+    func testLiveWithoutSpeakersIsDoneAndDropsTheWorkingCopyUnlessKept() {
+        XCTAssertEqual(plan(result(), diarization: .off).followUp, .markCompleted(discardCache: true))
+        XCTAssertEqual(plan(result(), diarization: .off, keep: true).followUp,
+                       .markCompleted(discardCache: false))
+    }
+
+    func testTwoLanesAlwaysGetTheWholeFilePass() {
+        let plan = plan(result(lanes: [.room, .remote]), diarization: .off)
+        XCTAssertEqual(plan.transcript, .completePersister, "the live lines are kept meanwhile")
+        XCTAssertEqual(plan.followUp, .fullTranscription)
+    }
+
+    func testFailedHopsBecomeAWarningWithTheDistinctionBetweenSomeAndAll() {
+        var some = SessionStats()
+        some.hops = 10
+        some.failedHops = 2
+        some.lastError = "boom"
+        let partial = plan(result(stats: some))
+        XCTAssertEqual(partial.liveFailureWarning,
+                       "2 decode(s) failed during this recording, so some words may be missing. Last error: boom")
+
+        var all = SessionStats()
+        all.failedHops = 5
+        let total = plan(result(stats: all))
+        XCTAssertTrue(total.liveFailureWarning?.hasPrefix("Live transcription failed for this entire recording (5 decode errors).") == true)
+
+        XCTAssertNil(plan(result(stats: all), decodedLive: false).liveFailureWarning,
+                     "a capture-only session has no decodes to fail")
+    }
+
+    func testNoticesJoinInOrder() {
+        let plan = plan(result(notices: [.microphoneChanged(now: "AirPods"), .microphoneLost("AirPods")]))
+        let text = plan.noticesWarning ?? ""
+        XCTAssertTrue(text.hasPrefix("The default input changed."))
+        XCTAssertTrue(text.contains("no other microphone is connected"))
+        XCTAssertNil(self.plan(result()).noticesWarning)
+    }
+
+    func testAShortTakeIsQuestionedWithItsWordCountOnlyWhenDecodedLive() {
+        let segments = [Segment(index: 0, startMs: 0, endMs: 900, text: "sige na"),
+                        Segment(index: 1, startMs: 1_000, endMs: 1_900, text: "ulit")]
+        let live = plan(result(durationMs: 4_000, segments: segments))
+        XCTAssertEqual(live.shortTake, .init(durationMs: 4_000, words: 3))
+
+        let captureOnly = plan(result(durationMs: 4_000, segments: segments), decodedLive: false)
+        XCTAssertEqual(captureOnly.shortTake, .init(durationMs: 4_000, words: nil))
+
+        XCTAssertNil(plan(result(durationMs: 10_000)).shortTake, "at the threshold it is kept quietly")
+    }
+}

--- a/app/Tests/TranscriberStoreTests/GraphMutationsTests.swift
+++ b/app/Tests/TranscriberStoreTests/GraphMutationsTests.swift
@@ -1,0 +1,94 @@
+import SwiftData
+import XCTest
+import TranscriberCore
+@testable import TranscriberStore
+
+/// The two graph mutations that the main-actor store and the writer actor
+/// share. Both callers must get the same result from the same input.
+@MainActor
+final class GraphMutationsTests: XCTestCase {
+
+    private var container: ModelContainer!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        container = try StoreContainer.ephemeral()
+    }
+
+    override func tearDown() async throws {
+        container = nil
+        try await super.tearDown()
+    }
+
+    private func roster(_ ids: [String]) -> [SpeakerLabel] {
+        ids.enumerated().map { SpeakerLabel(id: $1, displayName: "Person \($0 + 1)", speechMs: ($0 + 1) * 1_000) }
+    }
+
+    func testSyncKeepsRenamedRowsAndDropsOrphans() throws {
+        let context = container.mainContext
+        let recording = try RecordingStore.create(kind: .meeting, in: context)
+        SpeakerSync.apply(roster(["S1", "S2", "S3"]), to: recording, in: context)
+        try context.save()
+        let s2 = try XCTUnwrap((recording.speakers ?? []).first { $0.speakerId == "S2" })
+        s2.displayName = "Maria"
+
+        // A second pass without S3 and with S2 first.
+        SpeakerSync.apply(roster(["S2", "S1"]), to: recording, in: context)
+        try context.save()
+
+        let rows = (recording.speakers ?? []).sorted { $0.colorIndex < $1.colorIndex }
+        XCTAssertEqual(rows.map(\.speakerId), ["S2", "S1"], "colours follow roster order")
+        XCTAssertEqual(rows.first?.displayName, "Maria", "the user's name survives")
+        XCTAssertEqual(rows.first?.speechMs, 1_000, "talk time follows the new roster")
+        XCTAssertFalse(rows.contains { $0.speakerId == "S3" }, "the orphan is gone")
+    }
+
+    func testTheWriterAndTheStoreProduceTheSameRoster() async throws {
+        let context = container.mainContext
+        let viaStore = try RecordingStore.create(kind: .meeting, title: "store", in: context)
+        RecordingStore.syncSpeakers(roster(["S1", "S2"]), on: viaStore, in: context)
+        try context.save()
+
+        let viaWriter = try RecordingStore.create(kind: .meeting, title: "writer", in: context)
+        let writer = TranscriptWriter(modelContainer: container)
+        _ = try await writer.storeTranscript(
+            segments: [Segment(index: 0, startMs: 0, endMs: 1_000, text: "hello", speakerId: "S1")],
+            roster: roster(["S1", "S2"]), modelId: "m", language: "tl",
+            processMs: 1, didDiarize: true, for: viaWriter.id
+        )
+
+        let fresh = ModelContext(container)
+        let all = try fresh.fetch(FetchDescriptor<StoredRecording>())
+        let a = try XCTUnwrap(all.first { $0.title == "store" })
+        let b = try XCTUnwrap(all.first { $0.title == "writer" })
+        let shape: (StoredRecording) -> [(String, Int, Int)] = { recording in
+            (recording.speakers ?? []).sorted { $0.colorIndex < $1.colorIndex }
+                .map { ($0.speakerId, $0.colorIndex, $0.speechMs) }
+        }
+        XCTAssertEqual(shape(a).map(\.0), shape(b).map(\.0))
+        XCTAssertEqual(shape(a).map(\.1), shape(b).map(\.1))
+        XCTAssertEqual(shape(a).map(\.2), shape(b).map(\.2))
+        XCTAssertTrue(b.searchText.contains("hello"), "the writer rebuilt the index")
+    }
+
+    func testSearchIndexFlattensEverySource() throws {
+        let context = container.mainContext
+        let recording = try RecordingStore.create(kind: .meeting, title: "Budget", in: context)
+        recording.summary = "Q4 plan"
+        recording.body = "scratch"
+        let transcript = StoredTranscript(modelId: "m", language: "tl")
+        transcript.recording = recording
+        context.insert(transcript)
+        let row = StoredSegment(index: 0, startMs: 0, endMs: 900, text: "raw text", textClean: "clean text")
+        row.transcript = transcript
+        context.insert(row)
+        _ = try RecordingStore.addItem(.decision, text: "ship it", to: recording, in: context)
+        _ = try RecordingStore.addBookmark(at: 100, label: "important", to: recording, in: context)
+        try context.save()
+
+        SearchIndex.rebuild(recording)
+        let lines = recording.searchText.split(separator: "\n").map(String.init)
+        XCTAssertEqual(lines, ["Budget", "Q4 plan", "scratch", "clean text", "ship it", "important"])
+        XCTAssertFalse(recording.searchText.contains("raw text"), "the edit is what search sees")
+    }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -12,6 +12,7 @@ app/            Swift 6 and SwiftUI. The product.
 ├── Sources/TranscriberCore/     pure logic: commit policy, merger, exports, search
 ├── Sources/TranscriberStore/    SwiftData schema and queries
 ├── Sources/TranscriberEngine/   audio, WhisperKit, FluidAudio VAD and speaker models
+├── Sources/TranscriberFlow/     the app's decisions with no window
 ├── Sources/Transcriber/         the SwiftUI app
 └── Sources/TranscriberCLI/      the same pipeline, with no window
 ```
@@ -21,7 +22,7 @@ Transcriber, which the app had through its private builds. The data directory
 holds the recordings that those builds wrote, thus a rename there hides them.
 The module names are internal, and a rename gives the user nothing.
 
-## The four layers
+## The five layers
 
 Each layer builds and tests without the layer above it:
 
@@ -30,17 +31,18 @@ Each layer builds and tests without the layer above it:
 | `TranscriberCore` | nothing | AVFoundation, CoreML, SwiftUI, SwiftData, models |
 | `TranscriberStore` | Core | inference of any kind |
 | `TranscriberEngine` | Core | SwiftUI |
-| `Transcriber` | Core, Store, Engine | — |
+| `TranscriberFlow` | Core, Store, Engine | SwiftUI, AppKit |
+| `Transcriber` | Core, Store, Engine, Flow | — |
 
 This split lets you test the commit policy, the segment merger, the exporters
 and the search index on a Mac that has no microphone and no model weights. That
 property is what keeps the CI job free of secrets and free of model downloads.
 
-The diagram in the [README](../README.md) shows the same four layers as a
-stack, from the user interface down to the models. The table above is the
-dependency rule. `TranscriberStore` and `TranscriberEngine` both depend on
-`TranscriberCore` and not on each other. The SwiftUI app is the only layer that
-sees all three.
+The diagram in the [README](../README.md) shows the same layers as a stack,
+from the user interface down to the models. The table above is the dependency
+rule. `TranscriberStore` and `TranscriberEngine` both depend on
+`TranscriberCore` and not on each other. `TranscriberFlow` and the SwiftUI app
+see all three.
 
 ### `TranscriberCore`
 
@@ -67,6 +69,22 @@ the microphone, the audio of this Mac through `SystemAudioTap`, or both.
 run the live path. `OfflinePipeline` runs the whole-file path.
 `TranscriptionQueue` runs the background jobs. `EngineHost` owns the models.
 `BenchmarkRunner` measures the tiers.
+
+### `TranscriberFlow`
+
+The decisions of the app, with no window and no AppKit, so a test can make
+them. `JobCoordinator` consumes the events of the transcription queue, writes
+to the store through `TranscriptWriter`, and holds the three values the views
+read about a job: the progress, the warning and the transcript tick. It also
+takes the three commands: enqueue, cancel and add a warning.
+`RecordingDisplayStatus` is the one ladder from the stored status, the job
+progress, the live session and the warning to what a row, a header and an
+empty transcript show. `StopPlan` decides what a stop of the live session does:
+the failure warning, where the live transcript goes, the follow-up job, the
+device-notice warning and the short-take question. The app executes the plan.
+
+Before this layer existed, these three lived on the app state as private
+methods and internal dictionaries, and no test reached them.
 
 ### `Transcriber`
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -63,7 +63,7 @@ catalogue and the storage layout.
 cd app && swift test
 ```
 
-There are 301 tests: 273 XCTest tests and 28 swift-testing tests. **They need
+There are 327 tests: 299 XCTest tests and 28 swift-testing tests. **They need
 no model weights, no microphone and no network.** This property is deliberate,
 and you must keep it. The four-layer split in
 [ARCHITECTURE.md](ARCHITECTURE.md) is what makes it possible.
@@ -73,6 +73,7 @@ and you must keep it. The four-layer split in
 | `TranscriberCoreTests` | Pure logic. No fakes are necessary. |
 | `TranscriberStoreTests` | The SwiftData schema and the queries. |
 | `TranscriberEngineTests` | The real pipeline, driven through fakes for the three engine protocols. |
+| `TranscriberFlowTests` | The job coordinator against an in-memory store, the display status and the stop plan. |
 
 If model weights are unavailable for a test, add a fake. Do not skip the test.
 


### PR DESCRIPTION
## What this changes

Built on #3 (base branch `feature/simple-mode-pause-menubar-range`). Guided by two skills: `swiftui-expert-skill` (correctness and invalidation audit) and `improve-codebase-architecture` (deepening candidates, report in the PR description below). Seven commits, one per step, each green.

### SwiftUI hot paths (skill audit)
- No deprecated APIs found; `@State`/`@FocusState` private; `ForEach` identities stable.
- The recording screen is now a header, a transcript and a footer view type: a meter tick (10–12 Hz) re-runs the header only.
- The player bar: only the clock and the waveform read the 20 Hz playhead; bookmark ticks are `Button`s with labels.
- Transcript rows read one coarse `playingBlockId` from the follower instead of the raw playhead.
- `isCompact` / `hasRoomForInspector` are stored flags written in `didSet`; a window drag no longer invalidates readers per pixel.
- An unused `@Environment(\.modelContext)` removed; one static `DateFormatter` in the store.

### Deepening (architecture review)
1. **`TranscriberFlow`, a fifth layer** (Core + Store + Engine, no SwiftUI/AppKit, own test target). The app's decisions live here with tests.
2. **`JobCoordinator`** owns the six job dictionaries that lived on `AppState` and the event → writer reduction. Seven tests against an in-memory store. The live session's failure warning is now persisted (it was in memory only unless a device notice followed).
3. **`RecordingDisplayStatus`**: one ladder for the sidebar row, the detail header and the empty transcript; the warning has one source. Seven tests.
4. **`StopPlan`**: the stop decision is a pure value; `stopRecording` executes it. Eight tests.
5. **`SpeakerSync` / `SearchIndex`**: one nonisolated copy each for the main actor and the writer actor (they were byte-identical duplicates). Three tests.
6. **`LiveConfiguration`**: the session takes its six settings as one value; the launch path had copied four of six.
7. **Interface mode as an environment value** with one `advancedOnly()` modifier; the recording screen and the player take `LiveSession` / `AudioPlayer` as explicit inputs.

## Verification
- `swift build` zero warnings on a forced recompile; `swift test`: 299 XCTest + 28 swift-testing (was 273 + 28).
- App bundle smoke test in a throwaway library: Simple ↔ Advanced switch through the environment, Settings panes follow.
- Docs: ARCHITECTURE, CONTRIBUTING, DEVELOPMENT, README diagram, CHANGELOG.

## Not done
- Candidate 6 in full: the views still take engine objects (`LiveSession`, `AudioPlayer`) rather than per-screen protocols. A protocol per screen is the next step if a second adapter (a preview or a test double) appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
