### PR TITLE
Automatic meeting notes from the on-device model, behind a review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,24 @@
   path repeat the primer (27% to 96% WER), and `suppressBlank` was noise.
   `transcribe --style-hint` and `--prompt` repeat the measurement.
 
+### Under the hood
+
+- A new layer, `TranscriberFlow`, holds the decisions of the app with no
+  window: the job coordinator, the display status of a recording and the stop
+  plan. Each has tests. Before, these were private methods and internal
+  dictionaries on the app state, and no test reached them. The live session's
+  failure warning is now saved; before, it was in memory only unless a device
+  notice followed it.
+- The speaker roster sync and the search index exist one time each, for both
+  the main actor and the writer actor. They were byte-identical copies.
+- The live session takes its six settings as one value. Four call sites copied
+  them one by one, and the launch path copied four of the six.
+- The recording screen and the player bar are split by rate of change, thus a
+  meter tick or a playhead tick re-runs one small view and not the screen. The
+  transcript rows read one playing-turn value in place of the raw playhead.
+- The interface mode is an environment value with one `advancedOnly()`
+  modifier, in place of a read of the settings at each control.
+
 ### The audio input
 
 - When the room listens through speakers, the microphone also hears the persons

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 ## Unreleased
 
+### Automatic notes
+
+- On macOS 26 with Apple Intelligence on, the notes pane has **Draft Notes
+  from the Transcript** (⇧⌘D). The Apple Intelligence model on this Mac reads
+  the transcript in parts and proposes a summary and notes of the five kinds,
+  each with the line it came from. A sheet shows the draft with a checkbox on
+  each note. The app writes nothing until you select it, and it does not
+  replace a summary that you wrote unless you select that. Nothing leaves the
+  Mac. **Settings › General › Automatic notes** selects English or the mix of
+  languages that the speakers used.
+- **The Apple model refuses Tagalog.** Measured on a 93-minute Taglish meeting
+  from the library: a part with 28 % Tagalog words was accepted, and parts with
+  50 % and 92 % were refused before any generation. The app says so instead of
+  showing a draft made from the parts that passed. Finding 13 in
+  `docs/FINDINGS.md` gives the measurement, and the measurement of the MLX
+  models (Qwen, Gemma) that do accept Taglish, on the same meeting against the
+  notes that were written by hand.
+- `transcribe --notes EXPORT.json` drafts the notes for an exported recording
+  and scores the draft: how much of each note is in the transcript near its
+  timestamp, which language the notes lean to, and how many of the hand-written
+  notes in the export the draft also has. `eval/notes_eval.py` does the same
+  with an MLX model, thus a candidate model can be measured before it is wired
+  into the app.
+- The pipeline is behind a fourth engine protocol, `NotesGenerating`, beside
+  the three for speech, voice activity and speakers. A second backend is a new
+  conformance.
+
 ### Simple mode
 
 - The app has two modes. **Simple** is the default. It shows the recordings, a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,15 +16,27 @@
   from the library: a part with 28 % Tagalog words was accepted, and parts with
   50 % and 92 % were refused before any generation. The app says so instead of
   showing a draft made from the parts that passed. Finding 13 in
-  `docs/FINDINGS.md` gives the measurement, and the measurement of the MLX
-  models (Qwen, Gemma) that do accept Taglish, on the same meeting against the
-  notes that were written by hand.
+  `docs/FINDINGS.md` gives the measurement, and the measurement of the local
+  models that do accept Taglish, on the same meeting against the notes that
+  were written by hand. **None of those is in the app**, so automatic notes do
+  nothing for a Taglish meeting yet.
 - `transcribe --notes EXPORT.json` drafts the notes for an exported recording
   and scores the draft: how much of each note is in the transcript near its
   timestamp, which language the notes lean to, and how many of the hand-written
   notes in the export the draft also has. `eval/notes_eval.py` does the same
-  with an MLX model, thus a candidate model can be measured before it is wired
-  into the app.
+  with a local model through `mlx_lm`, thus a candidate can be measured before
+  it is wired into the app.
+- **Settings › General › Automatic notes › Draft the notes when a recording is
+  complete** drafts with no button, as soon as a transcript is ready. Off
+  unless you turn it on. **The model never runs during a recording:** an
+  automatic draft waits for the recording to stop, and a draft that is running
+  stops when you press Record, because the speech model and the notes model
+  would share one chip and a late decode is missing words. `AutoDraft` in
+  `TranscriberFlow` is that decision, with a test for each way it can be
+  refused.
+- The review sheet belongs to the recording rather than to the notes pane. An
+  automatic draft finishes whether or not that pane is open, and while the
+  sheet hung off the pane a draft made with it closed was invisible.
 - The pipeline is behind a fourth engine protocol, `NotesGenerating`, beside
   the three for speech, voice activity and speakers. A second backend is a new
   conformance.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,11 +46,11 @@ deliberate, and you must keep this property. Refer to "The five layers".
 Run each command that applies to your change:
 
 ```bash
-cd app && swift build && swift test    # 360 tests, and 0 warnings
+cd app && swift build && swift test    # 369 tests, and 0 warnings
 ./.venv/bin/python -m pytest           # 75 tests
 ```
 
-The 360 tests are 332 XCTest tests and 28 swift-testing tests. Keep
+The 369 tests are 341 XCTest tests and 28 swift-testing tests. Keep
 `swift build` at **zero warnings**. There is no linter and no formatter for
 either language. Write code in the style of the code around it.
 `.editorconfig` gives the indentation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,11 +46,11 @@ deliberate, and you must keep this property. Refer to "The five layers".
 Run each command that applies to your change:
 
 ```bash
-cd app && swift build && swift test    # 327 tests, and 0 warnings
+cd app && swift build && swift test    # 360 tests, and 0 warnings
 ./.venv/bin/python -m pytest           # 75 tests
 ```
 
-The 327 tests are 299 XCTest tests and 28 swift-testing tests. Keep
+The 360 tests are 332 XCTest tests and 28 swift-testing tests. Keep
 `swift build` at **zero warnings**. There is no linter and no formatter for
 either language. Write code in the style of the code around it.
 `.editorconfig` gives the indentation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,18 +39,18 @@ cd .. && python3 -m venv .venv
 ```
 
 Neither test suite needs model weights, a microphone or a network. This is
-deliberate, and you must keep this property. Refer to "The four layers".
+deliberate, and you must keep this property. Refer to "The five layers".
 
 ## Before you open a pull request
 
 Run each command that applies to your change:
 
 ```bash
-cd app && swift build && swift test    # 301 tests, and 0 warnings
+cd app && swift build && swift test    # 327 tests, and 0 warnings
 ./.venv/bin/python -m pytest           # 75 tests
 ```
 
-The 301 tests are 273 XCTest tests and 28 swift-testing tests. Keep
+The 327 tests are 299 XCTest tests and 28 swift-testing tests. Keep
 `swift build` at **zero warnings**. There is no linter and no formatter for
 either language. Write code in the style of the code around it.
 `.editorconfig` gives the indentation.
@@ -59,9 +59,9 @@ CI (`.github/workflows/app.yml`) builds the app, runs `swift test`, and
 assembles the release bundle. It does this on each push and each pull request
 that touches `app/`. CI needs no secrets, thus it also runs on a fork.
 
-## The four layers
+## The five layers
 
-`app/Sources/` has four layers. Each layer must build and be testable without
+`app/Sources/` has five layers. Each layer must build and be testable without
 the layer above it:
 
 | Layer | Can depend on | Must not touch |
@@ -69,7 +69,12 @@ the layer above it:
 | `TranscriberCore` | nothing | AVFoundation, CoreML, SwiftUI, SwiftData, models |
 | `TranscriberStore` | Core | inference of any kind |
 | `TranscriberEngine` | Core | SwiftUI |
-| `Transcriber` | Core, Store, Engine | — |
+| `TranscriberFlow` | Core, Store, Engine | SwiftUI, AppKit |
+| `Transcriber` | Core, Store, Engine, Flow | — |
+
+Put a decision of the app in `TranscriberFlow` with a test, and not in a view
+or in `AppState`. `JobCoordinator`, `RecordingDisplayStatus` and `StopPlan` are
+the pattern.
 
 This split lets you test the commit policy, the segment merger, the exporters
 and the search index on a Mac that has no microphone and no model weights.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ No recording, no transcript and no note goes off your Mac.
 - Meeting notes: a summary and five lists, which are key points, decisions,
   action items, questions and follow-ups. Each item keeps the timestamp and the
   transcript line that it came from.
+- A draft of the notes from the Apple Intelligence model on this Mac, on
+  macOS 26, with a review before anything is written. The Apple model does not
+  accept Tagalog; the measurement of the models that do is in the findings.
 - Transcript editing, with revisions and one-step undo for each turn. One
   turn can be transcribed again on another tier, without the rest of the
   meeting.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ development workflow.
 ```
 SwiftUI              the window, the library and the transcript view
   ↓
+TranscriberFlow      the decisions of the app: jobs, status, the stop of a recording
+  ↓
 TranscriberStore     the SwiftData schema and the queries
   ↓
 TranscriberCore      the commit policy, the merger, the exports and the search
@@ -94,7 +96,7 @@ TranscriberEngine    the audio, the models and the job queue
   └── FluidAudio     voice activity detection and speaker identification
 ```
 
-There are four layers. Each layer builds and tests without the layer above it.
+There are five layers. Each layer builds and tests without the layer above it.
 Three protocols hide the engines, thus you can replace a backend without a
 change to the user interface.
 
@@ -140,7 +142,7 @@ encryption of its own, thus FileVault is the only protection.
 | Document | Contents |
 | --- | --- |
 | [docs/USAGE.md](docs/USAGE.md) | What each part of the app does, and the keyboard |
-| [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) | The four layers, the pipelines and the algorithms |
+| [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) | The five layers, the pipelines and the algorithms |
 | [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) | Build, tests, CI, scripts and the workflow |
 | [docs/MODELS.md](docs/MODELS.md) | The three tiers, the model IDs and the naming trap |
 | [docs/CLI.md](docs/CLI.md) | The `transcribe` command-line tool |

--- a/app/Package.swift
+++ b/app/Package.swift
@@ -6,6 +6,8 @@ import PackageDescription
 //   TranscriberCore    pure logic. No AV, no CoreML, no UI, no models.
 //   TranscriberStore   SwiftData schema + queries. No inference.
 //   TranscriberEngine  audio I/O and the ASR/VAD/diarization backends.
+//   TranscriberFlow    the app's decisions with no window: the job coordinator,
+//                      the display status of a recording, the stop plan.
 //   Transcriber        the SwiftUI app.
 //
 // The split is what keeps the commit policy, the merger and the exporters
@@ -44,9 +46,19 @@ let package = Package(
             ],
             swiftSettings: [.swiftLanguageMode(.v6)]
         ),
+        .target(
+            name: "TranscriberFlow",
+            dependencies: ["TranscriberCore", "TranscriberStore", "TranscriberEngine"],
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                // The same isolation as the app: what lives here drives the
+                // views and is observed by them.
+                .defaultIsolation(MainActor.self),
+            ]
+        ),
         .executableTarget(
             name: "Transcriber",
-            dependencies: ["TranscriberCore", "TranscriberStore", "TranscriberEngine"],
+            dependencies: ["TranscriberCore", "TranscriberStore", "TranscriberEngine", "TranscriberFlow"],
             swiftSettings: [
                 .swiftLanguageMode(.v6),
                 // SwiftUI views, @Observable app state and SwiftData contexts are
@@ -72,6 +84,11 @@ let package = Package(
         .testTarget(
             name: "TranscriberStoreTests",
             dependencies: ["TranscriberStore", "TranscriberCore"],
+            swiftSettings: [.swiftLanguageMode(.v6)]
+        ),
+        .testTarget(
+            name: "TranscriberFlowTests",
+            dependencies: ["TranscriberFlow", "TranscriberCore", "TranscriberStore", "TranscriberEngine"],
             swiftSettings: [.swiftLanguageMode(.v6)]
         ),
     ]

--- a/app/Sources/Transcriber/AppCommands.swift
+++ b/app/Sources/Transcriber/AppCommands.swift
@@ -96,6 +96,16 @@ struct AppCommands: Commands {
                 .keyboardShortcut(shortcut(for: kind), modifiers: [.command, .control])
                 .disabled(state.selectedSegmentId == nil)
             }
+
+            if state.canDraftNotes {
+                Divider()
+                Button("Draft Notes from the Transcript") {
+                    if let recording = state.selectedRecording { state.draftNotes(for: recording) }
+                }
+                .keyboardShortcut("d", modifiers: [.command, .shift])
+                .disabled(state.selectedRecording?.transcript == nil
+                          || state.selectedRecording.map { state.notes.isBusy($0.id) } ?? true)
+            }
         }
 
         CommandMenu("Playback") {

--- a/app/Sources/Transcriber/AppCommands.swift
+++ b/app/Sources/Transcriber/AppCommands.swift
@@ -25,7 +25,7 @@ struct AppCommands: Commands {
             // ⌘R records in both modes. Simple mode makes a meeting, which
             // opens with the notes beside the transcript.
             Button(state.settings.isAdvanced ? "New Recording" : "Record") {
-                state.newItem(state.settings.isAdvanced ? .recording : .meeting)
+                state.newItem(state.newRecordingKind)
             }
             .keyboardShortcut("r")
             if state.settings.isAdvanced {

--- a/app/Sources/Transcriber/AppState+Library.swift
+++ b/app/Sources/Transcriber/AppState+Library.swift
@@ -3,6 +3,7 @@ import SwiftData
 import SwiftUI
 import TranscriberCore
 import TranscriberEngine
+import TranscriberFlow
 import TranscriberStore
 import UniformTypeIdentifiers
 
@@ -100,7 +101,8 @@ extension AppState {
                               modelId: String? = nil,
                               diarizationMode: DiarizationMode? = nil) {
         guard let name = recording.audioFileName else { return }
-        warnings[recording.id] = nil
+        // The row's stored warning goes at once; the coordinator clears its own
+        // copy when it takes the job.
         recording.warningMessage = nil
         let job = TranscriptionJob(
             id: recording.id,
@@ -117,9 +119,7 @@ extension AppState {
             expectedSpeakers: recording.expectedSpeakers,
             lanes: recording.lanes
         )
-        progress[recording.id] = JobProgress(status: .pending, fraction: 0)
-        queuedJobs[recording.id] = job
-        Task { await queue.enqueue(job) }
+        jobs.enqueue(job)
     }
 
     /// Decode again, optionally on a named tier. Nil means the tier Settings
@@ -136,7 +136,7 @@ extension AppState {
     /// with the turn's speaker on them.
     func retranscribe(_ recording: StoredRecording, turn block: TranscriptBlock,
                       tier: ModelTier = .accurate) {
-        guard let name = recording.audioFileName, progress[recording.id] == nil else { return }
+        guard let name = recording.audioFileName, !jobs.isBusy(recording.id) else { return }
         let job = TranscriptionJob(
             id: recording.id,
             title: recording.title,
@@ -152,9 +152,7 @@ extension AppState {
             roomMode: settings.roomMode,
             lanes: recording.lanes
         )
-        progress[recording.id] = JobProgress(status: .pending, fraction: 0)
-        queuedJobs[recording.id] = job
-        Task { await queue.enqueue(job) }
+        jobs.enqueue(job)
     }
 
     /// Speaker identification only, over the transcript that exists. Forced on
@@ -166,7 +164,7 @@ extension AppState {
     }
 
     func cancelJob(_ id: UUID) {
-        Task { await queue.cancel(id) }
+        jobs.cancel(id)
     }
 
     // MARK: - Deleting

--- a/app/Sources/Transcriber/AppState+Models.swift
+++ b/app/Sources/Transcriber/AppState+Models.swift
@@ -78,6 +78,7 @@ extension AppState {
                                           modelsDirectory: Paths.models) else { return }
         warmup = Task { [weak self] in
             guard let self else { return }
+            live.configure(settings.liveConfiguration)
             await live.prepare(model: settings.liveModelId)
         }
     }

--- a/app/Sources/Transcriber/AppState+Notes.swift
+++ b/app/Sources/Transcriber/AppState+Notes.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftData
 import TranscriberCore
 import TranscriberEngine
 import TranscriberFlow
@@ -56,6 +57,61 @@ extension AppState {
                              message: error.localizedDescription)
         }
         notes.dismiss(recording.id)
+    }
+
+    // MARK: - Drafting by itself
+
+    /// A transcription job left the queue. Draft the notes if everything
+    /// `AutoDraft` asks for is true.
+    ///
+    /// Availability is awaited first, so "Apple Intelligence is off" skips
+    /// quietly here rather than posting a failure into the pane of every
+    /// recording the user makes.
+    func autoDraftNotes(for id: UUID) {
+        guard settings.autoDraftNotes, let engine = Self.notesEngine else { return }
+        Task {
+            let ready = await engine.availability().isAvailable
+            // The status and the rows are read from a context of their own.
+            // The queue emits `.completed` and then `.finished`, and the
+            // status is written by the writer actor on its own context; the
+            // main context has not necessarily merged that by the time this
+            // runs, and a stale read here skips the draft on every recording.
+            let state = committedState(of: id)
+            let decision = AutoDraft.decide(
+                enabled: settings.autoDraftNotes,
+                hasModel: ready,
+                status: state.status,
+                hasTranscript: state.hasTranscript,
+                isRecording: isLiveBusy,
+                hasDraft: notes.state(for: id) != nil
+            )
+            guard decision.isDraft, let recording = recording(id) else { return }
+            draftNotes(for: recording)
+        }
+    }
+
+    /// The recording's status and whether it has any transcript rows, read
+    /// from a fresh context so the values are the ones on disk.
+    private func committedState(of id: UUID) -> (status: TranscriptionStatus, hasTranscript: Bool) {
+        let context = ModelContext(container)
+        var descriptor = FetchDescriptor<StoredRecording>(predicate: #Predicate { $0.id == id })
+        descriptor.fetchLimit = 1
+        guard let row = try? context.fetch(descriptor).first else { return (.failed, false) }
+        let hasRows = row.transcript.map { transcript in
+            ((try? TranscriptReader.segmentRows(ofTranscript: transcript.id, in: context)) ?? []).isEmpty == false
+        } ?? false
+        return (row.status, hasRows)
+    }
+
+    /// Stops any draft when a recording starts.
+    ///
+    /// The decision above keeps a draft from starting during a recording. This
+    /// is the other order: a draft already running when the user hits Record.
+    /// The live decoder needs the chip more, and a draft is cheap to repeat.
+    func stopNotesForRecording() {
+        for (id, state) in notes.states {
+            if case .running = state { notes.cancel(id) }
+        }
     }
 
     /// What the review sheet and the settings call the backend.

--- a/app/Sources/Transcriber/AppState+Notes.swift
+++ b/app/Sources/Transcriber/AppState+Notes.swift
@@ -1,0 +1,65 @@
+import Foundation
+import TranscriberCore
+import TranscriberEngine
+import TranscriberFlow
+import TranscriberStore
+
+/// Automatic notes: a draft from the model on this Mac, reviewed before any
+/// of it is written. The coordinator holds the draft; this is the glue to
+/// the store and the settings.
+extension AppState {
+
+    /// The backend for automatic notes in this build, on this macOS. Nil on
+    /// macOS 15, where the pane shows no button. Whether the model can run
+    /// today is `notesAvailability()`.
+    static let notesEngine: (any NotesGenerating)? = NotesEngines.systemModel()
+
+    var canDraftNotes: Bool { Self.notesEngine != nil }
+
+    func notesAvailability() async -> NotesAvailability {
+        guard let engine = Self.notesEngine else { return .needsNewerMacOS }
+        return await engine.availability()
+    }
+
+    /// Starts a draft from the latest transcript. The rows are read off the
+    /// main actor, as the transcript view reads them, and handed to the
+    /// coordinator as values.
+    func draftNotes(for recording: StoredRecording) {
+        guard let engine = Self.notesEngine, let transcript = recording.transcript,
+              !notes.isBusy(recording.id) else { return }
+        let id = recording.id
+        let title = recording.title
+        let transcriptId = transcript.id
+        let speakers = (recording.speakers ?? [])
+            .sorted { $0.colorIndex < $1.colorIndex }
+            .map { SpeakerLabel(id: $0.speakerId, displayName: $0.displayName, speechMs: $0.speechMs) }
+        let style = settings.notesStyle
+        let reader = makeReader()
+        Task {
+            do {
+                let segments = try await reader.segments(ofTranscript: transcriptId)
+                notes.generate(id: id, title: title, segments: segments, speakers: speakers,
+                               style: style, using: engine)
+            } catch {
+                alert = AppAlert(title: "The app could not read the transcript",
+                                 message: error.localizedDescription)
+            }
+        }
+    }
+
+    /// Writes the part of the draft the user kept, and closes the review.
+    func acceptNotes(_ items: [NotesDraft.Item], summary: String?, for recording: StoredRecording) {
+        do {
+            try RecordingStore.apply(items, summary: summary, to: recording, in: context)
+        } catch {
+            alert = AppAlert(title: "The app could not add the notes",
+                             message: error.localizedDescription)
+        }
+        notes.dismiss(recording.id)
+    }
+
+    /// What the review sheet and the settings call the backend.
+    static func notesModelLabel(_ modelId: String) -> String {
+        modelId == "apple-foundation-model" ? "the Apple Intelligence model" : modelId
+    }
+}

--- a/app/Sources/Transcriber/AppState+Recording.swift
+++ b/app/Sources/Transcriber/AppState+Recording.swift
@@ -47,6 +47,10 @@ extension AppState {
             )
             return
         }
+        // A draft that is running would compete with the live decoder for the
+        // GPU, and a late hop is dropped words. Refer to `AutoDraft`.
+        stopNotesForRecording()
+
         let id = recording.id
         activeRecordingId = id
         let name = Paths.newRecordingName(id: id, ext: "m4a", on: recording.createdAt)

--- a/app/Sources/Transcriber/AppState+Recording.swift
+++ b/app/Sources/Transcriber/AppState+Recording.swift
@@ -3,6 +3,7 @@ import SwiftData
 import SwiftUI
 import TranscriberCore
 import TranscriberEngine
+import TranscriberFlow
 import TranscriberStore
 
 /// The live session from the tap on New Recording to the row it leaves behind,
@@ -96,6 +97,8 @@ extension AppState {
         }
     }
 
+    /// Stops the session and carries out the plan for what it left behind.
+    /// The decisions are `StopPlan.make`; this method is the awaits.
     func stopRecording() async {
         let finished = await live.stop()
         live.onCommitted = nil
@@ -104,36 +107,35 @@ extension AppState {
         activeRecordingId = nil
         guard let result = finished else { return }
         await engines.endLive()
-        let decodedLive = live.decodeLive
+        let id = result.recordingId
+
+        let plan = StopPlan.make(
+            result: result, decodedLive: live.decodeLive, hadPersister: persister != nil,
+            diarizationMode: settings.diarizationMode, keepWorkingCopy: settings.keepWorkingCopy,
+            shortTakeMs: Self.shortTakeMs
+        )
 
         // A thrown decode is counted, not shown, during the session -- here is
-        // where it has to surface. Without this, a backend that failed on
-        // every hop produces a completed recording with an empty transcript.
-        if decodedLive, result.stats.failedHops > 0 {
-            let detail = result.stats.lastError.map { " Last error: \($0)" } ?? ""
-            await jobs.addWarning(result.stats.hops == 0
-                ? "Live transcription failed for this entire recording "
-                  + "(\(result.stats.failedHops) decode errors).\(detail) "
-                  + "The audio was saved. Use Transcribe Again to recover it."
-                : "\(result.stats.failedHops) decode(s) failed during this "
-                  + "recording, so some words may be missing.\(detail)",
-                for: result.recordingId)
+        // where it surfaces. Without it, a backend that failed on every hop
+        // produces a completed recording with an empty transcript.
+        if let warning = plan.liveFailureWarning {
+            await jobs.addWarning(warning, for: id)
         }
 
-        if decodedLive {
+        switch plan.transcript {
+        case .completePersister:
             // The final list replaces the rows written during the recording,
-            // through the same call the whole-file job uses; with no open
-            // revision it stores a fresh one, as before.
-            if let persister {
-                _ = try? await persister.complete(segments: result.segments,
-                                                  processMs: result.stats.totalInferMs)
-            } else {
-                _ = try? await writer.storeTranscript(
-                    segments: result.segments, roster: [], modelId: result.modelId,
-                    language: result.language, processMs: result.stats.totalInferMs,
-                    didDiarize: false, for: result.recordingId
-                )
-            }
+            // through the same call the whole-file job uses.
+            _ = try? await persister?.complete(segments: result.segments,
+                                               processMs: result.stats.totalInferMs)
+        case .storeFresh:
+            _ = try? await writer.storeTranscript(
+                segments: result.segments, roster: [], modelId: result.modelId,
+                language: result.language, processMs: result.stats.totalInferMs,
+                didDiarize: false, for: id
+            )
+        case .none:
+            break
         }
         try? await writer.attachAudio(
             fileName: result.archiveFileName ?? "",
@@ -141,64 +143,45 @@ extension AppState {
             durationMs: result.durationMs,
             waveform: result.waveform.isEmpty ? nil : result.waveform,
             lanes: result.lanes,
-            for: result.recordingId
+            for: id
         )
 
-        // A two-lane recording always gets the whole-file pass, even when the
-        // live decoder already produced a transcript. Live decoding runs on
-        // the two lanes summed -- one stream, because that is what a live
-        // transcript can afford -- so what it produced has no idea which side
-        // of the meeting each line came from. Only the whole-file pass reads
-        // the channels apart, and it is the better transcript in any case.
-        if !decodedLive || result.lanes.count > 1 {
-            // Capture-only session: the whole-file pass is the transcript.
-            // The working copy it needs is the one the session just wrote.
-            if let stored = recording(result.recordingId) {
+        switch plan.followUp {
+        case .fullTranscription:
+            // The working copy the pass needs is the one the session wrote.
+            if let stored = recording(id) {
                 enqueueTranscription(stored, work: .full)
             }
-        } else if settings.diarizationMode.performsDiarization {
-            let job = TranscriptionJob(
-                id: result.recordingId,
-                title: recording(result.recordingId)?.title ?? "Recording",
+        case .diarizeOnly(let mode):
+            jobs.enqueue(TranscriptionJob(
+                id: id,
+                title: recording(id)?.title ?? "Recording",
                 sourceURL: result.archiveFileName.map { Paths.recordingURL($0) },
                 cacheURL: result.cacheURL,
                 modelId: result.modelId,
                 language: result.language,
-                diarizationMode: settings.diarizationMode,
+                diarizationMode: mode,
                 work: .diarizeOnly,
                 discardCacheWhenDone: !settings.keepWorkingCopy,
-                expectedSpeakers: recording(result.recordingId)?.expectedSpeakers
-            )
-            jobs.enqueue(job)
-        } else {
-            try? await writer.updateStatus(.completed, progress: 1, for: result.recordingId)
-            if !settings.keepWorkingCopy {
+                expectedSpeakers: recording(id)?.expectedSpeakers
+            ))
+        case .markCompleted(let discardCache):
+            try? await writer.updateStatus(.completed, progress: 1, for: id)
+            if discardCache {
                 try? FileManager.default.removeItem(at: result.cacheURL)
             }
         }
-        // What changed under the recording: a microphone that was unplugged
-        // and replaced, a default input that moved, an input that could not
-        // be restarted. Kept with the recording, because the person reading
+
+        // What changed under the recording, kept with it: the person who reads
         // the transcript tomorrow has to know why the room goes quiet at 0:41.
-        // After the enqueue above, which clears the row's warning for the job
-        // it starts; the job's own warnings are added to this one, not put in
-        // its place.
-        if !result.notices.isEmpty {
-            await jobs.addWarning(result.notices.map(\.message).joined(separator: " "),
-                                  for: result.recordingId)
+        // After the enqueue, which clears the warning for the job it starts.
+        if let notices = plan.noticesWarning {
+            await jobs.addWarning(notices, for: id)
         }
         await queue.setLiveActive(false)
 
-        if result.durationMs < Self.shortTakeMs {
-            shortTake = ShortTake(
-                id: result.recordingId,
-                durationMs: result.durationMs,
-                words: decodedLive
-                    ? result.segments.reduce(0) {
-                        $0 + $1.displayText.split(whereSeparator: \.isWhitespace).count
-                    }
-                    : nil
-            )
+        if let take = plan.shortTake {
+            shortTake = ShortTake(id: id, durationMs: take.durationMs, words: take.words)
         }
     }
 

--- a/app/Sources/Transcriber/AppState+Recording.swift
+++ b/app/Sources/Transcriber/AppState+Recording.swift
@@ -111,12 +111,13 @@ extension AppState {
         // every hop produces a completed recording with an empty transcript.
         if decodedLive, result.stats.failedHops > 0 {
             let detail = result.stats.lastError.map { " Last error: \($0)" } ?? ""
-            warnings[result.recordingId] = result.stats.hops == 0
+            await jobs.addWarning(result.stats.hops == 0
                 ? "Live transcription failed for this entire recording "
                   + "(\(result.stats.failedHops) decode errors).\(detail) "
-                  + "The audio was saved -- use Transcribe Again to recover it."
+                  + "The audio was saved. Use Transcribe Again to recover it."
                 : "\(result.stats.failedHops) decode(s) failed during this "
-                  + "recording, so some words may be missing.\(detail)"
+                  + "recording, so some words may be missing.\(detail)",
+                for: result.recordingId)
         }
 
         if decodedLive {
@@ -168,8 +169,7 @@ extension AppState {
                 discardCacheWhenDone: !settings.keepWorkingCopy,
                 expectedSpeakers: recording(result.recordingId)?.expectedSpeakers
             )
-            queuedJobs[job.id] = job
-            await queue.enqueue(job)
+            jobs.enqueue(job)
         } else {
             try? await writer.updateStatus(.completed, progress: 1, for: result.recordingId)
             if !settings.keepWorkingCopy {
@@ -184,11 +184,8 @@ extension AppState {
         // it starts; the job's own warnings are added to this one, not put in
         // its place.
         if !result.notices.isEmpty {
-            let changes = result.notices.map(\.message).joined(separator: " ")
-            let combined = [warnings[result.recordingId], changes]
-                .compactMap { $0 }.joined(separator: " ")
-            warnings[result.recordingId] = combined
-            try? await writer.setWarning(combined, for: result.recordingId)
+            await jobs.addWarning(result.notices.map(\.message).joined(separator: " "),
+                                  for: result.recordingId)
         }
         await queue.setLiveActive(false)
 

--- a/app/Sources/Transcriber/AppState+Recording.swift
+++ b/app/Sources/Transcriber/AppState+Recording.swift
@@ -53,12 +53,7 @@ extension AppState {
         recording.status = .preparing
         try? context.save()
 
-        live.config = settings.sessionConfig
-        live.inputGainDb = settings.inputGainDb
-        live.isRoomMode = settings.roomMode
-        live.decodeLive = settings.liveTranscription
-        live.captureSource = settings.captureSource
-        live.microphoneUID = settings.microphoneUID
+        live.configure(settings.liveConfiguration)
 
         // The tap is global -- it has to be, or it stops delivering whenever
         // this app is the only thing playing -- so anything Notero plays goes

--- a/app/Sources/Transcriber/AppState.swift
+++ b/app/Sources/Transcriber/AppState.swift
@@ -253,6 +253,13 @@ final class AppState {
 
     // MARK: - Creating
 
+    /// What Record makes. Simple mode makes a meeting, which opens with the
+    /// notes beside the transcript; Advanced mode makes a plain recording and
+    /// offers the meeting as its own command.
+    var newRecordingKind: RecordingKind {
+        settings.isAdvanced ? .recording : .meeting
+    }
+
     @discardableResult
     func newItem(_ kind: RecordingKind) -> StoredRecording? {
         do {

--- a/app/Sources/Transcriber/AppState.swift
+++ b/app/Sources/Transcriber/AppState.swift
@@ -36,6 +36,9 @@ final class AppState {
     let queue: TranscriptionQueue
     /// Consumes the queue's events; owns what the views read about jobs.
     let jobs: JobCoordinator
+    /// One draft of automatic notes per recording, from the request to the
+    /// review. Refer to `AppState+Notes`.
+    let notes = NotesCoordinator()
     let live: LiveSession
     let player = AudioPlayer()
     let writer: TranscriptWriter

--- a/app/Sources/Transcriber/AppState.swift
+++ b/app/Sources/Transcriber/AppState.swift
@@ -119,16 +119,32 @@ final class AppState {
     /// split view gives the sidebar and the inspector their widths and lets
     /// the transcript overflow, cropping the window at both edges. Below
     /// `inspectorNeedsWidth` the inspector folds away instead.
-    var contentWidth: CGFloat = .infinity
+    ///
+    /// Written on every resize event. The two flags below are what the views
+    /// read, and they are stored rather than computed so that a reader
+    /// invalidates only when a threshold is crossed, not on every pixel of a
+    /// drag. `@Observable` skips the write when the value is unchanged.
+    var contentWidth: CGFloat = .infinity {
+        didSet {
+            isCompact = contentWidth < Self.sidebarNeedsWidth
+            hasRoomForInspector = contentWidth >= Self.inspectorNeedsWidth
+        }
+    }
     /// Sidebar at its ideal (268), a readable transcript (~450) and the
     /// inspector at its ideal (320), with slack for the dividers.
     static let inspectorNeedsWidth: CGFloat = 1_060
-    var hasRoomForInspector: Bool { contentWidth >= Self.inspectorNeedsWidth }
+    private(set) var hasRoomForInspector = true
     /// Sidebar at its minimum (200) plus a transcript column worth reading.
     /// Below this the sidebar folds and the detail has the window to itself;
     /// the toolbar toggle still brings it back on request.
     static let sidebarNeedsWidth: CGFloat = 800
-    var isCompact: Bool { contentWidth < Self.sidebarNeedsWidth }
+    private(set) var isCompact = false
+
+    /// The transcript turn under the playhead, or nil between turns. Set by
+    /// the transcript view's follower, which is the one view that reads the
+    /// raw playhead. The rows read this instead: it changes when the turn
+    /// changes, not twenty times a second.
+    var playingBlockId: UUID?
 
     /// Per-recording pipeline progress, keyed by recording id.
     var progress: [UUID: JobProgress] = [:]

--- a/app/Sources/Transcriber/AppState.swift
+++ b/app/Sources/Transcriber/AppState.swift
@@ -220,6 +220,22 @@ final class AppState {
     /// Pending questions, asked one at a time.
     var duplicateImports: [DuplicateImport] = []
 
+    // MARK: - Display status
+
+    /// The one ladder for a recording's row, header and empty transcript. The
+    /// warning has one source here: the stored one, else the coordinator's.
+    func displayStatus(for recording: StoredRecording) -> RecordingDisplayStatus {
+        RecordingDisplayStatus.make(
+            status: recording.status,
+            progress: jobs.progress(for: recording.id),
+            isLive: isLive(recording.id),
+            isPaused: isPaused,
+            warning: recording.warningMessage ?? jobs.warning(for: recording.id),
+            hasAudio: recording.hasAudio,
+            errorMessage: recording.errorMessage
+        )
+    }
+
     // MARK: - Lookup
 
     func recording(_ id: UUID) -> StoredRecording? {

--- a/app/Sources/Transcriber/AppState.swift
+++ b/app/Sources/Transcriber/AppState.swift
@@ -4,6 +4,7 @@ import SwiftData
 import SwiftUI
 import TranscriberCore
 import TranscriberEngine
+import TranscriberFlow
 import TranscriberStore
 
 /// Where the detail pane is pointing.
@@ -20,10 +21,12 @@ enum Route: Hashable {
 /// everything else through here.
 ///
 /// The stored state and the small view-facing helpers are here. The larger
-/// concerns each have a file: `AppState+Jobs` consumes the queue's events,
-/// `AppState+Recording` runs the live session, `AppState+Library` imports,
-/// re-runs and deletes, `AppState+Models` manages weights and memory. Members
-/// those files reach are internal rather than private for that reason.
+/// concerns each have a file: `AppState+Recording` runs the live session,
+/// `AppState+Library` imports, re-runs and deletes, `AppState+Models` manages
+/// weights and memory. The queue's events are consumed by `jobs`, a
+/// `JobCoordinator` from TranscriberFlow, which owns the progress, the
+/// warnings and the transcript ticks the views read. Members those files
+/// reach are internal rather than private for that reason.
 @Observable
 final class AppState {
 
@@ -31,6 +34,8 @@ final class AppState {
     let settings: AppSettings
     let engines: EngineHost
     let queue: TranscriptionQueue
+    /// Consumes the queue's events; owns what the views read about jobs.
+    let jobs: JobCoordinator
     let live: LiveSession
     let player = AudioPlayer()
     let writer: TranscriptWriter
@@ -146,15 +151,6 @@ final class AppState {
     /// changes, not twenty times a second.
     var playingBlockId: UUID?
 
-    /// Per-recording pipeline progress, keyed by recording id.
-    var progress: [UUID: JobProgress] = [:]
-    /// Bumped when a job writes rows into a recording's transcript: a batch of
-    /// partial rows, the final rows, the speaker labels. The transcript view
-    /// reads it instead of counting the rows, which is a query it would run
-    /// on every redraw.
-    var transcriptTicks: [UUID: Int] = [:]
-    /// Per-recording notes about work that finished imperfectly.
-    var warnings: [UUID: String] = [:]
     /// The recording the live session is working on, set the moment the user
     /// asks for one rather than when the first sample arrives. `live.recordingId`
     /// only exists once capture starts, which on a cold model is several
@@ -162,35 +158,11 @@ final class AppState {
     /// something for.
     var activeRecordingId: UUID?
 
-    var pump: Task<Void, Never>?
     var warmup: Task<Void, Never>?
 
-    /// Jobs handed to the queue, kept until they finish: `.partial` events
-    /// need the model and language the job was started with.
-    var queuedJobs: [UUID: TranscriptionJob] = [:]
-    /// The revision each running job is appending to, from its first window.
-    var openTranscripts: [UUID: UUID] = [:]
     /// Writes the live session's committed lines as they land, so a crash
     /// mid-meeting keeps everything up to the last commit.
     var livePersister: LiveTranscriptPersister?
-    /// When the current stage of each job began and the last estimate made
-    /// from it. The estimate is smoothed against this.
-    var stageClock: [UUID: StageClock] = [:]
-
-    struct StageClock {
-        var status: TranscriptionStatus
-        var since: Date
-        var remaining: TimeInterval?
-    }
-
-    struct JobProgress: Equatable {
-        var status: TranscriptionStatus
-        var fraction: Double
-        /// Seconds left in this stage, once enough of it has run to say.
-        var remaining: TimeInterval?
-        /// How far into the audio the decode has reached.
-        var coveredMs: Int = 0
-    }
 
     struct AppAlert: Identifiable {
         let id = UUID()
@@ -204,9 +176,12 @@ final class AppState {
         let engines = EngineHost(modelsDirectory: Paths.models,
                                  preferNeuralVAD: settings.neuralVAD)
         self.engines = engines
-        self.queue = TranscriptionQueue(engines: engines)
+        let queue = TranscriptionQueue(engines: engines)
+        let writer = TranscriptWriter(modelContainer: container)
+        self.queue = queue
+        self.writer = writer
+        self.jobs = JobCoordinator(queue: queue, writer: writer)
         self.live = LiveSession(engines: engines, supportDirectory: Paths.support)
-        self.writer = TranscriptWriter(modelContainer: container)
         // The whole configuration, not four of its six fields: the launch
         // warm-up asks the session whether it decodes live, and a session
         // configured by hand once loaded a 1.6 GB model at every launch for
@@ -216,7 +191,7 @@ final class AppState {
         // not survive the last quit, so anything they still claim to be working
         // on is stranded.
         _ = try? RecordingStore.recoverInterrupted(in: container.mainContext)
-        startPump()
+        jobs.start()
     }
 
     /// Persists the gain and pushes it to a session already running, so moving

--- a/app/Sources/Transcriber/AppState.swift
+++ b/app/Sources/Transcriber/AppState.swift
@@ -207,14 +207,11 @@ final class AppState {
         self.queue = TranscriptionQueue(engines: engines)
         self.live = LiveSession(engines: engines, supportDirectory: Paths.support)
         self.writer = TranscriptWriter(modelContainer: container)
-        live.config = settings.sessionConfig
-        live.inputGainDb = settings.inputGainDb
-        live.isRoomMode = settings.roomMode
-        // Read here, not only at the first recording: the launch warm-up asks
-        // the session whether it decodes live, and the session's own default
-        // is yes. With the setting off, a 1.6 GB model loaded at every launch
-        // for a path that was never going to run.
-        live.decodeLive = settings.liveTranscription
+        // The whole configuration, not four of its six fields: the launch
+        // warm-up asks the session whether it decodes live, and a session
+        // configured by hand once loaded a 1.6 GB model at every launch for
+        // a path that was never going to run.
+        live.configure(settings.liveConfiguration)
         // Before any view reads the store: the live session and the queue did
         // not survive the last quit, so anything they still claim to be working
         // on is stranded.

--- a/app/Sources/Transcriber/AppState.swift
+++ b/app/Sources/Transcriber/AppState.swift
@@ -194,6 +194,8 @@ final class AppState {
         // not survive the last quit, so anything they still claim to be working
         // on is stranded.
         _ = try? RecordingStore.recoverInterrupted(in: container.mainContext)
+        // Before the pump starts, so no finished job is missed.
+        jobs.onFinished = { [weak self] id in self?.autoDraftNotes(for: id) }
         jobs.start()
     }
 

--- a/app/Sources/Transcriber/MenuBar.swift
+++ b/app/Sources/Transcriber/MenuBar.swift
@@ -178,7 +178,7 @@ extension AppState {
         if isRecording {
             Task { await stopRecording() }
         } else if !isLiveBusy {
-            newItem(settings.isAdvanced ? .recording : .meeting)
+            newItem(newRecordingKind)
         }
     }
 

--- a/app/Sources/Transcriber/Settings.swift
+++ b/app/Sources/Transcriber/Settings.swift
@@ -64,6 +64,7 @@ final class AppSettings {
         static let hasSeenWelcome = "ui.hasSeenWelcome"
         static let interfaceMode = "ui.interfaceMode"
         static let menuBarItem = "ui.menuBarItem"
+        static let notesStyle = "notes.style"
     }
 
     private let defaults: UserDefaults
@@ -100,6 +101,7 @@ final class AppSettings {
         interfaceMode = InterfaceMode(rawValue: defaults.string(forKey: Key.interfaceMode) ?? "")
             ?? .simple
         menuBarItem = defaults.object(forKey: Key.menuBarItem) as? Bool ?? true
+        notesStyle = NotesStyle(rawValue: defaults.string(forKey: Key.notesStyle) ?? "") ?? .english
     }
 
     // MARK: - Interface
@@ -120,6 +122,11 @@ final class AppSettings {
 
     /// Show transcript times as time of day ("9:47:12 PM") rather than offsets.
     var clockTimestamps: Bool { didSet { defaults.set(clockTimestamps, forKey: Key.clockTimestamps) } }
+
+    /// The language the notes model writes in. English by default: the one
+    /// hand-written set of notes in the library is English with Taglish
+    /// quotes, and that is what the drafts are measured against.
+    var notesStyle: NotesStyle { didSet { defaults.set(notesStyle.rawValue, forKey: Key.notesStyle) } }
 
     /// The first-run card has been dismissed.
     var hasSeenWelcome: Bool { didSet { defaults.set(hasSeenWelcome, forKey: Key.hasSeenWelcome) } }

--- a/app/Sources/Transcriber/Settings.swift
+++ b/app/Sources/Transcriber/Settings.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Observation
 import TranscriberCore
+import TranscriberEngine
 
 /// How much of the app is on show.
 ///
@@ -215,6 +216,14 @@ final class AppSettings {
 
     var sessionConfig: SessionConfig {
         SessionConfig(language: language, prompt: promptOrNil, useNeuralVAD: neuralVAD)
+    }
+
+    /// Everything the live session reads from Settings, in one value. The one
+    /// place the six fields meet; the session takes it whole.
+    var liveConfiguration: LiveConfiguration {
+        LiveConfiguration(session: sessionConfig, decodeLive: liveTranscription,
+                          captureSource: captureSource, microphoneUID: microphoneUID,
+                          inputGainDb: inputGainDb, isRoomMode: roomMode)
     }
 
     // MARK: - Benchmark

--- a/app/Sources/Transcriber/Settings.swift
+++ b/app/Sources/Transcriber/Settings.swift
@@ -65,6 +65,7 @@ final class AppSettings {
         static let interfaceMode = "ui.interfaceMode"
         static let menuBarItem = "ui.menuBarItem"
         static let notesStyle = "notes.style"
+        static let autoDraftNotes = "notes.auto"
     }
 
     private let defaults: UserDefaults
@@ -102,6 +103,7 @@ final class AppSettings {
             ?? .simple
         menuBarItem = defaults.object(forKey: Key.menuBarItem) as? Bool ?? true
         notesStyle = NotesStyle(rawValue: defaults.string(forKey: Key.notesStyle) ?? "") ?? .english
+        autoDraftNotes = defaults.object(forKey: Key.autoDraftNotes) as? Bool ?? false
     }
 
     // MARK: - Interface
@@ -127,6 +129,13 @@ final class AppSettings {
     /// hand-written set of notes in the library is English with Taglish
     /// quotes, and that is what the drafts are measured against.
     var notesStyle: NotesStyle { didSet { defaults.set(notesStyle.rawValue, forKey: Key.notesStyle) } }
+
+    /// Draft the notes as soon as a transcription finishes, with no button.
+    ///
+    /// Off unless asked for, as live text is: it is a minute or two of the
+    /// chip after every recording. It never runs during a recording -- refer
+    /// to `AutoDraft`.
+    var autoDraftNotes: Bool { didSet { defaults.set(autoDraftNotes, forKey: Key.autoDraftNotes) } }
 
     /// The first-run card has been dismissed.
     var hasSeenWelcome: Bool { didSet { defaults.set(hasSeenWelcome, forKey: Key.hasSeenWelcome) } }

--- a/app/Sources/Transcriber/TranscriberApp.swift
+++ b/app/Sources/Transcriber/TranscriberApp.swift
@@ -74,6 +74,7 @@ struct TranscriberApp: App {
         WindowGroup("Notero", id: "main") {
             ContentView()
                 .environment(state)
+                .environment(\.interfaceMode, state.settings.interfaceMode)
                 .modelContainer(state.container)
                 // Small enough to sit beside another window. Below ~700 pt the
                 // sidebar folds, below ~1060 the inspector does; every row in
@@ -105,6 +106,7 @@ struct TranscriberApp: App {
         Settings {
             SettingsView()
                 .environment(state)
+                .environment(\.interfaceMode, state.settings.interfaceMode)
                 .modelContainer(state.container)
         }
 

--- a/app/Sources/Transcriber/Views/Components/InterfaceModeEnvironment.swift
+++ b/app/Sources/Transcriber/Views/Components/InterfaceModeEnvironment.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+extension EnvironmentValues {
+    /// Simple or Advanced, for the views. Set once at the root of each scene
+    /// from Settings; the views read it here rather than reaching into
+    /// `AppState.settings`. The default is a stable enum case, so a reader
+    /// that falls back to it does not invalidate on unrelated writes.
+    @Entry var interfaceMode: InterfaceMode = .simple
+}
+
+extension View {
+    /// Shown in Advanced mode only. The one modifier for the controls that
+    /// Simple mode hides, in place of an `if` at each of them.
+    func advancedOnly() -> some View {
+        modifier(AdvancedOnly())
+    }
+}
+
+private struct AdvancedOnly: ViewModifier {
+    @Environment(\.interfaceMode) private var mode
+
+    func body(content: Content) -> some View {
+        if mode == .advanced {
+            content
+        }
+    }
+}

--- a/app/Sources/Transcriber/Views/Components/PlayerBar.swift
+++ b/app/Sources/Transcriber/Views/Components/PlayerBar.swift
@@ -3,41 +3,21 @@ import TranscriberCore
 import TranscriberStore
 
 /// Transport, scrubber and waveform for a finished recording.
+///
+/// Three views inside read the playhead, which moves twenty times a second:
+/// the waveform's playhead line, the clock, and nothing else. They are their
+/// own view types, so a tick re-runs those two bodies and not the bar with
+/// its buttons, menu and bookmark targets. The bar itself depends on the
+/// recording and on the loaded duration, which change on selection.
 struct PlayerBar: View {
     @Environment(AppState.self) private var state
     let recording: StoredRecording
 
     var body: some View {
-        @Bindable var state = state
-
         VStack(spacing: 8) {
-            WaveformView(
-                samples: recording.waveform ?? [],
-                progress: fraction,
-                bookmarks: bookmarkFractions,
-                showsPlayhead: true,
-                onScrub: { value in
-                    state.seek(to: Int(value * Double(max(1, duration))), in: recording)
-                }
-            )
-            .frame(height: 52)
-            .overlay {
-                // A hover target over each bookmark tick, so the label shows
-                // and a click lands exactly on the moment rather than a few
-                // hundred milliseconds off it.
-                GeometryReader { geometry in
-                    ForEach(sortedBookmarks) { bookmark in
-                        let x = geometry.size.width
-                            * CGFloat(Double(bookmark.atMs) / Double(max(1, duration)))
-                        Color.clear
-                            .frame(width: 10, height: geometry.size.height)
-                            .contentShape(Rectangle())
-                            .help("\(bookmark.displayLabel) · \(TimeFormat.short(ms: bookmark.atMs))")
-                            .onTapGesture { state.seek(to: bookmark.atMs, in: recording) }
-                            .position(x: x, y: geometry.size.height / 2)
-                    }
-                }
-            }
+            PlayheadWaveform(recording: recording, durationMs: duration,
+                             bookmarks: sortedBookmarks)
+                .frame(height: 52)
 
             HStack(spacing: 14) {
                 // Skip buttons go first when the column is narrow; play and
@@ -75,6 +55,7 @@ struct PlayerBar: View {
                 } label: {
                     Image(systemName: "gobackward.10")
                 }
+                .help("Back 10 seconds")
             }
             Button {
                 ensureLoaded()
@@ -85,18 +66,17 @@ struct PlayerBar: View {
                     .frame(width: 26)
             }
             .keyboardShortcut(.return, modifiers: [])
+            .help(state.player.isPlaying ? "Pause" : "Play")
             if withSkips {
                 Button {
                     state.player.skip(seconds: 10)
                 } label: {
                     Image(systemName: "goforward.10")
                 }
+                .help("Forward 10 seconds")
             }
 
-            Text("\(TimeFormat.short(ms: state.player.currentMs)) / \(TimeFormat.short(ms: duration))")
-                .font(.system(.caption, design: .monospaced))
-                .foregroundStyle(.secondary)
-                .monospacedDigit()
+            PlaybackClock(durationMs: duration)
         }
         .fixedSize()
     }
@@ -117,7 +97,7 @@ struct PlayerBar: View {
                 Label("Follow", systemImage: "text.line.first.and.arrowtriangle.forward")
             }
             .toggleStyle(.button)
-            .help("Keep the playing line in view. Scrolling by hand turns this off.")
+            .help("Keep the line that plays in view. A scroll by hand turns this off.")
 
             Button {
                 _ = state.addBookmark()
@@ -147,21 +127,80 @@ struct PlayerBar: View {
         max(state.player.durationMs, recording.durationMs)
     }
 
-    private var fraction: Double {
-        duration > 0 ? Double(state.player.currentMs) / Double(duration) : 0
-    }
-
     private var sortedBookmarks: [StoredBookmark] {
         (recording.bookmarks ?? []).sorted { $0.atMs < $1.atMs }
-    }
-
-    private var bookmarkFractions: [Double] {
-        guard duration > 0 else { return [] }
-        return sortedBookmarks.map { Double($0.atMs) / Double(duration) }
     }
 
     private func ensureLoaded() {
         guard let url = recording.audioURL, state.player.loadedURL != url else { return }
         _ = state.player.load(url)
+    }
+}
+
+/// "0:42 / 1:15". The one text that changes with every tick.
+private struct PlaybackClock: View {
+    @Environment(AppState.self) private var state
+    let durationMs: Int
+
+    var body: some View {
+        Text("\(TimeFormat.short(ms: state.player.currentMs)) / \(TimeFormat.short(ms: durationMs))")
+            .font(.system(.caption, design: .monospaced))
+            .foregroundStyle(.secondary)
+            .monospacedDigit()
+    }
+}
+
+/// The waveform with the playhead line over it, and one target on each
+/// bookmark tick. The playhead is why this view reads the player; the
+/// targets are a separate view again so their layout does not re-run with it.
+private struct PlayheadWaveform: View {
+    @Environment(AppState.self) private var state
+    let recording: StoredRecording
+    let durationMs: Int
+    let bookmarks: [StoredBookmark]
+
+    var body: some View {
+        WaveformView(
+            samples: recording.waveform ?? [],
+            progress: durationMs > 0 ? Double(state.player.currentMs) / Double(durationMs) : 0,
+            bookmarks: bookmarks.map { Double($0.atMs) / Double(max(1, durationMs)) },
+            showsPlayhead: true,
+            onScrub: { value in
+                state.seek(to: Int(value * Double(max(1, durationMs))), in: recording)
+            }
+        )
+        .overlay {
+            BookmarkTargets(recording: recording, durationMs: durationMs, bookmarks: bookmarks)
+        }
+    }
+}
+
+/// A hover target over each bookmark tick, so the label shows and a click
+/// lands exactly on the moment rather than a few hundred milliseconds off it.
+/// Buttons, not tap gestures: they carry the label for assistive technology.
+private struct BookmarkTargets: View {
+    @Environment(AppState.self) private var state
+    let recording: StoredRecording
+    let durationMs: Int
+    let bookmarks: [StoredBookmark]
+
+    var body: some View {
+        GeometryReader { geometry in
+            ForEach(bookmarks) { bookmark in
+                let x = geometry.size.width
+                    * CGFloat(Double(bookmark.atMs) / Double(max(1, durationMs)))
+                Button {
+                    state.seek(to: bookmark.atMs, in: recording)
+                } label: {
+                    Color.clear
+                        .frame(width: 10, height: geometry.size.height)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .help("\(bookmark.displayLabel) · \(TimeFormat.short(ms: bookmark.atMs))")
+                .accessibilityLabel(bookmark.displayLabel)
+                .position(x: x, y: geometry.size.height / 2)
+            }
+        }
     }
 }

--- a/app/Sources/Transcriber/Views/Components/PlayerBar.swift
+++ b/app/Sources/Transcriber/Views/Components/PlayerBar.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import TranscriberCore
+import TranscriberEngine
 import TranscriberStore
 
 /// Transport, scrubber and waveform for a finished recording.
@@ -15,7 +16,7 @@ struct PlayerBar: View {
 
     var body: some View {
         VStack(spacing: 8) {
-            PlayheadWaveform(recording: recording, durationMs: duration,
+            PlayheadWaveform(player: state.player, recording: recording, durationMs: duration,
                              bookmarks: sortedBookmarks)
                 .frame(height: 52)
 
@@ -76,7 +77,7 @@ struct PlayerBar: View {
                 .help("Forward 10 seconds")
             }
 
-            PlaybackClock(durationMs: duration)
+            PlaybackClock(player: state.player, durationMs: duration)
         }
         .fixedSize()
     }
@@ -139,11 +140,11 @@ struct PlayerBar: View {
 
 /// "0:42 / 1:15". The one text that changes with every tick.
 private struct PlaybackClock: View {
-    @Environment(AppState.self) private var state
+    let player: AudioPlayer
     let durationMs: Int
 
     var body: some View {
-        Text("\(TimeFormat.short(ms: state.player.currentMs)) / \(TimeFormat.short(ms: durationMs))")
+        Text("\(TimeFormat.short(ms: player.currentMs)) / \(TimeFormat.short(ms: durationMs))")
             .font(.system(.caption, design: .monospaced))
             .foregroundStyle(.secondary)
             .monospacedDigit()
@@ -155,6 +156,7 @@ private struct PlaybackClock: View {
 /// targets are a separate view again so their layout does not re-run with it.
 private struct PlayheadWaveform: View {
     @Environment(AppState.self) private var state
+    let player: AudioPlayer
     let recording: StoredRecording
     let durationMs: Int
     let bookmarks: [StoredBookmark]
@@ -162,7 +164,7 @@ private struct PlayheadWaveform: View {
     var body: some View {
         WaveformView(
             samples: recording.waveform ?? [],
-            progress: durationMs > 0 ? Double(state.player.currentMs) / Double(durationMs) : 0,
+            progress: durationMs > 0 ? Double(player.currentMs) / Double(durationMs) : 0,
             bookmarks: bookmarks.map { Double($0.atMs) / Double(max(1, durationMs)) },
             showsPlayhead: true,
             onScrub: { value in

--- a/app/Sources/Transcriber/Views/Components/RecordingInfoBar.swift
+++ b/app/Sources/Transcriber/Views/Components/RecordingInfoBar.swift
@@ -11,6 +11,7 @@ import TranscriberStore
 /// out is an expensive way to answer it.
 struct RecordingInfoBar: View {
     @Environment(AppState.self) private var state
+    @Environment(\.interfaceMode) private var mode
     let recording: StoredRecording
     /// The revision on show in the transcript. Nil is the latest.
     @Binding var revision: Int?
@@ -39,13 +40,13 @@ struct RecordingInfoBar: View {
          String(recording.updatedAt.timeIntervalSinceReferenceDate),
          recording.statusRaw,
          String(recording.durationMs),
-         state.settings.interfaceMode.rawValue].joined(separator: "|")
+         mode.rawValue].joined(separator: "|")
     }
 
     /// The model, the decode cost and the revisions are for the Advanced
     /// mode. In Simple mode the bar gives the date, the length, the language
     /// and the word count.
-    private var technical: Bool { state.settings.isAdvanced }
+    private var technical: Bool { mode == .advanced }
 
     var body: some View {
         HStack(spacing: 6) {

--- a/app/Sources/Transcriber/Views/Components/RecordingInfoBar.swift
+++ b/app/Sources/Transcriber/Views/Components/RecordingInfoBar.swift
@@ -35,7 +35,7 @@ struct RecordingInfoBar: View {
          shown?.id.uuidString ?? "-",
          // Rows arrive in batches while a job runs; the word count follows
          // them. The tick moves with each batch, and it costs no query.
-         String(state.transcriptTicks[recording.id] ?? 0),
+         String(state.jobs.tick(for: recording.id)),
          String(recording.updatedAt.timeIntervalSinceReferenceDate),
          recording.statusRaw,
          String(recording.durationMs),

--- a/app/Sources/Transcriber/Views/ContentView.swift
+++ b/app/Sources/Transcriber/Views/ContentView.swift
@@ -7,6 +7,7 @@ import UniformTypeIdentifiers
 
 struct ContentView: View {
     @Environment(AppState.self) private var state
+    @Environment(\.interfaceMode) private var mode
     @State private var columnVisibility = NavigationSplitViewVisibility.all
     /// What the user last chose while there was room, restored on widening.
     @State private var wideVisibility = NavigationSplitViewVisibility.all
@@ -210,7 +211,7 @@ struct ContentView: View {
 
     @ToolbarContentBuilder
     private var toolbar: some ToolbarContent {
-        if state.settings.isAdvanced {
+        if mode == .advanced {
             ToolbarItem(placement: .primaryAction) {
                 Menu {
                     Button("Recording", systemImage: RecordingKind.recording.symbol) {

--- a/app/Sources/Transcriber/Views/ContentView.swift
+++ b/app/Sources/Transcriber/Views/ContentView.swift
@@ -7,7 +7,6 @@ import UniformTypeIdentifiers
 
 struct ContentView: View {
     @Environment(AppState.self) private var state
-    @Environment(\.modelContext) private var context
     @State private var columnVisibility = NavigationSplitViewVisibility.all
     /// What the user last chose while there was room, restored on widening.
     @State private var wideVisibility = NavigationSplitViewVisibility.all

--- a/app/Sources/Transcriber/Views/DetailView.swift
+++ b/app/Sources/Transcriber/Views/DetailView.swift
@@ -365,6 +365,18 @@ struct RecordingDetailView: View {
         .onChange(of: showInspector) { _, shown in
             if let shown { state.settings.setInspectorShown(shown, for: recording.kind) }
         }
+        // The review of a draft, on the recording and not on the notes pane.
+        // An automatic draft finishes whether or not that pane is open, and a
+        // draft nobody is shown is two minutes of the GPU for nothing.
+        // Closing the sheet any way other than a button is a dismiss.
+        .sheet(isPresented: Binding(
+            get: { state.notes.draft(for: recording.id) != nil },
+            set: { if !$0 { state.notes.dismiss(recording.id) } }
+        )) {
+            if let draft = state.notes.draft(for: recording.id) {
+                NotesDraftSheet(recording: recording, draft: draft)
+            }
+        }
         .toolbar {
             ToolbarItem {
                 Button {

--- a/app/Sources/Transcriber/Views/DetailView.swift
+++ b/app/Sources/Transcriber/Views/DetailView.swift
@@ -420,33 +420,27 @@ struct RecordingDetailView: View {
 
     @ViewBuilder
     private var headerControls: some View {
+        let display = state.displayStatus(for: recording)
         HStack(alignment: .firstTextBaseline, spacing: 12) {
-            if let progress = state.jobs.progress(for: recording.id) {
-                StatusChip(status: progress.status, fraction: progress.fraction,
-                           remaining: progress.remaining)
-                Button("Cancel") { state.cancelJob(recording.id) }
-                    .buttonStyle(.borderless)
-                    .font(.caption)
-            } else if recording.status.isBusy {
-                // Live work never reaches the queue, so it has no progress
-                // entry. Without this fallback the preparing and recording
-                // phases show no chip at all.
-                StatusChip(status: recording.status)
-            } else if recording.status == .failed {
-                StatusChip(status: .failed)
-                if recording.hasAudio { rerun("Retry") }
-            } else if recording.status == .cancelled {
-                StatusChip(status: .cancelled)
-                if recording.hasAudio { rerun("Transcribe") }
-            } else if let warning = recording.warningMessage ?? state.jobs.warning(for: recording.id) {
+            if let chip = display.chip {
+                StatusChip(status: chip.status, fraction: chip.fraction, remaining: chip.remaining)
+            }
+            if let warning = display.warning, !display.isBusy {
                 Label(warning, systemImage: "exclamationmark.triangle.fill")
                     .font(.caption)
                     .foregroundStyle(.orange)
                     .lineLimit(2)
                     .help(warning)
-                if recording.hasAudio { rerun("Transcribe Again") }
-            } else if recording.hasAudio {
-                rerun("Transcribe Again")
+            }
+            switch display.action {
+            case .cancel:
+                Button("Cancel") { state.cancelJob(recording.id) }
+                    .buttonStyle(.borderless)
+                    .font(.caption)
+            case .retry: rerun("Retry")
+            case .transcribe: rerun("Transcribe")
+            case .transcribeAgain: rerun("Transcribe Again")
+            case nil: EmptyView()
             }
 
             // Click exports; the arrow offers the clipboard. Copy is the more

--- a/app/Sources/Transcriber/Views/DetailView.swift
+++ b/app/Sources/Transcriber/Views/DetailView.swift
@@ -421,7 +421,7 @@ struct RecordingDetailView: View {
     @ViewBuilder
     private var headerControls: some View {
         HStack(alignment: .firstTextBaseline, spacing: 12) {
-            if let progress = state.progress[recording.id] {
+            if let progress = state.jobs.progress(for: recording.id) {
                 StatusChip(status: progress.status, fraction: progress.fraction,
                            remaining: progress.remaining)
                 Button("Cancel") { state.cancelJob(recording.id) }
@@ -438,7 +438,7 @@ struct RecordingDetailView: View {
             } else if recording.status == .cancelled {
                 StatusChip(status: .cancelled)
                 if recording.hasAudio { rerun("Transcribe") }
-            } else if let warning = recording.warningMessage ?? state.warnings[recording.id] {
+            } else if let warning = recording.warningMessage ?? state.jobs.warning(for: recording.id) {
                 Label(warning, systemImage: "exclamationmark.triangle.fill")
                     .font(.caption)
                     .foregroundStyle(.orange)

--- a/app/Sources/Transcriber/Views/DetailView.swift
+++ b/app/Sources/Transcriber/Views/DetailView.swift
@@ -46,6 +46,7 @@ struct DetailView: View {
 /// that a drop is possible at all.
 struct HomeView: View {
     @Environment(AppState.self) private var state
+    @Environment(\.interfaceMode) private var mode
 
     var body: some View {
         VStack(spacing: 24) {
@@ -72,7 +73,7 @@ struct HomeView: View {
                 .keyboardShortcut(.defaultAction)
 
                 Button {
-                    state.newItem(state.settings.isAdvanced ? .recording : .meeting)
+                    state.newItem(state.newRecordingKind)
                 } label: {
                     Label("Record", systemImage: "record.circle")
                         .frame(minWidth: 130)
@@ -80,7 +81,7 @@ struct HomeView: View {
                 .controlSize(.large)
             }
 
-            if state.settings.isAdvanced {
+            if mode == .advanced {
                 HStack(spacing: 16) {
                     Button("New Meeting") { state.newItem(.meeting) }
                     Button("New Note") { state.newItem(.note) }
@@ -145,6 +146,7 @@ struct HomeView: View {
 /// files is never asked.
 struct WelcomeCard: View {
     @Environment(AppState.self) private var state
+    @Environment(\.interfaceMode) private var mode
 
     /// Called when a button has answered the card. Recording that it was seen
     /// is the card's; taking it off the screen is the caller's.
@@ -168,7 +170,7 @@ struct WelcomeCard: View {
 
             GroupBox {
                 VStack(alignment: .leading, spacing: 14) {
-                    if state.settings.isAdvanced {
+                    if mode == .advanced {
                         MicrophonePermissionRow()
                         Divider()
                     }
@@ -208,7 +210,7 @@ struct WelcomeCard: View {
                     .help("Close this card. Everything on it is also in Settings.")
                 Button("Record") {
                     answered()
-                    state.newItem(state.settings.isAdvanced ? .recording : .meeting)
+                    state.newItem(state.newRecordingKind)
                 }
                 .buttonStyle(.borderedProminent)
                 .keyboardShortcut(.defaultAction)
@@ -277,6 +279,7 @@ struct WelcomeCard: View {
 /// meeting workspace on the right when there is one.
 struct RecordingDetailView: View {
     @Environment(AppState.self) private var state
+    @Environment(\.interfaceMode) private var mode
     @Environment(\.modelContext) private var context
     let recording: StoredRecording
 
@@ -471,7 +474,7 @@ struct RecordingDetailView: View {
     /// one button that uses the tier from Settings.
     @ViewBuilder
     private func rerun(_ label: String) -> some View {
-        if state.settings.isAdvanced {
+        if mode == .advanced {
             RerunButton(recording: recording, label: label)
                 .help("Transcribe again on another tier, or identify the speakers again")
         } else {

--- a/app/Sources/Transcriber/Views/MeetingPanes.swift
+++ b/app/Sources/Transcriber/Views/MeetingPanes.swift
@@ -21,10 +21,14 @@ struct NotesPane: View {
     @State private var quickKind: MeetingItemKind = .keyPoint
     @State private var quickText = ""
     @FocusState private var quickFocused: Bool
+    /// Whether the notes model can run on this Mac today. Asked once per
+    /// pane; nil until the answer is in.
+    @State private var availability: NotesAvailability?
 
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 18) {
+                draftRow
                 quickAdd
 
                 section("Summary") {
@@ -71,6 +75,68 @@ struct NotesPane: View {
             .padding(14)
         }
         .onDisappear { save() }
+        .task { availability = await state.notesAvailability() }
+        // The review of a draft, up while the coordinator holds one for this
+        // recording. Closing it any way other than a button is a dismiss.
+        .sheet(isPresented: Binding(
+            get: { state.notes.draft(for: recording.id) != nil },
+            set: { if !$0 { state.notes.dismiss(recording.id) } }
+        )) {
+            if let draft = state.notes.draft(for: recording.id) {
+                NotesDraftSheet(recording: recording, draft: draft)
+            }
+        }
+    }
+
+    /// The model's offer, above the hand-written notes: one button, the
+    /// progress while it reads, or the reason it stopped. Nothing at all on a
+    /// macOS that has no model; the pane is the same as before then.
+    @ViewBuilder
+    private var draftRow: some View {
+        if let progress = state.notes.progress(for: recording.id) {
+            HStack(spacing: 8) {
+                ProgressView(value: progress.fraction)
+                Text(progress.label)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+                    .fixedSize()
+                Button("Cancel") { state.notes.cancel(recording.id) }
+                    .controlSize(.small)
+            }
+        } else if let failure = state.notes.failure(for: recording.id) {
+            VStack(alignment: .leading, spacing: 6) {
+                Label(failure, systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                    .fixedSize(horizontal: false, vertical: true)
+                Button("OK") { state.notes.dismiss(recording.id) }
+                    .controlSize(.small)
+            }
+        } else if state.canDraftNotes {
+            Button {
+                state.draftNotes(for: recording)
+            } label: {
+                Label("Draft Notes from the Transcript", systemImage: "sparkles")
+                    .font(.callout)
+            }
+            .controlSize(.small)
+            .disabled(!draftEnabled)
+            .help(draftHelp)
+        }
+    }
+
+    private var draftEnabled: Bool {
+        (availability?.isAvailable ?? false) && recording.transcript != nil
+            && !state.jobs.isBusy(recording.id)
+    }
+
+    private var draftHelp: String {
+        if let availability, !availability.isAvailable { return availability.message }
+        if recording.transcript == nil { return "Transcribe the recording first." }
+        if state.jobs.isBusy(recording.id) { return "Wait for the transcription to complete." }
+        return "The Apple Intelligence model on this Mac reads the transcript and proposes a "
+             + "summary and notes. You select what to keep. Nothing leaves the Mac."
     }
 
     /// Kind on the left, text on the right, ↩ to add. The kind menu shows the

--- a/app/Sources/Transcriber/Views/MeetingPanes.swift
+++ b/app/Sources/Transcriber/Views/MeetingPanes.swift
@@ -76,16 +76,6 @@ struct NotesPane: View {
         }
         .onDisappear { save() }
         .task { availability = await state.notesAvailability() }
-        // The review of a draft, up while the coordinator holds one for this
-        // recording. Closing it any way other than a button is a dismiss.
-        .sheet(isPresented: Binding(
-            get: { state.notes.draft(for: recording.id) != nil },
-            set: { if !$0 { state.notes.dismiss(recording.id) } }
-        )) {
-            if let draft = state.notes.draft(for: recording.id) {
-                NotesDraftSheet(recording: recording, draft: draft)
-            }
-        }
     }
 
     /// The model's offer, above the hand-written notes: one button, the

--- a/app/Sources/Transcriber/Views/MeetingPanes.swift
+++ b/app/Sources/Transcriber/Views/MeetingPanes.swift
@@ -309,7 +309,7 @@ struct SpeakersPane: View {
                 ContentUnavailableView {
                     Label("No speakers yet", systemImage: "person.2")
                 } description: {
-                    Text(state.progress[recording.id]?.status == .diarizing
+                    Text(state.jobs.progress(for: recording.id)?.status == .diarizing
                          ? "Speaker identification in progress…"
                          : "The app identifies the speakers after the transcription.")
                 }
@@ -360,7 +360,7 @@ struct SpeakersPane: View {
                 }
                 .font(.callout)
                 Spacer()
-                if recording.hasAudio, state.progress[recording.id] == nil {
+                if recording.hasAudio, !state.jobs.isBusy(recording.id) {
                     Button("Identify Again") { state.rediarize(recording) }
                         .controlSize(.small)
                         .help("Run the speaker identification again, with this count as the target")

--- a/app/Sources/Transcriber/Views/NotesDraftSheet.swift
+++ b/app/Sources/Transcriber/Views/NotesDraftSheet.swift
@@ -1,0 +1,181 @@
+import SwiftUI
+import TranscriberCore
+import TranscriberStore
+
+/// The model's draft, before any of it becomes a note.
+///
+/// Every item is a checkbox, on by default, with the timestamp it came from
+/// so it can be checked against the audio before it is kept. The summary is
+/// a checkbox too, and it is off when the user already wrote one: a summary
+/// written by hand is never replaced without a click that says so.
+struct NotesDraftSheet: View {
+    @Environment(AppState.self) private var state
+    @Environment(\.dismiss) private var dismiss
+    let recording: StoredRecording
+    let draft: NotesDraft
+
+    @State private var selected: Set<UUID>
+    @State private var useSummary: Bool
+
+    init(recording: StoredRecording, draft: NotesDraft) {
+        self.recording = recording
+        self.draft = draft
+        _selected = State(initialValue: Set(draft.items.map(\.id)))
+        _useSummary = State(initialValue: recording.summary.isEmpty && !draft.summary.isEmpty)
+    }
+
+    private var hadSummary: Bool { !recording.summary.isEmpty }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            Divider()
+            ScrollView {
+                VStack(alignment: .leading, spacing: 18) {
+                    if !draft.warnings.isEmpty { warnings }
+                    if !draft.summary.isEmpty { summarySection }
+                    ForEach(MeetingItemKind.allCases) { kind in
+                        let items = draft.items(kind)
+                        if !items.isEmpty { section(kind, items: items) }
+                    }
+                    if draft.isEmpty {
+                        Text("The model found nothing worth keeping in this transcript.")
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .padding(16)
+            }
+            Divider()
+            footer
+        }
+        .frame(minWidth: 520, idealWidth: 620, minHeight: 420, idealHeight: 660)
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Draft of the notes")
+                .font(.title2.weight(.semibold))
+            Text("Written by \(AppState.notesModelLabel(draft.modelId)) from \(draft.chunkCount) "
+                 + "part\(draft.chunkCount == 1 ? "" : "s") of the transcript in "
+                 + "\(TimeFormat.short(ms: draft.elapsedMs)). Select what to keep. Each note "
+                 + "shows the moment it came from.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(16)
+    }
+
+    private var warnings: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            ForEach(draft.warnings, id: \.self) { warning in
+                Label(warning, systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    private var summarySection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Toggle(isOn: $useSummary) {
+                Text(hadSummary ? "REPLACE THE SUMMARY" : "SUMMARY")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+            }
+            .toggleStyle(.checkbox)
+            Text(draft.summary)
+                .font(.callout)
+                .textSelection(.enabled)
+                .fixedSize(horizontal: false, vertical: true)
+                .foregroundStyle(useSummary ? .primary : .secondary)
+            if hadSummary {
+                Text("You wrote a summary. It stays unless you select this.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private func section(_ kind: MeetingItemKind, items: [NotesDraft.Item]) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Label {
+                Text(kind.plural.uppercased())
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+            } icon: {
+                Image(systemName: kind.symbol).font(.caption)
+            }
+            ForEach(items) { item in
+                HStack(alignment: .top, spacing: 8) {
+                    Toggle("", isOn: Binding(
+                        get: { selected.contains(item.id) },
+                        set: { on in if on { selected.insert(item.id) } else { selected.remove(item.id) } }
+                    ))
+                    .labelsHidden()
+                    .toggleStyle(.checkbox)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(item.text)
+                            .font(.callout)
+                            .textSelection(.enabled)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .foregroundStyle(selected.contains(item.id) ? .primary : .secondary)
+                        if let at = item.sourceMs {
+                            Button {
+                                state.pendingScrollTarget = item.sourceSegmentId
+                                state.seek(to: at, in: recording)
+                            } label: {
+                                Label(state.timestamp(ms: at, in: recording), systemImage: "arrow.turn.up.left")
+                                    .font(.caption2)
+                                    .monospacedDigit()
+                            }
+                            .buttonStyle(.plain)
+                            .foregroundStyle(.tint)
+                            .help("Play the line this came from")
+                        } else {
+                            Text("No line named")
+                                .font(.caption2)
+                                .foregroundStyle(.tertiary)
+                                .help("The model did not say which line this came from.")
+                        }
+                    }
+                    Spacer(minLength: 0)
+                }
+            }
+        }
+    }
+
+    private var keptCount: Int { selected.count }
+
+    private var footer: some View {
+        HStack {
+            Button("Select All") { selected = Set(draft.items.map(\.id)) }
+                .disabled(selected.count == draft.items.count)
+            Button("Select None") { selected.removeAll() }
+                .disabled(selected.isEmpty)
+            Spacer()
+            Button("Cancel") {
+                state.notes.dismiss(recording.id)
+                dismiss()
+            }
+            .keyboardShortcut(.cancelAction)
+            Button(addLabel) {
+                let items = draft.items.filter { selected.contains($0.id) }
+                state.acceptNotes(items, summary: useSummary ? draft.summary : nil, for: recording)
+                dismiss()
+            }
+            .keyboardShortcut(.defaultAction)
+            .disabled(keptCount == 0 && !useSummary)
+        }
+        .padding(16)
+    }
+
+    private var addLabel: String {
+        switch (keptCount, useSummary) {
+        case (0, true): return "Use the Summary"
+        case (1, _): return "Add 1 Note"
+        default: return "Add \(keptCount) Notes"
+        }
+    }
+}

--- a/app/Sources/Transcriber/Views/RecordingView.swift
+++ b/app/Sources/Transcriber/Views/RecordingView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import TranscriberCore
+import TranscriberEngine
 import TranscriberStore
 
 /// The live screen. Everything on it is transient except the committed text.
@@ -13,8 +14,13 @@ import TranscriberStore
 /// Simple mode shows the clock, the meter, the buttons and the text.
 /// Advanced mode adds the gain slider, room mode, the model and the decode
 /// statistics.
+///
+/// The session is an explicit input of every subview here, not something
+/// reached through the app state. What a subview reads is in its
+/// declaration; the app state is asked for actions only.
 struct RecordingView: View {
     @Environment(AppState.self) private var state
+    @Environment(\.interfaceMode) private var mode
     let recording: StoredRecording
 
     /// The model is still loading. Capture has not started, so there is no
@@ -22,56 +28,69 @@ struct RecordingView: View {
     /// much something to say.
     private var isPreparing: Bool { !state.live.state.isRecording }
 
+    /// "large-v3-turbo · 1.6 GB · English".
+    private var modelSummary: String {
+        let id = state.settings.liveModelId
+        let model = ModelCatalogue.option(id)
+        return [model?.label ?? id, model?.sizeLabel, languageLabel]
+            .compactMap { $0 }
+            .joined(separator: " · ")
+    }
+
+    private var languageLabel: String {
+        let code = state.settings.language
+        return code == "auto" ? "Automatic language" : (LanguageCatalogue.option(code)?.label ?? code)
+    }
+
     var body: some View {
+        let live = state.live
+        let advanced = mode == .advanced
         VStack(spacing: 0) {
             if isPreparing {
-                RecordingPreparingHeader()
+                RecordingPreparingHeader(live: live, modelSummary: advanced ? modelSummary : nil)
             } else {
-                RecordingHeader()
+                RecordingHeader(live: live, advanced: advanced)
             }
             Divider()
-            LiveTranscript(isPreparing: isPreparing)
+            LiveTranscript(live: live, isPreparing: isPreparing)
             Divider()
-            RecordingFooter()
+            RecordingFooter(
+                live: live, languageLabel: languageLabel,
+                liveModel: advanced ? ModelCatalogue.option(state.settings.liveModelId) : nil,
+                offlineModelLabel: advanced
+                    ? (ModelCatalogue.option(state.settings.offlineModelId)?.label ?? state.settings.offlineModelId)
+                    : nil
+            )
         }
     }
 }
 
 /// The model load, which is seconds cold. Reads the session state only.
 private struct RecordingPreparingHeader: View {
-    @Environment(AppState.self) private var state
-
-    private var advanced: Bool { state.settings.isAdvanced }
+    let live: LiveSession
+    /// The model and the language, in Advanced mode; nil hides the line.
+    let modelSummary: String?
 
     /// Specifically the model load, as opposed to `.finishing`, which uses the
     /// same header on the way out and should not be told the model loads once.
     private var isLoadingModel: Bool {
-        if case .preparing = state.live.state { return true }
+        if case .preparing = live.state { return true }
         return false
-    }
-
-    /// "large-v3-turbo · 1.6 GB · English".
-    private var modelSummary: String {
-        let id = state.settings.liveModelId
-        let model = ModelCatalogue.option(id)
-        return [model?.label ?? id, model?.sizeLabel, RecordingLabels.language(state.settings.language)]
-            .compactMap { $0 }
-            .joined(separator: " · ")
     }
 
     var body: some View {
         VStack(spacing: 12) {
             HStack(spacing: 10) {
-                if state.live.state.fraction == nil {
+                if live.state.fraction == nil {
                     ProgressView()
                         .controlSize(.small)
                 }
                 // WhisperKit's own message: "Loading large-v3-turbo…", or the
                 // download and its size when the model is not on disk yet.
-                Text(state.live.state.label)
+                Text(live.state.label)
                     .font(.headline)
             }
-            if let fraction = state.live.state.fraction {
+            if let fraction = live.state.fraction {
                 // A download has a length; a spinner over 1.6 GB reads as a hang.
                 HStack(spacing: 10) {
                     ProgressView(value: fraction)
@@ -84,7 +103,7 @@ private struct RecordingPreparingHeader: View {
                 }
             }
             if isLoadingModel {
-                if advanced {
+                if let modelSummary {
                     // Named here rather than left to WhisperKit's progress
                     // string, which only says "Loading" once the file is found.
                     Text(modelSummary)
@@ -105,16 +124,17 @@ private struct RecordingPreparingHeader: View {
 }
 
 /// The clock, the meter and the transport. The one view here whose body runs
-/// on every audio chunk.
+/// on every audio chunk. The app state is asked for the two live knobs.
 private struct RecordingHeader: View {
     @Environment(AppState.self) private var state
+    let live: LiveSession
+    let advanced: Bool
 
-    private var advanced: Bool { state.settings.isAdvanced }
-    private var isPaused: Bool { state.live.isPaused }
+    private var isPaused: Bool { live.isPaused }
 
     private var title: String {
         if isPaused { return "Paused" }
-        return state.live.isMuted ? "Muted" : "Recording"
+        return live.isMuted ? "Muted" : "Recording"
     }
 
     var body: some View {
@@ -123,25 +143,25 @@ private struct RecordingHeader: View {
                 Circle()
                     .fill(isPaused ? Color.secondary : Color.red)
                     .frame(width: 10, height: 10)
-                    .opacity(state.live.isMuted && !isPaused ? 0.3 : 1)
+                    .opacity(live.isMuted && !isPaused ? 0.3 : 1)
                     .symbolEffect(.pulse, isActive: !isPaused)
                 Text(title)
                     .font(.headline)
                     .contentTransition(.identity)
             }
 
-            Text(TimeFormat.short(ms: state.live.elapsedMs))
+            Text(TimeFormat.short(ms: live.elapsedMs))
                 .font(.system(size: 46, weight: .light, design: .rounded))
                 .monospacedDigit()
                 .contentTransition(.numericText())
 
-            LevelMeter(samples: state.live.meter, level: state.live.level)
+            LevelMeter(samples: live.meter, level: live.level)
                 .frame(height: 64)
                 .padding(.horizontal, 40)
 
             // The microphone changed under this recording. Said here, while
             // there is still time to plug it back in or stop.
-            if let notice = state.live.notices.last {
+            if let notice = live.notices.last {
                 Label(notice.message, systemImage: "exclamationmark.triangle.fill")
                     .font(.caption)
                     .foregroundStyle(.orange)
@@ -153,7 +173,7 @@ private struct RecordingHeader: View {
                 InputGainSlider(gainDb: Binding(
                     get: { state.settings.inputGainDb },
                     set: { state.setInputGain($0) }
-                ), isClipping: InputGain.isClipping(state.live.level))
+                ), isClipping: InputGain.isClipping(live.level))
                 .padding(.horizontal, 40)
 
                 Toggle(isOn: Binding(
@@ -170,8 +190,8 @@ private struct RecordingHeader: View {
 
             // Words on the buttons while there is room, icons in a narrow window.
             ViewThatFits(in: .horizontal) {
-                RecordingTransport().fixedSize()
-                RecordingTransport().labelStyle(.iconOnly).fixedSize()
+                RecordingTransport(live: live).fixedSize()
+                RecordingTransport(live: live).labelStyle(.iconOnly).fixedSize()
             }
         }
         .padding(.vertical, 24)
@@ -184,18 +204,19 @@ private struct RecordingHeader: View {
 /// clock does not rebuild the buttons.
 private struct RecordingTransport: View {
     @Environment(AppState.self) private var state
+    let live: LiveSession
 
-    private var isPaused: Bool { state.live.isPaused }
+    private var isPaused: Bool { live.isPaused }
 
     var body: some View {
         HStack(spacing: 16) {
             Button {
-                state.live.isMuted.toggle()
+                live.isMuted.toggle()
             } label: {
-                Label(state.live.isMuted ? "Unmute" : "Mute",
-                      systemImage: state.live.isMuted ? "mic.slash.fill" : "mic.fill")
+                Label(live.isMuted ? "Unmute" : "Mute",
+                      systemImage: live.isMuted ? "mic.slash.fill" : "mic.fill")
             }
-            .help(state.live.isMuted
+            .help(live.isMuted
                   ? "Unmute the microphone"
                   : "Mute the microphone. The clock continues, and the file gets silence.")
 
@@ -239,27 +260,27 @@ private struct RecordingTransport: View {
 /// The committed lines and the provisional tail. Reads them and the two
 /// flags that decide the empty state; not the clock.
 private struct LiveTranscript: View {
-    @Environment(AppState.self) private var state
+    let live: LiveSession
     let isPreparing: Bool
 
-    private var isPaused: Bool { state.live.isPaused }
+    private var isPaused: Bool { live.isPaused }
 
     var body: some View {
         ScrollViewReader { proxy in
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 10) {
-                    ForEach(state.live.segments) { segment in
+                    ForEach(live.segments) { segment in
                         LiveSegmentRow(startMs: segment.startMs, text: segment.displayText)
                             .id(segment.id)
                     }
 
-                    if !state.live.partial.isEmpty {
+                    if !live.partial.isEmpty {
                         HStack(alignment: .firstTextBaseline, spacing: 10) {
                             Color.clear
                                 .frame(width: 52, height: 1)
                             // Provisional. It may be rewritten by the next pass;
                             // committed text above it never will be.
-                            Text(state.live.partial)
+                            Text(live.partial)
                                 .foregroundStyle(.secondary)
                                 .italic()
                         }
@@ -273,11 +294,11 @@ private struct LiveTranscript: View {
                             .frame(maxWidth: .infinity)
                     }
 
-                    if state.live.segments.isEmpty && state.live.partial.isEmpty && !isPaused {
+                    if live.segments.isEmpty && live.partial.isEmpty && !isPaused {
                         VStack(spacing: 6) {
                             Text(isPreparing ? "The recording has not started."
-                                 : (state.live.decodeLive ? "The app listens. Text comes here." : "Recording"))
-                            if !isPreparing, !state.live.decodeLive {
+                                 : (live.decodeLive ? "The app listens. Text comes here." : "Recording"))
+                            if !isPreparing, !live.decodeLive {
                                 Text("The transcript comes after you stop. To see text during "
                                      + "a recording, turn on “Show text while you record” in Settings.")
                                     .font(.caption)
@@ -293,9 +314,9 @@ private struct LiveTranscript: View {
                 .padding(20)
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
-            .onChange(of: state.live.segments.count) { _, _ in
+            .onChange(of: live.segments.count) { _, _ in
                 withAnimation(.easeOut(duration: 0.2)) {
-                    proxy.scrollTo(state.live.segments.last?.id ?? "partial" as AnyHashable,
+                    proxy.scrollTo(live.segments.last?.id ?? "partial" as AnyHashable,
                                    anchor: .bottom)
                 }
             }
@@ -321,12 +342,14 @@ private struct LiveSegmentRow: View {
     }
 }
 
-/// The model, the language and the decode statistics.
+/// The model, the language and the decode statistics. The model labels are
+/// nil in Simple mode, which is how the footer knows to keep quiet.
 private struct RecordingFooter: View {
-    @Environment(AppState.self) private var state
+    let live: LiveSession
+    let languageLabel: String
+    let liveModel: ModelOption?
+    let offlineModelLabel: String?
     @State private var showStats = false
-
-    private var advanced: Bool { state.settings.isAdvanced }
 
     var body: some View {
         HStack(spacing: 14) {
@@ -335,7 +358,7 @@ private struct RecordingFooter: View {
                 leading.labelStyle(.iconOnly).fixedSize()
             }
             Spacer()
-            Text(RecordingLabels.language(state.settings.language))
+            Text(languageLabel)
                 .lineLimit(1)
         }
         .font(.caption)
@@ -348,34 +371,31 @@ private struct RecordingFooter: View {
     @ViewBuilder
     private var leading: some View {
         HStack(spacing: 14) {
-            if !state.live.decodeLive {
-                if advanced {
-                    Label("The transcript comes after you stop, on "
-                          + "\(ModelCatalogue.option(state.settings.offlineModelId)?.label ?? state.settings.offlineModelId)",
+            if !live.decodeLive {
+                if let offlineModelLabel {
+                    Label("The transcript comes after you stop, on \(offlineModelLabel)",
                           systemImage: "clock")
                 } else {
                     Label("The transcript comes after you stop", systemImage: "clock")
                 }
-            } else if advanced {
+            } else if let liveModel {
                 // Which model is decoding: the first thing anyone wants to know
                 // when the live text reads oddly.
-                Label(ModelCatalogue.option(state.settings.liveModelId)?.label
-                      ?? state.settings.liveModelId,
-                      systemImage: "cpu")
-                    .help(ModelCatalogue.option(state.settings.liveModelId)?.detail ?? "")
+                Label(liveModel.label, systemImage: "cpu")
+                    .help(liveModel.detail)
                 // The engineering numbers live behind a button. They were the
                 // whole footer, and nobody in a meeting needs the RTF -- but
                 // the dropped-window count is a warning and stays in sight.
                 Button {
                     showStats.toggle()
                 } label: {
-                    Label("Statistics", systemImage: state.live.stats.droppedHops > 0
+                    Label("Statistics", systemImage: live.stats.droppedHops > 0
                           ? "exclamationmark.circle" : "info.circle")
                 }
                 .buttonStyle(.borderless)
-                .foregroundStyle(state.live.stats.droppedHops > 0 ? .orange : .secondary)
+                .foregroundStyle(live.stats.droppedHops > 0 ? .orange : .secondary)
                 .popover(isPresented: $showStats, arrowEdge: .top) {
-                    LiveStatsTable(stats: state.live.stats, vadBackend: state.live.vadBackend)
+                    LiveStatsTable(stats: live.stats, vadBackend: live.vadBackend)
                 }
             } else {
                 Label("Live text", systemImage: "text.bubble")
@@ -465,11 +485,3 @@ private struct LiveStatsTable: View {
     }
 }
 
-/// Labels the live screen shares between its views.
-private enum RecordingLabels {
-    static func language(_ code: String) -> String {
-        code == "auto"
-            ? "Automatic language"
-            : (LanguageCatalogue.option(code)?.label ?? code)
-    }
-}

--- a/app/Sources/Transcriber/Views/RecordingView.swift
+++ b/app/Sources/Transcriber/Views/RecordingView.swift
@@ -4,19 +4,44 @@ import TranscriberStore
 
 /// The live screen. Everything on it is transient except the committed text.
 ///
-/// Simple mode shows the clock, the meter, the three buttons and the text.
+/// Three view types, one per rate of change. The header reads the clock,
+/// the level and the meter, which move ten to twelve times a second. The
+/// transcript reads the committed lines and the partial, which move at each
+/// commit. The footer reads the statistics, which move at each decode. As
+/// one body, a meter tick re-ran the transcript list and the footer with it.
+///
+/// Simple mode shows the clock, the meter, the buttons and the text.
 /// Advanced mode adds the gain slider, room mode, the model and the decode
 /// statistics.
 struct RecordingView: View {
     @Environment(AppState.self) private var state
     let recording: StoredRecording
 
-    private var advanced: Bool { state.settings.isAdvanced }
-
     /// The model is still loading. Capture has not started, so there is no
     /// elapsed time, no level and nothing to mute yet -- but there is very
     /// much something to say.
     private var isPreparing: Bool { !state.live.state.isRecording }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if isPreparing {
+                RecordingPreparingHeader()
+            } else {
+                RecordingHeader()
+            }
+            Divider()
+            LiveTranscript(isPreparing: isPreparing)
+            Divider()
+            RecordingFooter()
+        }
+    }
+}
+
+/// The model load, which is seconds cold. Reads the session state only.
+private struct RecordingPreparingHeader: View {
+    @Environment(AppState.self) private var state
+
+    private var advanced: Bool { state.settings.isAdvanced }
 
     /// Specifically the model load, as opposed to `.finishing`, which uses the
     /// same header on the way out and should not be told the model loads once.
@@ -29,29 +54,12 @@ struct RecordingView: View {
     private var modelSummary: String {
         let id = state.settings.liveModelId
         let model = ModelCatalogue.option(id)
-        return [model?.label ?? id, model?.sizeLabel, languageLabel]
+        return [model?.label ?? id, model?.sizeLabel, RecordingLabels.language(state.settings.language)]
             .compactMap { $0 }
             .joined(separator: " · ")
     }
 
-    private var languageLabel: String {
-        state.settings.language == "auto"
-            ? "Automatic language"
-            : (LanguageCatalogue.option(state.settings.language)?.label ?? state.settings.language)
-    }
-
     var body: some View {
-        VStack(spacing: 0) {
-            if isPreparing { preparingHeader } else { recordingHeader }
-
-            Divider()
-            liveTranscript
-            Divider()
-            footer
-        }
-    }
-
-    private var preparingHeader: some View {
         VStack(spacing: 12) {
             HStack(spacing: 10) {
                 if state.live.state.fraction == nil {
@@ -94,15 +102,22 @@ struct RecordingView: View {
         .frame(maxWidth: .infinity)
         .background(.background.secondary)
     }
+}
 
+/// The clock, the meter and the transport. The one view here whose body runs
+/// on every audio chunk.
+private struct RecordingHeader: View {
+    @Environment(AppState.self) private var state
+
+    private var advanced: Bool { state.settings.isAdvanced }
     private var isPaused: Bool { state.live.isPaused }
 
-    private var headerTitle: String {
+    private var title: String {
         if isPaused { return "Paused" }
         return state.live.isMuted ? "Muted" : "Recording"
     }
 
-    private var recordingHeader: some View {
+    var body: some View {
         VStack(spacing: 14) {
             HStack(spacing: 8) {
                 Circle()
@@ -110,7 +125,7 @@ struct RecordingView: View {
                     .frame(width: 10, height: 10)
                     .opacity(state.live.isMuted && !isPaused ? 0.3 : 1)
                     .symbolEffect(.pulse, isActive: !isPaused)
-                Text(headerTitle)
+                Text(title)
                     .font(.headline)
                     .contentTransition(.identity)
             }
@@ -155,16 +170,24 @@ struct RecordingView: View {
 
             // Words on the buttons while there is room, icons in a narrow window.
             ViewThatFits(in: .horizontal) {
-                transportButtons.fixedSize()
-                transportButtons.labelStyle(.iconOnly).fixedSize()
+                RecordingTransport().fixedSize()
+                RecordingTransport().labelStyle(.iconOnly).fixedSize()
             }
         }
         .padding(.vertical, 24)
         .frame(maxWidth: .infinity)
         .background(.background.secondary)
     }
+}
 
-    private var transportButtons: some View {
+/// Mute, Pause, Stop and Bookmark. Reads the two switches only, so the
+/// clock does not rebuild the buttons.
+private struct RecordingTransport: View {
+    @Environment(AppState.self) private var state
+
+    private var isPaused: Bool { state.live.isPaused }
+
+    var body: some View {
         HStack(spacing: 16) {
             Button {
                 state.live.isMuted.toggle()
@@ -211,27 +234,29 @@ struct RecordingView: View {
             .help("Bookmark this moment (⌘B)")
         }
     }
+}
 
-    private var liveTranscript: some View {
+/// The committed lines and the provisional tail. Reads them and the two
+/// flags that decide the empty state; not the clock.
+private struct LiveTranscript: View {
+    @Environment(AppState.self) private var state
+    let isPreparing: Bool
+
+    private var isPaused: Bool { state.live.isPaused }
+
+    var body: some View {
         ScrollViewReader { proxy in
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 10) {
                     ForEach(state.live.segments) { segment in
-                        HStack(alignment: .firstTextBaseline, spacing: 10) {
-                            Text(TimeFormat.short(ms: segment.startMs))
-                                .font(.system(.caption, design: .monospaced))
-                                .foregroundStyle(.tertiary)
-                                .frame(width: 52, alignment: .trailing)
-                            Text(segment.displayText)
-                                .textSelection(.enabled)
-                        }
-                        .id(segment.id)
+                        LiveSegmentRow(startMs: segment.startMs, text: segment.displayText)
+                            .id(segment.id)
                     }
 
                     if !state.live.partial.isEmpty {
                         HStack(alignment: .firstTextBaseline, spacing: 10) {
-                            Text("")
-                                .frame(width: 52)
+                            Color.clear
+                                .frame(width: 52, height: 1)
                             // Provisional. It may be rewritten by the next pass;
                             // committed text above it never will be.
                             Text(state.live.partial)
@@ -276,17 +301,41 @@ struct RecordingView: View {
             }
         }
     }
+}
 
+/// One committed line. Plain data in, so the list skips the rows that did
+/// not change when a new one lands.
+private struct LiveSegmentRow: View {
+    let startMs: Int
+    let text: String
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 10) {
+            Text(TimeFormat.short(ms: startMs))
+                .font(.system(.caption, design: .monospaced))
+                .foregroundStyle(.tertiary)
+                .frame(width: 52, alignment: .trailing)
+            Text(text)
+                .textSelection(.enabled)
+        }
+    }
+}
+
+/// The model, the language and the decode statistics.
+private struct RecordingFooter: View {
+    @Environment(AppState.self) private var state
     @State private var showStats = false
 
-    private var footer: some View {
+    private var advanced: Bool { state.settings.isAdvanced }
+
+    var body: some View {
         HStack(spacing: 14) {
             ViewThatFits(in: .horizontal) {
-                footerLeading.fixedSize()
-                footerLeading.labelStyle(.iconOnly).fixedSize()
+                leading.fixedSize()
+                leading.labelStyle(.iconOnly).fixedSize()
             }
             Spacer()
-            Text(languageLabel)
+            Text(RecordingLabels.language(state.settings.language))
                 .lineLimit(1)
         }
         .font(.caption)
@@ -297,7 +346,7 @@ struct RecordingView: View {
     }
 
     @ViewBuilder
-    private var footerLeading: some View {
+    private var leading: some View {
         HStack(spacing: 14) {
             if !state.live.decodeLive {
                 if advanced {
@@ -325,19 +374,26 @@ struct RecordingView: View {
                 }
                 .buttonStyle(.borderless)
                 .foregroundStyle(state.live.stats.droppedHops > 0 ? .orange : .secondary)
-                .popover(isPresented: $showStats, arrowEdge: .top) { statsPopover }
+                .popover(isPresented: $showStats, arrowEdge: .top) {
+                    LiveStatsTable(stats: state.live.stats, vadBackend: state.live.vadBackend)
+                }
             } else {
                 Label("Live text", systemImage: "text.bubble")
             }
         }
     }
+}
 
-    private var statsPopover: some View {
-        let stats = state.live.stats
-        return Grid(alignment: .leadingFirstTextBaseline, horizontalSpacing: 14, verticalSpacing: 6) {
+/// The decode counters. Plain data in: the popover shows a snapshot.
+private struct LiveStatsTable: View {
+    let stats: SessionStats
+    let vadBackend: String
+
+    var body: some View {
+        Grid(alignment: .leadingFirstTextBaseline, horizontalSpacing: 14, verticalSpacing: 6) {
             GridRow {
                 Text("Voice detection").foregroundStyle(.secondary)
-                Text(state.live.vadBackend == "silero" ? "Silero (neural)" : "Energy")
+                Text(vadBackend == "silero" ? "Silero (neural)" : "Energy")
             }
             GridRow {
                 Text("Decodes").foregroundStyle(.secondary)
@@ -406,5 +462,14 @@ struct RecordingView: View {
         .font(.callout)
         .monospacedDigit()
         .padding(14)
+    }
+}
+
+/// Labels the live screen shares between its views.
+private enum RecordingLabels {
+    static func language(_ code: String) -> String {
+        code == "auto"
+            ? "Automatic language"
+            : (LanguageCatalogue.option(code)?.label ?? code)
     }
 }

--- a/app/Sources/Transcriber/Views/SettingsView.swift
+++ b/app/Sources/Transcriber/Views/SettingsView.swift
@@ -99,6 +99,7 @@ struct InterfaceModeSection: View {
 struct GeneralSettings: View {
     @Environment(AppState.self) private var state
     @Environment(\.interfaceMode) private var mode
+    @State private var notesAvailability: NotesAvailability?
 
     var body: some View {
         @Bindable var settings = state.settings
@@ -193,8 +194,43 @@ struct GeneralSettings: View {
                         .fixedSize(horizontal: false, vertical: true)
                 }
             }
+
+            if state.canDraftNotes {
+                Section {
+                    Picker("Language of the notes", selection: $settings.notesStyle) {
+                        ForEach(NotesStyle.allCases) { style in
+                            Text(style.label).tag(style)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                    Text(settings.notesStyle.detail)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                } header: {
+                    Text("Automatic notes")
+                } footer: {
+                    Text(notesFooter)
+                        .font(.caption)
+                        .foregroundStyle(notesAvailability?.isAvailable == false ? .orange : .secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .task { notesAvailability = await state.notesAvailability() }
+            }
         }
         .formStyle(.grouped)
+    }
+
+    /// What the button in the notes pane does, and whether it can run today.
+    /// The language limit is stated here because a Taglish meeting is the
+    /// normal case for this app, and the model refuses it.
+    private var notesFooter: String {
+        let what = "Draft Notes in the notes pane reads the transcript with the Apple Intelligence "
+                 + "model on this Mac and proposes a summary and notes. You select what to keep. "
+                 + "Nothing leaves the Mac. The model does not accept a transcript that is mostly "
+                 + "Tagalog."
+        guard let notesAvailability, !notesAvailability.isAvailable else { return what }
+        return what + " " + notesAvailability.message
     }
 
     private func liveDetail(advanced: Bool) -> String {

--- a/app/Sources/Transcriber/Views/SettingsView.swift
+++ b/app/Sources/Transcriber/Views/SettingsView.swift
@@ -12,6 +12,7 @@ import TranscriberStore
 /// Models and Storage, and more rows in the first two.
 struct SettingsView: View {
     @Environment(AppState.self) private var state
+    @Environment(\.interfaceMode) private var mode
     @State private var pane: Pane? = .general
 
     enum Pane: String, CaseIterable, Identifiable {
@@ -39,7 +40,7 @@ struct SettingsView: View {
     }
 
     private var panes: [Pane] {
-        Pane.allCases.filter { state.settings.isAdvanced || !$0.isAdvanced }
+        Pane.allCases.filter { mode == .advanced || !$0.isAdvanced }
     }
 
     var body: some View {
@@ -61,9 +62,9 @@ struct SettingsView: View {
         }
         .navigationTitle((pane ?? .general).label)
         .frame(minWidth: 700, idealWidth: 760, minHeight: 500, idealHeight: 580)
-        .onChange(of: state.settings.isAdvanced) { _, advanced in
+        .onChange(of: mode) { _, mode in
             // A pane that just left the list must not stay on show.
-            if !advanced, pane?.isAdvanced == true { pane = .general }
+            if mode == .simple, pane?.isAdvanced == true { pane = .general }
         }
     }
 }
@@ -97,10 +98,11 @@ struct InterfaceModeSection: View {
 
 struct GeneralSettings: View {
     @Environment(AppState.self) private var state
+    @Environment(\.interfaceMode) private var mode
 
     var body: some View {
         @Bindable var settings = state.settings
-        let advanced = settings.isAdvanced
+        let advanced = mode == .advanced
 
         Form {
             InterfaceModeSection()
@@ -215,6 +217,7 @@ struct GeneralSettings: View {
 
 struct AudioSettings: View {
     @Environment(AppState.self) private var state
+    @Environment(\.interfaceMode) private var mode
 
     var body: some View {
         @Bindable var settings = state.settings
@@ -245,7 +248,7 @@ struct AudioSettings: View {
                 }
             }
 
-            if settings.isAdvanced {
+            if mode == .advanced {
                 Section("Input") {
                     InputGainSlider(gainDb: $settings.inputGainDb)
                     Text("The microphone in a laptop is 15 to 20 dB quieter than a headset at "

--- a/app/Sources/Transcriber/Views/SettingsView.swift
+++ b/app/Sources/Transcriber/Views/SettingsView.swift
@@ -197,6 +197,22 @@ struct GeneralSettings: View {
 
             if state.canDraftNotes {
                 Section {
+                    Toggle("Draft the notes when a recording is complete",
+                           isOn: $settings.autoDraftNotes)
+                    // A plain string, not a literal, so SwiftUI does not read
+                    // markdown here. Emphasis has to be carried by the words.
+                    Text(settings.autoDraftNotes
+                         ? "The app drafts the notes as soon as the transcript is ready, and "
+                         + "shows them for you to select. It never runs during a recording, "
+                         + "and a draft that is running stops when you record: the two would "
+                         + "share one chip."
+                         : "The app drafts the notes only when you click Draft Notes. Turn "
+                         + "this on and it drafts them after every recording instead. Either "
+                         + "way it never runs during a recording.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+
                     Picker("Language of the notes", selection: $settings.notesStyle) {
                         ForEach(NotesStyle.allCases) { style in
                             Text(style.label).tag(style)

--- a/app/Sources/Transcriber/Views/SidebarView.swift
+++ b/app/Sources/Transcriber/Views/SidebarView.swift
@@ -5,6 +5,7 @@ import TranscriberStore
 
 struct SidebarView: View {
     @Environment(AppState.self) private var state
+    @Environment(\.interfaceMode) private var mode
     @Environment(\.modelContext) private var context
     @Query(sort: \StoredRecording.createdAt, order: .reverse)
     private var recordings: [StoredRecording]
@@ -35,7 +36,7 @@ struct SidebarView: View {
         VStack(spacing: 0) {
             // The filter is an Advanced control. Simple mode shows the whole
             // library, newest first, and nothing to select before the list.
-            if state.settings.isAdvanced {
+            if mode == .advanced {
                 filterBar
             } else {
                 simpleTopBar
@@ -54,8 +55,8 @@ struct SidebarView: View {
             if let route, !selection.contains(route) { selection = [route] }
             if route == nil { selection = [] }
         }
-        .onChange(of: state.settings.isAdvanced) { _, advanced in
-            if !advanced { filter = .all }
+        .onChange(of: mode) { _, mode in
+            if mode == .simple { filter = .all }
         }
         .onDeleteCommand { pendingDelete = selectedRecordings }
         .confirmationDialog(
@@ -212,24 +213,22 @@ struct SidebarView: View {
                 Button {
                     withAnimation(.snappy) { state.settings.isAdvanced.toggle() }
                 } label: {
-                    Label(state.settings.isAdvanced ? "Advanced" : "Simple",
-                          systemImage: "slider.horizontal.3")
+                    Label(mode.label, systemImage: "slider.horizontal.3")
                         .font(.caption)
                 }
-                .help(state.settings.isAdvanced
+                .help(mode == .advanced
                       ? "Advanced mode. Click to change to Simple mode, which has fewer controls."
                       : "Simple mode. Click to change to Advanced mode, which shows all controls.")
 
                 Spacer()
-                if state.settings.isAdvanced {
-                    Button {
-                        state.route = .benchmark
-                    } label: {
-                        Label("Benchmark", systemImage: "speedometer")
-                    }
-                    .help("Measure the model tiers on this Mac (⇧⌘K)")
-                    .labelStyle(.iconOnly)
+                Button {
+                    state.route = .benchmark
+                } label: {
+                    Label("Benchmark", systemImage: "speedometer")
                 }
+                .help("Measure the model tiers on this Mac (⇧⌘K)")
+                .labelStyle(.iconOnly)
+                .advancedOnly()
                 SettingsLink {
                     Label("Settings", systemImage: "gearshape")
                 }
@@ -252,7 +251,7 @@ struct SidebarView: View {
             try? context.save()
         }
         if recording.hasAudio {
-            if state.settings.isAdvanced {
+            if mode == .advanced {
                 RerunItems(recording: recording)
             } else {
                 Button("Transcribe Again", systemImage: "arrow.clockwise") {
@@ -263,7 +262,7 @@ struct SidebarView: View {
                 if let url = recording.audioURL { NSWorkspace.shared.activateFileViewerSelecting([url]) }
             }
         }
-        if recording.kind == .recording, state.settings.isAdvanced {
+        if recording.kind == .recording, mode == .advanced {
             Button("Make This a Meeting", systemImage: RecordingKind.meeting.symbol) {
                 recording.kind = .meeting
                 try? context.save()

--- a/app/Sources/Transcriber/Views/SidebarView.swift
+++ b/app/Sources/Transcriber/Views/SidebarView.swift
@@ -106,7 +106,7 @@ struct SidebarView: View {
         switch filter {
         case .all: return recordings
         case .active:
-            return recordings.filter { state.progress[$0.id] != nil || $0.status.isBusy }
+            return recordings.filter { state.jobs.isBusy($0.id) || $0.status.isBusy }
         case .favorites: return recordings.filter(\.isFavorite)
         case .meetings: return recordings.filter { $0.kind == .meeting }
         }
@@ -349,7 +349,7 @@ struct HistoryRow: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
 
-                if let progress = state.progress[recording.id] {
+                if let progress = state.jobs.progress(for: recording.id) {
                     StatusChip(status: progress.status, fraction: progress.fraction,
                                remaining: progress.remaining)
                 } else if state.isLive(recording.id), state.isPaused {

--- a/app/Sources/Transcriber/Views/SidebarView.swift
+++ b/app/Sources/Transcriber/Views/SidebarView.swift
@@ -297,6 +297,7 @@ struct HistoryRow: View {
     private var isRenaming: Bool { renaming == recording.id }
 
     var body: some View {
+        let display = state.displayStatus(for: recording)
         HStack(alignment: .top, spacing: 10) {
             Image(systemName: recording.kind.symbol)
                 .font(.system(size: 13))
@@ -340,7 +341,7 @@ struct HistoryRow: View {
                     if (recording.items?.isEmpty == false) {
                         Image(systemName: "note.text")
                     }
-                    if let warning = recording.warningMessage {
+                    if let warning = display.warning {
                         Image(systemName: "exclamationmark.triangle.fill")
                             .foregroundStyle(.orange)
                             .help(warning)
@@ -349,21 +350,12 @@ struct HistoryRow: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
 
-                if let progress = state.jobs.progress(for: recording.id) {
-                    StatusChip(status: progress.status, fraction: progress.fraction,
-                               remaining: progress.remaining)
-                } else if state.isLive(recording.id), state.isPaused {
+                if display.isPaused {
                     Label("Paused", systemImage: "pause.circle.fill")
                         .font(.caption2)
                         .foregroundStyle(.secondary)
-                } else if recording.status.isBusy {
-                    // Preparing and recording are live-path states; they never
-                    // get a queue entry, so they need the stored status.
-                    StatusChip(status: recording.status, fraction: 0)
-                } else if recording.status == .failed {
-                    StatusChip(status: .failed, fraction: 0)
-                } else if recording.status == .cancelled {
-                    StatusChip(status: .cancelled, fraction: 0)
+                } else if let chip = display.chip {
+                    StatusChip(status: chip.status, fraction: chip.fraction, remaining: chip.remaining)
                 }
             }
             Spacer(minLength: 0)

--- a/app/Sources/Transcriber/Views/TranscriptView.swift
+++ b/app/Sources/Transcriber/Views/TranscriptView.swift
@@ -372,47 +372,25 @@ struct TranscriptView: View {
     // MARK: - Empty
 
     private var emptyState: some View {
-        ContentUnavailableView {
-            Label(label, systemImage: icon)
+        let display = state.displayStatus(for: recording)
+        return ContentUnavailableView {
+            Label(display.emptyState.title, systemImage: display.emptyState.symbol)
         } description: {
-            Text(detail)
+            Text(display.emptyState.detail)
         } actions: {
-            if recording.hasAudio, !state.jobs.isBusy(recording.id) {
+            switch display.action {
+            case .retry, .transcribe, .transcribeAgain:
                 Button("Transcribe") { state.retranscribe(recording) }
-            } else if !recording.hasAudio, !state.jobs.isBusy(recording.id) {
+            case nil where !recording.hasAudio && !display.isBusy:
                 // Without this the row is a dead end: no audio means nothing to
                 // transcribe, and the only way out was to find it in the
                 // sidebar and work out that it should be deleted.
                 Button("Delete This Recording", role: .destructive) { state.delete(recording) }
                 Button("Transcribe a File…") { state.isImporting = true }
+            default:
+                EmptyView()
             }
         }
-    }
-
-    private var label: String {
-        if state.jobs.isBusy(recording.id) { return "Work in progress" }
-        if recording.status == .cancelled { return "Transcription cancelled" }
-        guard recording.status == .failed else { return "No transcript yet" }
-        // "Transcription failed" is wrong for a recording that never captured
-        // anything -- nothing got as far as being transcribed.
-        return recording.hasAudio ? "Transcription failed" : "The recording stopped early"
-    }
-
-    private var icon: String {
-        if recording.status == .cancelled { return "xmark.circle" }
-        return recording.status == .failed ? "exclamationmark.triangle" : "text.alignleft"
-    }
-
-    private var detail: String {
-        if let progress = state.jobs.progress(for: recording.id) {
-            guard let remaining = progress.remaining else { return progress.status.label }
-            return "\(progress.status.label) · \(TimeFormat.remaining(seconds: remaining)) left"
-        }
-        if let error = recording.errorMessage, recording.status == .failed { return error }
-        return recording.hasAudio
-            ? "The audio is on this Mac. It has no transcript yet."
-            : "The app captured no audio, thus there is nothing to transcribe. "
-              + "A file that you import becomes a new recording. You can delete this one."
     }
 
     // MARK: - Speakers

--- a/app/Sources/Transcriber/Views/TranscriptView.swift
+++ b/app/Sources/Transcriber/Views/TranscriptView.swift
@@ -240,9 +240,11 @@ struct TranscriptView: View {
                 .frame(maxWidth: .infinity)
                 .background {
                     // Lives inside the scroll view so it re-renders per player
-                    // tick on its own, not the whole list with it.
+                    // tick on its own, not the whole list with it. It is the
+                    // one view here that reads the raw playhead; it publishes
+                    // the turn under it for the rows.
                     PlaybackFollower(blocks: blocks) { blockId in
-                        guard state.followPlayback, state.player.isPlaying else { return }
+                        guard let blockId, state.followPlayback, state.player.isPlaying else { return }
                         request(blockId, anchor: .center)
                     }
                 }
@@ -429,18 +431,23 @@ struct TranscriptView: View {
 }
 
 /// Watches the playhead and names the block under it. Its body is the only
-/// thing that re-evaluates per tick.
+/// thing that re-evaluates per tick: a binary search over the blocks, and a
+/// write to `AppState.playingBlockId` that `@Observable` drops when the turn
+/// has not changed. Every visible row used to read the playhead itself and
+/// re-run its body twenty times a second; now only the row that gains or
+/// loses the highlight does.
 private struct PlaybackFollower: View {
     @Environment(AppState.self) private var state
     let blocks: [TranscriptBlock]
-    let onChange: (UUID) -> Void
+    let onChange: (UUID?) -> Void
 
     var body: some View {
         let current = TranscriptGrouping.blockIndex(at: state.player.currentMs, in: blocks)
             .map { blocks[$0].id }
         Color.clear
-            .onChange(of: current) { _, next in
-                if let next { onChange(next) }
+            .onChange(of: current, initial: true) { _, next in
+                state.playingBlockId = next
+                onChange(next)
             }
     }
 }
@@ -581,11 +588,10 @@ struct TranscriptBlockRow: View {
     /// Nil when the transcript cannot be edited right now.
     var onEdit: (() -> Void)?
 
-    /// Read here rather than passed in from the list. Observation then
-    /// invalidates only the rows, and `LazyVStack` only builds the visible
-    /// ones -- so a two-hour transcript costs the same per tick as a short one.
+    /// The coarse value from the follower, not the raw playhead: this row
+    /// invalidates when the highlight arrives or leaves, and at no other tick.
     private var isPlaying: Bool {
-        block.contains(ms: state.player.currentMs)
+        state.playingBlockId == block.id
     }
 
     private var isSelected: Bool {

--- a/app/Sources/Transcriber/Views/TranscriptView.swift
+++ b/app/Sources/Transcriber/Views/TranscriptView.swift
@@ -2,6 +2,7 @@ import OSLog
 import SwiftData
 import SwiftUI
 import TranscriberCore
+import TranscriberFlow
 import TranscriberStore
 
 /// The transcript, grouped into speaker turns, every row a seek target.
@@ -122,7 +123,7 @@ struct TranscriptView: View {
 
     /// No edits while rows are still arriving or an older revision is open.
     private var isReadOnly: Bool {
-        isViewingOlderRevision || state.progress[recording.id] != nil
+        isViewingOlderRevision || state.jobs.isBusy(recording.id)
     }
 
     /// Changes exactly when the rows do: a new revision, an edit, a batch of
@@ -133,7 +134,7 @@ struct TranscriptView: View {
         let transcript = transcript
         return [transcript?.id.uuidString ?? "-",
                 String(recording.updatedAt.timeIntervalSinceReferenceDate),
-                String(state.transcriptTicks[recording.id] ?? 0),
+                String(state.jobs.tick(for: recording.id)),
                 String(editVersion)].joined(separator: "|")
     }
 
@@ -181,7 +182,7 @@ struct TranscriptView: View {
 
     private var list: some View {
         VStack(spacing: 0) {
-            if let progress = state.progress[recording.id] {
+            if let progress = state.jobs.progress(for: recording.id) {
                 // Rows are arriving under this. Without it a growing list with
                 // no status reads as a finished transcript that is oddly short.
                 TranscriptProgressBanner(progress: progress, durationMs: recording.durationMs) {
@@ -376,9 +377,9 @@ struct TranscriptView: View {
         } description: {
             Text(detail)
         } actions: {
-            if recording.hasAudio, state.progress[recording.id] == nil {
+            if recording.hasAudio, !state.jobs.isBusy(recording.id) {
                 Button("Transcribe") { state.retranscribe(recording) }
-            } else if !recording.hasAudio, state.progress[recording.id] == nil {
+            } else if !recording.hasAudio, !state.jobs.isBusy(recording.id) {
                 // Without this the row is a dead end: no audio means nothing to
                 // transcribe, and the only way out was to find it in the
                 // sidebar and work out that it should be deleted.
@@ -389,7 +390,7 @@ struct TranscriptView: View {
     }
 
     private var label: String {
-        if state.progress[recording.id] != nil { return "Work in progress" }
+        if state.jobs.isBusy(recording.id) { return "Work in progress" }
         if recording.status == .cancelled { return "Transcription cancelled" }
         guard recording.status == .failed else { return "No transcript yet" }
         // "Transcription failed" is wrong for a recording that never captured
@@ -403,7 +404,7 @@ struct TranscriptView: View {
     }
 
     private var detail: String {
-        if let progress = state.progress[recording.id] {
+        if let progress = state.jobs.progress(for: recording.id) {
             guard let remaining = progress.remaining else { return progress.status.label }
             return "\(progress.status.label) · \(TimeFormat.remaining(seconds: remaining)) left"
         }
@@ -454,7 +455,7 @@ private struct PlaybackFollower: View {
 
 /// "Transcription · 42% · about 14 min left", over a transcript still arriving.
 struct TranscriptProgressBanner: View {
-    let progress: AppState.JobProgress
+    let progress: JobProgress
     let durationMs: Int
     let onCancel: () -> Void
 

--- a/app/Sources/Transcriber/Views/TranscriptView.swift
+++ b/app/Sources/Transcriber/Views/TranscriptView.swift
@@ -556,6 +556,7 @@ struct TranscriptFindBar: View {
 
 struct TranscriptBlockRow: View {
     @Environment(AppState.self) private var state
+    @Environment(\.interfaceMode) private var mode
     @Environment(\.modelContext) private var context
 
     let recording: StoredRecording
@@ -669,7 +670,7 @@ struct TranscriptBlockRow: View {
                     // The one bad window in a long meeting, without the other
                     // four hours. Advanced offers the tiers; Simple takes the
                     // Accurate one, which is why anyone redoes a turn.
-                    if state.settings.isAdvanced {
+                    if mode == .advanced {
                         Menu("Transcribe This Turn Again", systemImage: "arrow.clockwise") {
                             ForEach(ModelTier.allCases) { tier in
                                 Button("\(tier.label) · \(ModelCatalogue.option(state.settings.modelId(for: tier))?.label ?? "")") {

--- a/app/Sources/TranscriberCLI/Notes.swift
+++ b/app/Sources/TranscriberCLI/Notes.swift
@@ -1,0 +1,126 @@
+import Foundation
+import TranscriberCore
+import TranscriberEngine
+
+// `transcribe --notes FILE.json`: a draft of the notes for a recording the
+// app exported as JSON, through the same pipeline and the same backend the
+// app uses, plus the measurement the app does not make: how much of each
+// note is in the transcript, which language the notes lean to, and how many
+// of the hand-written notes in the export the draft also found.
+//
+// The reference is whatever notes the export carries. A meeting with notes
+// written by hand is therefore a scored pair with no extra work.
+
+/// One run, machine-readable. `eval/notes_eval.py` writes the same fields
+/// for an MLX model, so the two can be put side by side.
+struct NotesRunReport: Codable {
+    var document: String
+    var model: String
+    var style: NotesStyle
+    var durationMs: Int
+    var chunkCount: Int
+    var elapsedMs: Int
+    var items: [String: Int]
+    var itemsTotal: Int
+    var withSource: Int
+    var grounding: NotesScoring.Grounding
+    var transcriptLanguage: NotesScoring.LanguageMix
+    var notesLanguage: NotesScoring.LanguageMix
+    var coverage: NotesScoring.Coverage
+    var warnings: [String]
+    var draft: NotesDraft
+}
+
+func runNotes(documentURL: URL, style: NotesStyle, maxCharacters: Int,
+              output: URL?, json: URL?) async -> Never {
+    let document: MeetingDocument
+    do {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        document = try decoder.decode(MeetingDocument.self, from: Data(contentsOf: documentURL))
+    } catch {
+        log("error: could not read \(documentURL.path) as a JSON export: \(error.localizedDescription)")
+        exit(1)
+    }
+    guard let engine = NotesEngines.systemModel() else {
+        log("error: \(NotesAvailability.needsNewerMacOS.message)")
+        exit(1)
+    }
+    let availability = await engine.availability()
+    guard availability.isAvailable else {
+        log("error: \(availability.message)")
+        exit(1)
+    }
+
+    let transcriptText = document.segments.map(\.displayText).joined(separator: " ")
+    let transcriptMix = NotesScoring.languageMix(of: transcriptText)
+    log("document: \(document.title), \(TimeFormat.short(ms: document.durationMs)), "
+        + "\(document.segments.count) segments, \(document.items.count) hand-written notes, "
+        + "\(Int(transcriptMix.tagalogShare * 100)) % Tagalog words")
+    log("model: \(engine.modelId), style: \(style.rawValue), \(maxCharacters) characters per part")
+
+    let draft: NotesDraft
+    do {
+        draft = try await NotesPipeline.generate(
+            segments: document.segments, speakers: document.speakers, title: document.title,
+            style: style, using: engine, maxCharacters: maxCharacters
+        ) { progress in log("  \(progress.label)") }
+    } catch {
+        log("error: \(error.localizedDescription)")
+        exit(1)
+    }
+
+    let rendered = draft.markdown(title: document.title)
+    if let output {
+        do {
+            try rendered.write(to: output, atomically: true, encoding: .utf8)
+            log("wrote \(output.path)")
+        } catch {
+            log("error: could not write \(output.path): \(error.localizedDescription)")
+            exit(1)
+        }
+    } else {
+        print(rendered)
+    }
+
+    let grounding = NotesScoring.grounding(of: draft.items, in: document.segments)
+    let notesMix = NotesScoring.languageMix(of: ([draft.summary] + draft.items.map(\.text)).joined(separator: " "))
+    let coverage = NotesScoring.coverage(reference: document.items, draft: draft.items)
+    log("draft: \(draft.items.count) notes (\(draft.items.filter { $0.sourceMs != nil }.count) with a line) "
+        + "and a summary of \(draft.summary.count) characters, from \(draft.chunkCount) parts in "
+        + "\(TimeFormat.short(ms: draft.elapsedMs))")
+    log(String(format: "grounding: mean overlap %.2f, %d of %d notes under %.1f",
+               grounding.meanOverlap, grounding.ungrounded, grounding.itemsScored,
+               NotesScoring.Grounding.threshold))
+    log("language: transcript \(Int(transcriptMix.tagalogShare * 100)) % Tagalog words, "
+        + "notes \(Int(notesMix.tagalogShare * 100)) %")
+    if coverage.reference > 0 {
+        log("coverage: \(coverage.covered) of \(coverage.reference) hand-written notes are in the draft; "
+            + "\(coverage.matched) of \(coverage.draft) draft notes match a hand-written one")
+    }
+    for warning in draft.warnings { log("  WARNING \(warning)") }
+
+    if let json {
+        let report = NotesRunReport(
+            document: document.title, model: engine.modelId, style: style,
+            durationMs: document.durationMs, chunkCount: draft.chunkCount, elapsedMs: draft.elapsedMs,
+            items: Dictionary(uniqueKeysWithValues: MeetingItemKind.allCases.map { ($0.rawValue, draft.items($0).count) }),
+            itemsTotal: draft.items.count,
+            withSource: draft.items.filter { $0.sourceMs != nil }.count,
+            grounding: grounding, transcriptLanguage: transcriptMix, notesLanguage: notesMix,
+            coverage: coverage, warnings: draft.warnings, draft: draft
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        do {
+            try FileManager.default.createDirectory(at: json.deletingLastPathComponent(),
+                                                    withIntermediateDirectories: true)
+            try encoder.encode(report).write(to: json)
+            log("wrote \(json.path)")
+        } catch {
+            log("error: could not write \(json.path): \(error.localizedDescription)")
+            exit(1)
+        }
+    }
+    exit(0)
+}

--- a/app/Sources/TranscriberCLI/Notes.swift
+++ b/app/Sources/TranscriberCLI/Notes.swift
@@ -12,7 +12,7 @@ import TranscriberEngine
 // written by hand is therefore a scored pair with no extra work.
 
 /// One run, machine-readable. `eval/notes_eval.py` writes the same fields
-/// for an MLX model, so the two can be put side by side.
+/// for a candidate model, so the two can be put side by side.
 struct NotesRunReport: Codable {
     var document: String
     var model: String

--- a/app/Sources/TranscriberCLI/main.swift
+++ b/app/Sources/TranscriberCLI/main.swift
@@ -58,6 +58,10 @@ struct Options {
     /// the other.
     var lane: CaptureLane?
     var logFile: URL?
+    // Automatic notes from an exported recording.
+    var notesDocument: URL?
+    var notesStyle: NotesStyle = .english
+    var notesCharacters = NotesChunker.defaultMaxCharacters
 }
 
 func parse() -> Options {
@@ -102,6 +106,11 @@ func parse() -> Options {
         case "--hop": options.hopMs = value().flatMap(Int.init) ?? options.hopMs
         case "--pre-roll": options.preRollMs = value().flatMap(Int.init) ?? options.preRollMs
         case "--context": options.contextMs = value().flatMap(Int.init) ?? options.contextMs
+        case "--notes": options.notesDocument = value().map { URL(fileURLWithPath: $0) }
+        case "--notes-style":
+            options.notesStyle = value().flatMap { $0 == "spoken" ? .asSpoken : NotesStyle(rawValue: $0) }
+                ?? options.notesStyle
+        case "--notes-chars": options.notesCharacters = value().flatMap(Int.init) ?? options.notesCharacters
         case "--help", "-h":
             print("""
             transcribe --audio FILE [--reference FILE] [--models DIR]
@@ -113,6 +122,8 @@ func parse() -> Options {
             transcribe --record [--source microphone|systemAudio|both] [--device UID]
                        [--seconds N] [--out FILE.m4a] [--gui]
             transcribe --audio FILE --lane room|remote   # one channel of a two-lane file
+            transcribe --notes EXPORT.json [--notes-style english|spoken] [--notes-chars N]
+                       [--out DRAFT.md] [--json REPORT.json]   # automatic notes, scored
             transcribe --devices
             """)
             exit(0)
@@ -184,6 +195,12 @@ if options.channelScan {
 if options.record {
     runRecord(source: options.captureSource, deviceUID: options.deviceUID,
               seconds: options.seconds, out: options.output, gui: options.gui)
+}
+
+// Also before it: this reads an export, not audio.
+if let document = options.notesDocument {
+    await runNotes(documentURL: document, style: options.notesStyle,
+                   maxCharacters: options.notesCharacters, output: options.output, json: options.json)
 }
 
 guard let audioURL = options.audio else {

--- a/app/Sources/TranscriberCore/MeetingNotes.swift
+++ b/app/Sources/TranscriberCore/MeetingNotes.swift
@@ -1,0 +1,762 @@
+import Foundation
+
+// Automatic notes: the pure half.
+//
+// An on-device language model reads the transcript in parts and writes a
+// summary and typed notes into the same shape the user fills by hand --
+// `MeetingItemKind` rows with a source timestamp. Nothing here calls a model.
+// This file decides how the transcript is cut into parts that fit a small
+// context window, how the model's answer is checked and resolved back to a
+// transcript line, and how a draft is measured against the transcript and
+// against hand-written notes. The backends are in TranscriberEngine.
+
+// MARK: - Availability and errors
+
+/// Whether a notes model can run on this Mac, and if not, why.
+public enum NotesAvailability: Equatable, Sendable {
+    case available
+    /// The system framework is not on this version of macOS.
+    case needsNewerMacOS
+    case appleIntelligenceOff
+    /// macOS is still downloading the system model.
+    case modelNotReady
+    case deviceNotEligible
+    case unavailable(String)
+
+    public var isAvailable: Bool { self == .available }
+
+    /// What the app shows in place of the button.
+    public var message: String {
+        switch self {
+        case .available:
+            return "Ready."
+        case .needsNewerMacOS:
+            return "Automatic notes need macOS 26 or later."
+        case .appleIntelligenceOff:
+            return "Turn on Apple Intelligence in System Settings to draft notes on this Mac."
+        case .modelNotReady:
+            return "macOS is still downloading the Apple Intelligence model. Try again later."
+        case .deviceNotEligible:
+            return "This Mac cannot run the Apple Intelligence model."
+        case .unavailable(let why):
+            return why
+        }
+    }
+}
+
+public enum NotesError: LocalizedError, Equatable, Sendable {
+    case unavailable(NotesAvailability)
+    /// One part did not fit the model's window even after it was halved
+    /// down to a single line.
+    case partTooLong
+    /// The model's content filter refused a part.
+    case contentRefused
+    /// The model does not accept the language of the transcript. Measured on
+    /// 2026-09-06: Apple's model refuses a part at 50 % Tagalog words and
+    /// accepts it at 28 % (docs/FINDINGS.md, finding 13).
+    case languageNotSupported
+    case noTranscript
+    case failed(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .unavailable(let availability):
+            return availability.message
+        case .partTooLong:
+            return "One part of the transcript is too long for the model, even as a single line."
+        case .contentRefused:
+            return "The model's content filter refused this part of the transcript."
+        case .languageNotSupported:
+            return "The model does not accept the language of this transcript. Apple's model "
+                 + "refuses text that is mostly Tagalog."
+        case .noTranscript:
+            return "There is no transcript to read."
+        case .failed(let why):
+            return why
+        }
+    }
+}
+
+/// The language of the notes the model writes.
+public enum NotesStyle: String, Codable, CaseIterable, Identifiable, Sendable {
+    case english, asSpoken
+
+    public var id: String { rawValue }
+
+    public var label: String {
+        switch self {
+        case .english: return "English"
+        case .asSpoken: return "As spoken"
+        }
+    }
+
+    public var detail: String {
+        switch self {
+        case .english:
+            return "The notes are in English, whatever language the speakers used."
+        case .asSpoken:
+            return "The notes use the same mix of languages that the speakers used."
+        }
+    }
+}
+
+// MARK: - The draft
+
+/// What the model wrote for a recording, before the user has accepted any of
+/// it. A value, so the review sheet can show it, the CLI can score it and a
+/// test can build one.
+public struct NotesDraft: Codable, Equatable, Sendable {
+    public var summary: String
+    public var items: [Item]
+    /// Which backend and model wrote it.
+    public var modelId: String
+    public var style: NotesStyle
+    /// How many parts the transcript was cut into.
+    public var chunkCount: Int
+    public var elapsedMs: Int
+    /// Parts that were skipped, and why. Shown with the draft, never hidden.
+    public var warnings: [String]
+
+    public struct Item: Identifiable, Codable, Equatable, Sendable {
+        public var id: UUID
+        public var kind: MeetingItemKind
+        public var text: String
+        /// The transcript line the note came from, when the model named a
+        /// timestamp inside the part it was reading. Nil when it did not: no
+        /// back-link is better than a wrong one.
+        public var sourceMs: Int?
+        public var sourceSegmentId: UUID?
+
+        public init(id: UUID = UUID(), kind: MeetingItemKind, text: String,
+                    sourceMs: Int? = nil, sourceSegmentId: UUID? = nil) {
+            self.id = id
+            self.kind = kind
+            self.text = text
+            self.sourceMs = sourceMs
+            self.sourceSegmentId = sourceSegmentId
+        }
+    }
+
+    public init(summary: String, items: [Item], modelId: String, style: NotesStyle,
+                chunkCount: Int, elapsedMs: Int = 0, warnings: [String] = []) {
+        self.summary = summary
+        self.items = items
+        self.modelId = modelId
+        self.style = style
+        self.chunkCount = chunkCount
+        self.elapsedMs = elapsedMs
+        self.warnings = warnings
+    }
+
+    public func items(_ kind: MeetingItemKind) -> [Item] { items.filter { $0.kind == kind } }
+
+    public var isEmpty: Bool { summary.isEmpty && items.isEmpty }
+
+    /// The draft as Markdown, in the order of the minutes export: summary,
+    /// then the five lists with the timestamp of each note. What the CLI
+    /// prints.
+    public func markdown(title: String) -> String {
+        var lines = ["# \(title)", "", "*Draft by \(modelId), \(style.label.lowercased()), "
+                     + "\(chunkCount) part\(chunkCount == 1 ? "" : "s"), \(TimeFormat.short(ms: elapsedMs))*", ""]
+        for warning in warnings { lines.append("> \(warning)") }
+        if !warnings.isEmpty { lines.append("") }
+        if !summary.isEmpty {
+            lines.append("## Summary")
+            lines.append(summary)
+            lines.append("")
+        }
+        for kind in MeetingItemKind.allCases {
+            let rows = items(kind)
+            guard !rows.isEmpty else { continue }
+            lines.append("## \(kind.plural)")
+            for item in rows {
+                var row = kind.isCheckable ? "- [ ] " : "- "
+                row += item.text
+                if let at = item.sourceMs { row += " *(\(TimeFormat.short(ms: at)))*" }
+                lines.append(row)
+            }
+            lines.append("")
+        }
+        return lines.joined(separator: "\n").trimmingCharacters(in: .newlines) + "\n"
+    }
+}
+
+/// Where a draft is, for the pane and the row.
+public struct NotesProgress: Equatable, Sendable {
+    public enum Stage: Equatable, Sendable { case reading, summarizing }
+
+    public var stage: Stage
+    public var chunksDone: Int
+    public var chunkCount: Int
+
+    public init(stage: Stage, chunksDone: Int, chunkCount: Int) {
+        self.stage = stage
+        self.chunksDone = chunksDone
+        self.chunkCount = chunkCount
+    }
+
+    /// Reading is nine tenths of the work; the summary is one call.
+    public var fraction: Double {
+        guard chunkCount > 0 else { return 0 }
+        switch stage {
+        case .reading: return 0.9 * Double(chunksDone) / Double(chunkCount)
+        case .summarizing: return 0.95
+        }
+    }
+
+    public var label: String {
+        switch stage {
+        case .reading: return "Part \(min(chunksDone + 1, chunkCount)) of \(chunkCount)"
+        case .summarizing: return "Writing the summary"
+        }
+    }
+}
+
+// MARK: - Parts of the transcript
+
+/// One stretch of the transcript, cut to fit a model's window, with the
+/// line each timestamp points back to.
+public struct NotesChunk: Equatable, Sendable {
+    public var index: Int
+    public var startMs: Int
+    public var endMs: Int
+    public var lines: [Line]
+
+    /// One speaker turn, or one segment of a turn that was too long.
+    public struct Line: Equatable, Sendable {
+        public var startMs: Int
+        public var segmentId: UUID
+        public var speaker: String?
+        public var text: String
+
+        public init(startMs: Int, segmentId: UUID, speaker: String?, text: String) {
+            self.startMs = startMs
+            self.segmentId = segmentId
+            self.speaker = speaker
+            self.text = text
+        }
+
+        /// `[12:34]`, as the model sees it and is asked to copy it back.
+        public var stamp: String { TimeFormat.short(ms: startMs) }
+
+        public var rendered: String {
+            "[\(stamp)] " + (speaker.map { "\($0): " } ?? "") + text
+        }
+    }
+
+    public init(index: Int, lines: [Line], endMs: Int) {
+        self.index = index
+        self.lines = lines
+        self.startMs = lines.first?.startMs ?? 0
+        self.endMs = max(endMs, startMs)
+    }
+
+    /// The text the model reads: one line per turn.
+    public var text: String { lines.map(\.rendered).joined(separator: "\n") }
+
+    public var characterCount: Int {
+        lines.reduce(0) { $0 + $1.rendered.count + 1 }
+    }
+
+    /// "12:34–18:02", for a warning about this part.
+    public var span: String {
+        "\(TimeFormat.short(ms: startMs))–\(TimeFormat.short(ms: endMs))"
+    }
+}
+
+/// Cuts a transcript into parts that fit a small context window.
+///
+/// Apple's model has a window of 4,096 tokens for the instructions, the part
+/// and the answer together. Tagalog costs more tokens per word than English,
+/// so the budget is stated in characters and kept low. A part is never cut
+/// inside a turn unless the turn alone is over budget.
+public enum NotesChunker {
+
+    /// About 1,400 tokens of Taglish. Leaves room for the instructions, the
+    /// schema and an answer of ten notes.
+    public static let defaultMaxCharacters = 5_000
+
+    /// Turns longer than this are cut at segment boundaries first, so that a
+    /// monologue does not become one 6,000-character line.
+    public static let maxTurnMs = 30_000
+
+    /// One line per turn, with the speaker's display name.
+    public static func lines(from segments: [Segment], speakers: [SpeakerLabel],
+                             maxCharacters: Int = defaultMaxCharacters) -> [NotesChunk.Line] {
+        let names = Dictionary(speakers.map { ($0.id, $0.displayName) }, uniquingKeysWith: { first, _ in first })
+        func name(_ id: String?) -> String? {
+            guard let id else { return nil }
+            return names[id] ?? SpeakerLabel.defaultName(for: id)
+        }
+        var out: [NotesChunk.Line] = []
+        for block in TranscriptGrouping.blocks(from: segments, maxBlockMs: maxTurnMs) {
+            let text = block.text.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !text.isEmpty else { continue }
+            if text.count + 24 <= maxCharacters {
+                out.append(NotesChunk.Line(startMs: block.startMs, segmentId: block.id,
+                                           speaker: name(block.speakerId), text: text))
+            } else {
+                // A turn over budget: one line per segment, so the packer can
+                // cut between them.
+                for segment in block.segments {
+                    let piece = segment.displayText.trimmingCharacters(in: .whitespacesAndNewlines)
+                    guard !piece.isEmpty else { continue }
+                    out.append(NotesChunk.Line(startMs: segment.startMs, segmentId: segment.id,
+                                               speaker: name(segment.speakerId), text: piece))
+                }
+            }
+        }
+        return out
+    }
+
+    /// Packs lines into parts of at most `maxCharacters`. A single line over
+    /// the budget is a part of its own; `halves(of:)` cannot cut it further
+    /// and the pipeline reports it.
+    public static func chunks(lines: [NotesChunk.Line], endMs: Int,
+                              maxCharacters: Int = defaultMaxCharacters) -> [NotesChunk] {
+        var out: [NotesChunk] = []
+        var bucket: [NotesChunk.Line] = []
+        var count = 0
+
+        func flush(next: NotesChunk.Line?) {
+            guard !bucket.isEmpty else { return }
+            out.append(NotesChunk(index: out.count, lines: bucket, endMs: next?.startMs ?? endMs))
+            bucket.removeAll()
+            count = 0
+        }
+
+        for line in lines {
+            let cost = line.rendered.count + 1
+            if !bucket.isEmpty, count + cost > maxCharacters { flush(next: line) }
+            bucket.append(line)
+            count += cost
+        }
+        flush(next: nil)
+        return out
+    }
+
+    public static func chunks(from segments: [Segment], speakers: [SpeakerLabel],
+                              maxCharacters: Int = defaultMaxCharacters) -> [NotesChunk] {
+        let endMs = segments.map(\.endMs).max() ?? 0
+        return chunks(lines: lines(from: segments, speakers: speakers, maxCharacters: maxCharacters),
+                      endMs: endMs, maxCharacters: maxCharacters)
+    }
+
+    /// The part cut in two at a line boundary, for a retry after the model
+    /// said the part was too long. Nil when it is one line already.
+    public static func halves(of chunk: NotesChunk) -> [NotesChunk]? {
+        guard chunk.lines.count >= 2 else { return nil }
+        let middle = chunk.lines.count / 2
+        let first = Array(chunk.lines[..<middle])
+        let second = Array(chunk.lines[middle...])
+        return [
+            NotesChunk(index: chunk.index, lines: first, endMs: second[0].startMs),
+            NotesChunk(index: chunk.index, lines: second, endMs: chunk.endMs),
+        ]
+    }
+}
+
+// MARK: - What the model says about one part
+
+/// The model's answer for one part, as it came back and before it is checked.
+public struct ChunkNotes: Equatable, Sendable {
+    public var summary: String
+    public var items: [Item]
+
+    public struct Item: Equatable, Sendable {
+        public var kind: MeetingItemKind
+        public var text: String
+        /// The timestamp as the model wrote it: "12:34", "[12:34]", "1:02:03".
+        public var at: String?
+
+        public init(kind: MeetingItemKind, text: String, at: String?) {
+            self.kind = kind
+            self.text = text
+            self.at = at
+        }
+    }
+
+    public init(summary: String, items: [Item]) {
+        self.summary = summary
+        self.items = items
+    }
+
+    /// Reads the JSON a text-only backend is asked for:
+    ///
+    ///     {"summary": "...", "items": [{"kind": "decision", "text": "...", "at": "12:34"}]}
+    ///
+    /// Tolerant of prose around the object and of a kind written as its label
+    /// ("Action Item") rather than its raw value. Nil when there is no object
+    /// to read, which the caller counts as a failed part.
+    public static func parse(json text: String) -> ChunkNotes? {
+        parseStrict(text) ?? parseLoose(text)
+    }
+
+    /// The object as valid JSON.
+    static func parseStrict(_ text: String) -> ChunkNotes? {
+        guard let open = text.firstIndex(of: "{"), let close = text.lastIndex(of: "}"),
+              open < close else { return nil }
+        let body = String(text[open...close])
+        guard let data = body.data(using: .utf8),
+              let object = (try? JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed]))
+                as? [String: Any]
+        else { return nil }
+        let summary = (object["summary"] as? String ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        let rawItems = object["items"] as? [[String: Any]] ?? []
+        return ChunkNotes(summary: summary, items: rawItems.compactMap(item(from:)))
+    }
+
+    /// The object as a small model writes it: the summary string and each
+    /// item object read on their own, whatever the brackets around them.
+    /// Measured on 2026-09-06, Qwen2.5-3B closed 8 of 14 answers with `}}}`
+    /// and no `]`, and every one of them held usable items.
+    static func parseLoose(_ text: String) -> ChunkNotes? {
+        guard text.contains("\"summary\"") || text.contains("\"items\"") else { return nil }
+        let summary = string(forKey: "summary", in: text) ?? ""
+        var items: [Item] = []
+        for object in matches(of: #"\{[^{}]*\}"#, in: text) {
+            guard object.contains("\"text\""),
+                  let data = object.data(using: .utf8),
+                  let raw = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+                  let item = item(from: raw) else { continue }
+            items.append(item)
+        }
+        guard !summary.isEmpty || !items.isEmpty else { return nil }
+        return ChunkNotes(summary: summary, items: items)
+    }
+
+    static func item(from raw: [String: Any]) -> Item? {
+        guard let text = raw["text"] as? String,
+              let kind = kind(named: raw["kind"] as? String ?? "") else { return nil }
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        let at = raw["at"] as? String ?? (raw["at"] as? NSNumber).map { TimeFormat.short(ms: $0.intValue * 1000) }
+        return Item(kind: kind, text: trimmed, at: at)
+    }
+
+    /// The JSON string value after `"key":`, unescaped. Nil when there is none.
+    static func string(forKey key: String, in text: String) -> String? {
+        let pattern = "\"\(key)\"\\s*:\\s*(\"(?:[^\"\\\\]|\\\\.)*\")"
+        guard let regex = try? NSRegularExpression(pattern: pattern),
+              let match = regex.firstMatch(in: text, range: NSRange(text.startIndex..., in: text)),
+              let range = Range(match.range(at: 1), in: text),
+              let data = String(text[range]).data(using: .utf8),
+              let value = (try? JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed])) as? String
+        else { return nil }
+        return value.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    static func matches(of pattern: String, in text: String) -> [String] {
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
+        return regex.matches(in: text, range: NSRange(text.startIndex..., in: text))
+            .compactMap { Range($0.range, in: text).map { String(text[$0]) } }
+    }
+
+    /// "decision", "Decision", "action item", "actionItem", "action_item",
+    /// "follow-up"... to the kind. Nil for anything else.
+    public static func kind(named name: String) -> MeetingItemKind? {
+        let key = name.lowercased().filter { $0.isLetter }
+        for kind in MeetingItemKind.allCases {
+            if kind.rawValue.lowercased() == key
+                || kind.label.lowercased().filter({ $0.isLetter }) == key { return kind }
+        }
+        switch key {
+        case "action", "task", "todo": return .actionItem
+        case "followup", "follow": return .followUp
+        case "key", "point", "keypoints", "note", "fact": return .keyPoint
+        case "decided", "decisions", "agreement", "agreed": return .decision
+        case "questions", "open", "openquestion": return .question
+        default: return nil
+        }
+    }
+}
+
+// MARK: - Resolving and merging
+
+/// Turns the model's answers into draft items with back-links, and merges
+/// the answers for several parts into one list.
+public enum NotesReducer {
+
+    /// "12:34", "[12:34]", "1:02:03", "at 12:34" to milliseconds. Nil for
+    /// anything that is not a clock reading.
+    public static func parseStamp(_ text: String?) -> Int? {
+        guard let text else { return nil }
+        let allowed = CharacterSet(charactersIn: "0123456789:")
+        let cleaned = text.unicodeScalars.filter { allowed.contains($0) }
+        let candidate = String(String.UnicodeScalarView(cleaned))
+        guard candidate.contains(":") else { return nil }
+        return TimeFormat.parse(candidate)
+    }
+
+    /// Draft items for one part. An item keeps its back-link only when the
+    /// timestamp the model wrote falls inside the part it was reading; the
+    /// link then points at the line at or before that moment. A timestamp
+    /// outside the part is a copy error, and the item goes in with no link.
+    public static func resolve(_ notes: ChunkNotes, in chunk: NotesChunk) -> [NotesDraft.Item] {
+        notes.items.compactMap { item in
+            let text = item.text.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !text.isEmpty else { return nil }
+            var draft = NotesDraft.Item(kind: item.kind, text: text)
+            if let ms = parseStamp(item.at), ms >= chunk.startMs, ms <= chunk.endMs,
+               let line = chunk.lines.last(where: { $0.startMs <= ms }) ?? chunk.lines.first {
+                draft.sourceMs = line.startMs
+                draft.sourceSegmentId = line.segmentId
+            }
+            return draft
+        }
+    }
+
+    /// Drops a note that says what an earlier note already said. Two notes
+    /// of the same kind are the same when they share most of their content
+    /// words. The first one stays; it has the earlier timestamp.
+    public static func dedupe(_ items: [NotesDraft.Item], threshold: Double = 0.7) -> [NotesDraft.Item] {
+        var kept: [(item: NotesDraft.Item, words: Set<String>)] = []
+        for item in items {
+            let words = contentWords(item.text)
+            let duplicate = kept.contains { previous in
+                previous.item.kind == item.kind && similarity(previous.words, words) >= threshold
+            }
+            if !duplicate { kept.append((item, words)) }
+        }
+        return kept.map(\.item)
+    }
+
+    /// Jaccard over content words; 1 when both are empty.
+    public static func similarity(_ a: Set<String>, _ b: Set<String>) -> Double {
+        let union = a.union(b)
+        guard !union.isEmpty else { return 1 }
+        return Double(a.intersection(b).count) / Double(union.count)
+    }
+
+    /// The words that carry meaning: lower-cased, letters and digits only,
+    /// three characters or more, and not a function word in English or
+    /// Tagalog.
+    public static func contentWords(_ text: String) -> Set<String> {
+        var out: Set<String> = []
+        for raw in text.lowercased().split(whereSeparator: { !$0.isLetter && !$0.isNumber && $0 != "-" && $0 != "'" }) {
+            let word = raw.trimmingCharacters(in: CharacterSet(charactersIn: "-'"))
+            guard word.count >= 3, !stopWords.contains(word) else { continue }
+            out.insert(word)
+        }
+        return out
+    }
+
+    static let stopWords: Set<String> = Set("""
+    the and for that this with have from are was were will would can could should they them their
+    there here what when where which who whom how why not but all any some also into onto about
+    then than been being does did doing has had our you your his her its out over under after
+    before because while just very more most much many such only same other another each both
+    ang mga ito iyan iyon yan yun yung nito dito diyan doon hindi wala walang may mayroon meron
+    kung kasi para pero tapos lang lamang din rin naman daw raw kaya dahil pwede puwede dapat
+    baka siguro talaga medyo masyado lahat bawat ngayon kanina mamaya muna ulit pala nga kaso
+    saka sana yata kapag habang bago hanggang mula tungkol ganito ganyan ganun ganon mas sobrang
+    ako ikaw siya kami tayo kayo sila natin namin ninyo nila niya kita nyo kayong ating
+    """.split(whereSeparator: \.isWhitespace).map(String.init))
+}
+
+// MARK: - Measurement
+
+/// The checks the CLI reports and the tests assert. None of this decides
+/// anything in the app; it is how a backend is measured before it is trusted.
+public enum NotesScoring {
+
+    /// How much of each note's content is in the transcript near its
+    /// timestamp. A note whose words are not there is the model inventing.
+    ///
+    /// A note in English about Tagalog speech scores lower by construction:
+    /// the words differ although the meaning is the same. Compare the two
+    /// styles on the same transcript with that in mind.
+    public struct Grounding: Codable, Equatable, Sendable {
+        public var itemsScored: Int
+        public var meanOverlap: Double
+        /// Items whose overlap is under `threshold`.
+        public var ungrounded: Int
+        public static let threshold = 0.4
+
+        public init(itemsScored: Int, meanOverlap: Double, ungrounded: Int) {
+            self.itemsScored = itemsScored
+            self.meanOverlap = meanOverlap
+            self.ungrounded = ungrounded
+        }
+    }
+
+    /// `windowMs` either side of the note's timestamp is what counts as
+    /// "near". A note with no timestamp is checked against the whole
+    /// transcript.
+    public static func grounding(of items: [NotesDraft.Item], in segments: [Segment],
+                                 windowMs: Int = 120_000) -> Grounding {
+        let sorted = segments.sorted { $0.startMs < $1.startMs }
+        let whole = NotesReducer.contentWords(sorted.map(\.displayText).joined(separator: " "))
+        var overlaps: [Double] = []
+        for item in items {
+            let words = NotesReducer.contentWords(item.text)
+            guard !words.isEmpty else { continue }
+            let nearby: Set<String>
+            if let at = item.sourceMs {
+                let text = sorted
+                    .filter { $0.endMs >= at - windowMs && $0.startMs <= at + windowMs }
+                    .map(\.displayText).joined(separator: " ")
+                nearby = NotesReducer.contentWords(text)
+            } else {
+                nearby = whole
+            }
+            overlaps.append(Double(words.intersection(nearby).count) / Double(words.count))
+        }
+        let mean = overlaps.isEmpty ? 0 : overlaps.reduce(0, +) / Double(overlaps.count)
+        return Grounding(itemsScored: overlaps.count, meanOverlap: mean,
+                         ungrounded: overlaps.filter { $0 < Grounding.threshold }.count)
+    }
+
+    /// Which language a text leans to, by a list of Tagalog function words
+    /// and the hyphenated affixes of Taglish ("i-send", "nag-review"). A
+    /// heuristic for one comparison: the transcript against the notes
+    /// written from it. `eval/langscore.py` has the fuller version.
+    public struct LanguageMix: Codable, Equatable, Sendable {
+        public var words: Int
+        public var tagalogShare: Double
+
+        public init(words: Int, tagalogShare: Double) {
+            self.words = words
+            self.tagalogShare = tagalogShare
+        }
+    }
+
+    public static func languageMix(of text: String) -> LanguageMix {
+        var words = 0
+        var tagalog = 0
+        for raw in text.lowercased().split(whereSeparator: { !$0.isLetter && $0 != "-" && $0 != "'" }) {
+            let word = raw.trimmingCharacters(in: CharacterSet(charactersIn: "-'"))
+            guard !word.isEmpty else { continue }
+            words += 1
+            if tagalogWords.contains(word) || hasTagalogAffix(word) { tagalog += 1 }
+        }
+        return LanguageMix(words: words, tagalogShare: words > 0 ? Double(tagalog) / Double(words) : 0)
+    }
+
+    static func hasTagalogAffix(_ word: String) -> Bool {
+        guard let dash = word.firstIndex(of: "-"), dash > word.startIndex, dash < word.index(before: word.endIndex)
+        else { return false }
+        return tagalogAffixes.contains(String(word[..<dash]))
+    }
+
+    static let tagalogAffixes: Set<String> = [
+        "i", "na", "nag", "mag", "pa", "ma", "pina", "ipa", "ipina", "ka", "um", "in", "maka", "naka",
+        "magpa", "nagpa", "pag", "pinag", "mapa", "napa", "pinaka", "mang", "maki", "naki", "pakiki",
+        "nakiki", "makipag", "nakipag", "mai", "nai",
+    ]
+
+    /// Function words and everyday vocabulary. "at", "may", "no" and "so"
+    /// are left out: they are Tagalog words that also occur in English
+    /// notes, and here they would count against English.
+    static let tagalogWords: Set<String> = Set("""
+    ang ng mga sa na ay si ni kay kina nina ko mo niya namin natin ninyo nila ako ikaw ka siya kami
+    tayo kayo sila ito iyan iyon yan yun yung nito niyan niyon dito diyan doon hindi oo opo wala
+    walang mayroon meron kung kasi para pero tapos lang lamang din rin naman ba po ho daw raw kaya
+    dahil kailangan pwede puwede dapat gusto ayaw baka siguro talaga sobra medyo masyado lahat bawat
+    ilan marami konti kaunti isa dalawa tatlo apat lima ngayon kanina mamaya bukas kahapon araw gabi
+    umaga hapon linggo buwan taon oras sandali muna ulit uli pala nga eh kaso saka sana yata pag
+    kapag habang bago pagkatapos hanggang mula tungkol ganito ganyan ganoon ganun ganon mas pinaka
+    sobrang gawa gawin ginawa gagawin sabi sinabi kita nakita makita tingin tingnan alam alamin
+    kilala punta pumunta bili bumili kain kumain uwi bigay ibigay kuha kunin dala dalhin tawag usap
+    hintay tulong trabaho pera bahay tao anak asawa kaibigan kasama kumpanya opisina tanong sagot
+    problema ayos sige salamat pasensya tama mali totoo sarili ganda mahal mura malaki maliit
+    mahaba maikli matagal mabilis mabagal madali mahirap luma marunong kayong nyo ating
+    """.split(whereSeparator: \.isWhitespace).map(String.init))
+
+    /// How many hand-written notes the draft also has, and how many draft
+    /// notes match a hand-written one. A match shares at least `threshold`
+    /// of the hand-written note's content words.
+    public struct Coverage: Codable, Equatable, Sendable {
+        public var reference: Int
+        public var covered: Int
+        public var draft: Int
+        public var matched: Int
+
+        public init(reference: Int, covered: Int, draft: Int, matched: Int) {
+            self.reference = reference
+            self.covered = covered
+            self.draft = draft
+            self.matched = matched
+        }
+    }
+
+    public static func coverage(reference: [MeetingItem], draft: [NotesDraft.Item],
+                                threshold: Double = 0.5) -> Coverage {
+        let referenceWords = reference.map { NotesReducer.contentWords($0.text) }
+        let draftWords = draft.map { NotesReducer.contentWords($0.text) }
+        var matched = Set<Int>()
+        var covered = 0
+        for words in referenceWords where !words.isEmpty {
+            var hit = false
+            for (index, candidate) in draftWords.enumerated() {
+                let shared = Double(words.intersection(candidate).count) / Double(words.count)
+                if shared >= threshold {
+                    hit = true
+                    matched.insert(index)
+                }
+            }
+            if hit { covered += 1 }
+        }
+        return Coverage(reference: reference.count, covered: covered,
+                        draft: draft.count, matched: matched.count)
+    }
+}
+
+// MARK: - The prompt
+
+/// What every backend tells its model. In one place so that the Swift
+/// backends and the Python harness in `eval/` ask the same thing, and a
+/// change to the wording is measured once.
+public enum NotesPrompt {
+
+    public static func instructions(style: NotesStyle) -> String {
+        let language: String
+        switch style {
+        case .english:
+            language = "Write the notes in English."
+        case .asSpoken:
+            language = "Write the notes in the same mix of languages that the speakers used."
+        }
+        return """
+        You take notes for a meeting. The transcript is from a business meeting in the Philippines. \
+        The speakers mix Tagalog and English. Each line starts with a timestamp in square brackets \
+        and the name of the speaker. \(language) Write only what the transcript supports. Do not \
+        invent a name, a number or a decision. Keep names, product names and numbers exactly as \
+        written. A decision is something the group agreed. An action item is a task that one \
+        person agreed to do. A question is one that was asked and not answered. A follow-up is \
+        something to return to later. A key point is a fact or a position worth keeping.
+        """
+    }
+
+    /// The request for one part, for a backend that returns text rather than
+    /// a typed value. The answer is read by `ChunkNotes.parse(json:)`.
+    public static func request(for chunk: NotesChunk) -> String {
+        """
+        Transcript, part \(chunk.index + 1):
+
+        \(chunk.text)
+
+        Answer with one JSON object and nothing else, in this form:
+        {"summary": "two or three sentences on what this part was about", \
+        "items": [{"kind": "keyPoint|decision|actionItem|question|followUp", \
+        "text": "the note in one sentence", "at": "the timestamp of the line it comes from, copied exactly, for example 12:34"}]}
+        Give at most ten items. Leave the list empty when this part has nothing worth keeping.
+        """
+    }
+
+    /// The request for the whole-meeting summary from the summaries of the
+    /// parts.
+    public static func summaryRequest(partSummaries: [String], title: String) -> String {
+        let numbered = partSummaries.enumerated()
+            .map { "Part \($0.offset + 1): \($0.element)" }
+            .joined(separator: "\n")
+        return """
+        These are the summaries of the parts of the meeting "\(title)", in order:
+
+        \(numbered)
+
+        Write one summary of the whole meeting in three to six sentences: what it was about, \
+        what was decided, and what is still open. Answer with the summary only.
+        """
+    }
+}

--- a/app/Sources/TranscriberEngine/LiveSession.swift
+++ b/app/Sources/TranscriberEngine/LiveSession.swift
@@ -20,6 +20,23 @@ public struct LiveSessionResult: Sendable {
     /// What changed under the recording, in order: a replaced microphone, a
     /// moved default input, a capture that could not be restarted.
     public var notices: [CaptureNotice]
+
+    public init(recordingId: UUID, segments: [Segment], durationMs: Int, archiveFileName: String?,
+                archiveSampleRate: Int, cacheURL: URL, waveform: [Float], stats: SessionStats,
+                modelId: String, language: String, lanes: [CaptureLane], notices: [CaptureNotice]) {
+        self.recordingId = recordingId
+        self.segments = segments
+        self.durationMs = durationMs
+        self.archiveFileName = archiveFileName
+        self.archiveSampleRate = archiveSampleRate
+        self.cacheURL = cacheURL
+        self.waveform = waveform
+        self.stats = stats
+        self.modelId = modelId
+        self.language = language
+        self.lanes = lanes
+        self.notices = notices
+    }
 }
 
 /// Everything a live session needs to know before it starts, in one value.

--- a/app/Sources/TranscriberEngine/LiveSession.swift
+++ b/app/Sources/TranscriberEngine/LiveSession.swift
@@ -22,6 +22,39 @@ public struct LiveSessionResult: Sendable {
     public var notices: [CaptureNotice]
 }
 
+/// Everything a live session needs to know before it starts, in one value.
+///
+/// Six settings used to be copied onto `LiveSession` one property at a time
+/// from four call sites, and the launch warm-up copied four of the six. One
+/// value cannot be half-copied: a caller either hands over a configuration or
+/// it does not. The two knobs a person turns during a recording, the gain and
+/// room mode, stay as properties as well, because they change mid-session.
+public struct LiveConfiguration: Sendable, Equatable {
+    /// The decoder's knobs: language, prompt, hop, context.
+    public var session: SessionConfig
+    /// Whether to decode while recording, or only capture.
+    public var decodeLive: Bool
+    /// Which lanes to record.
+    public var captureSource: CaptureSource
+    /// Which microphone, by UID, or nil to follow the system default.
+    public var microphoneUID: String?
+    /// Microphone boost in decibels at the start. Adjustable afterwards.
+    public var inputGainDb: Float
+    /// High-pass for a far-field room at the start. Adjustable afterwards.
+    public var isRoomMode: Bool
+
+    public init(session: SessionConfig = SessionConfig(), decodeLive: Bool = true,
+                captureSource: CaptureSource = .default, microphoneUID: String? = nil,
+                inputGainDb: Float = InputGain.defaultDb, isRoomMode: Bool = false) {
+        self.session = session
+        self.decodeLive = decodeLive
+        self.captureSource = captureSource
+        self.microphoneUID = microphoneUID
+        self.inputGainDb = inputGainDb
+        self.isRoomMode = isRoomMode
+    }
+}
+
 /// The live path: capture -> working copy -> `LiveDecoder` -> commit -> UI.
 ///
 /// The design contract this exists to keep is that committed text never
@@ -97,7 +130,8 @@ public final class LiveSession {
     public private(set) var vadBackend = "energy"
     public private(set) var recordingId: UUID?
 
-    public var config = SessionConfig()
+    /// The decoder's knobs. Set through `configure(_:)`.
+    public private(set) var config = SessionConfig()
     public var isMuted = false { didSet { capture?.isMuted = isMuted } }
 
     /// Paused: the clock, the file and the live text all stop, and resume
@@ -116,19 +150,35 @@ public final class LiveSession {
         }
     }
 
-    /// Which lanes to record. Read at `start`; changing it mid-session does
-    /// nothing, because the archive's channel count is fixed when the file is
-    /// created.
-    public var captureSource: CaptureSource = .default
+    /// Which lanes to record. Read at `start`; the archive's channel count is
+    /// fixed when the file is created. Set through `configure(_:)`.
+    public private(set) var captureSource: CaptureSource = .default
 
-    /// Which microphone, by UID, or nil to follow the system default.
-    public var microphoneUID: String?
+    /// Which microphone, by UID, or nil to follow the system default. Set
+    /// through `configure(_:)`.
+    public private(set) var microphoneUID: String?
 
     /// Whether to decode while recording. Off, the session only captures --
     /// archive and working copy -- and the whole-file pass runs at stop. That
     /// pass is the better transcript anyway, and a two-hour meeting with no
     /// model running keeps the machine cool and the fan quiet at the table.
-    public var decodeLive = true
+    /// Set through `configure(_:)`.
+    public private(set) var decodeLive = true
+
+    /// Takes every setting the next session needs, in one call. Refused while
+    /// a session is under way: the archive and the decoder are already built
+    /// on the previous values, and a change now would describe a recording
+    /// other than the one being made. The gain and room mode are the
+    /// exception and have their own properties.
+    public func configure(_ configuration: LiveConfiguration) {
+        guard !state.isBusy else { return }
+        config = configuration.session
+        decodeLive = configuration.decodeLive
+        captureSource = configuration.captureSource
+        microphoneUID = configuration.microphoneUID
+        inputGainDb = configuration.inputGainDb
+        isRoomMode = configuration.isRoomMode
+    }
 
     /// Called with each batch of newly committed segments, in order, as soon
     /// as they are committed -- during the recording, not at Stop. This is how

--- a/app/Sources/TranscriberEngine/NotesEngine.swift
+++ b/app/Sources/TranscriberEngine/NotesEngine.swift
@@ -5,7 +5,7 @@ import TranscriberCore
 //
 // The fourth seam beside the three in `Protocols.swift`. Everything above
 // talks to `NotesGenerating` and never to a model framework directly, so a
-// second backend -- an MLX model for a language Apple's model refuses -- is
+// second backend -- for a language Apple's model refuses -- is
 // a new conformance and one line where the app picks one.
 
 // MARK: - The seam

--- a/app/Sources/TranscriberEngine/NotesEngine.swift
+++ b/app/Sources/TranscriberEngine/NotesEngine.swift
@@ -1,0 +1,256 @@
+import Foundation
+import TranscriberCore
+
+// Automatic notes: the backends and the pipeline over them.
+//
+// The fourth seam beside the three in `Protocols.swift`. Everything above
+// talks to `NotesGenerating` and never to a model framework directly, so a
+// second backend -- an MLX model for a language Apple's model refuses -- is
+// a new conformance and one line where the app picks one.
+
+// MARK: - The seam
+
+/// A language model that writes notes from one part of a transcript.
+public protocol NotesGenerating: Sendable {
+    /// Shown with the draft, so the user knows what wrote it.
+    var modelId: String { get }
+    func availability() async -> NotesAvailability
+    /// The summary and the notes for one part. Throws a `NotesError`; the
+    /// pipeline knows what to do with `partTooLong` and `contentRefused`.
+    func notes(for chunk: NotesChunk, style: NotesStyle) async throws -> ChunkNotes
+    /// One summary of the meeting from the summaries of its parts.
+    func summary(partSummaries: [String], title: String, style: NotesStyle) async throws -> String
+}
+
+/// Which backends this build and this Mac have.
+public enum NotesEngines {
+
+    /// Apple's system model, when this macOS has the framework. Nil on
+    /// macOS 15, where nothing in this build can write notes. Whether the
+    /// model can run is the engine's `availability()`, asked at use.
+    public static func systemModel() -> (any NotesGenerating)? {
+        #if canImport(FoundationModels)
+        if #available(macOS 26, *) { return FoundationNotesEngine() }
+        #endif
+        return nil
+    }
+}
+
+// MARK: - The pipeline
+
+/// Reads the transcript part by part, resolves the answers to draft items
+/// with back-links, and writes the summary. Backend-agnostic, so a test
+/// drives it with a fake and the CLI with the real thing.
+public enum NotesPipeline {
+
+    public static func generate(
+        segments: [Segment], speakers: [SpeakerLabel], title: String, style: NotesStyle,
+        using engine: any NotesGenerating,
+        maxCharacters: Int = NotesChunker.defaultMaxCharacters,
+        progress: (@Sendable (NotesProgress) -> Void)? = nil
+    ) async throws -> NotesDraft {
+        guard !segments.isEmpty else { throw NotesError.noTranscript }
+        let availability = await engine.availability()
+        guard availability.isAvailable else { throw NotesError.unavailable(availability) }
+
+        let started = Date()
+        let chunks = NotesChunker.chunks(from: segments, speakers: speakers, maxCharacters: maxCharacters)
+        guard !chunks.isEmpty else { throw NotesError.noTranscript }
+
+        var items: [NotesDraft.Item] = []
+        var summaries: [String] = []
+        var warnings: [String] = []
+        for (done, chunk) in chunks.enumerated() {
+            try Task.checkCancellation()
+            progress?(NotesProgress(stage: .reading, chunksDone: done, chunkCount: chunks.count))
+            let part = try await read(chunk, style: style, using: engine)
+            items.append(contentsOf: part.items)
+            summaries.append(contentsOf: part.summaries)
+            warnings.append(contentsOf: part.warnings)
+        }
+
+        try Task.checkCancellation()
+        progress?(NotesProgress(stage: .summarizing, chunksDone: chunks.count, chunkCount: chunks.count))
+        let summary: String
+        if summaries.count <= 1 {
+            summary = summaries.first ?? ""
+        } else {
+            summary = try await summarize(summaries, title: title, style: style, using: engine)
+        }
+
+        return NotesDraft(
+            summary: summary.trimmingCharacters(in: .whitespacesAndNewlines),
+            items: NotesReducer.dedupe(items),
+            modelId: engine.modelId,
+            style: style,
+            chunkCount: chunks.count,
+            elapsedMs: Int(Date().timeIntervalSince(started) * 1000),
+            warnings: warnings
+        )
+    }
+
+    struct PartResult {
+        var items: [NotesDraft.Item] = []
+        var summaries: [String] = []
+        var warnings: [String] = []
+    }
+
+    /// One part, with the two recoveries. Too long: the part is halved and
+    /// each half read, down to a single line. Refused by the content filter:
+    /// the part is skipped and the draft says so. A language refusal is not
+    /// recovered: the rest of the transcript is in the same language, and a
+    /// draft made from the parts that happened to pass would misrepresent the
+    /// meeting.
+    static func read(_ chunk: NotesChunk, style: NotesStyle,
+                     using engine: any NotesGenerating) async throws -> PartResult {
+        do {
+            let notes = try await engine.notes(for: chunk, style: style)
+            let summary = notes.summary.trimmingCharacters(in: .whitespacesAndNewlines)
+            return PartResult(items: NotesReducer.resolve(notes, in: chunk),
+                              summaries: summary.isEmpty ? [] : [summary])
+        } catch NotesError.partTooLong {
+            guard let halves = NotesChunker.halves(of: chunk) else {
+                return PartResult(warnings: [
+                    "Part \(chunk.index + 1) (\(chunk.span)) is one line that is too long for the model. It was skipped.",
+                ])
+            }
+            var out = PartResult()
+            for half in halves {
+                try Task.checkCancellation()
+                let result = try await read(half, style: style, using: engine)
+                out.items.append(contentsOf: result.items)
+                out.summaries.append(contentsOf: result.summaries)
+                out.warnings.append(contentsOf: result.warnings)
+            }
+            return out
+        } catch NotesError.contentRefused {
+            return PartResult(warnings: [
+                "The model's content filter refused part \(chunk.index + 1) (\(chunk.span)). It was skipped.",
+            ])
+        }
+    }
+
+    /// The whole-meeting summary. When the part summaries together are too
+    /// long for one call, each half is summarized first and the two results
+    /// are summarized together.
+    static func summarize(_ summaries: [String], title: String, style: NotesStyle,
+                          using engine: any NotesGenerating) async throws -> String {
+        do {
+            return try await engine.summary(partSummaries: summaries, title: title, style: style)
+        } catch NotesError.partTooLong where summaries.count >= 2 {
+            let middle = summaries.count / 2
+            let first = try await summarize(Array(summaries[..<middle]), title: title, style: style, using: engine)
+            let second = try await summarize(Array(summaries[middle...]), title: title, style: style, using: engine)
+            return try await engine.summary(partSummaries: [first, second], title: title, style: style)
+        }
+    }
+}
+
+// MARK: - Apple's system model
+
+#if canImport(FoundationModels)
+import FoundationModels
+
+/// The Apple Intelligence model through the Foundation Models framework:
+/// on this Mac, free, and with guided generation so the answer is typed
+/// rather than parsed.
+///
+/// It does not accept Tagalog. Measured on 2026-09-06 on a 93-minute Taglish
+/// meeting: a part with 28 % Tagalog words was accepted, parts with 50 % and
+/// 92 % were refused with `unsupportedLanguageOrLocale` before any
+/// generation, and the guardrail setting made no difference (docs/FINDINGS.md,
+/// finding 13). The pipeline reports that as `NotesError.languageNotSupported`.
+@available(macOS 26, *)
+public struct FoundationNotesEngine: NotesGenerating {
+
+    public let modelId = "apple-foundation-model"
+
+    public init() {}
+
+    public func availability() async -> NotesAvailability {
+        switch SystemLanguageModel.default.availability {
+        case .available:
+            return .available
+        case .unavailable(let reason):
+            switch reason {
+            case .deviceNotEligible: return .deviceNotEligible
+            case .appleIntelligenceNotEnabled: return .appleIntelligenceOff
+            case .modelNotReady: return .modelNotReady
+            @unknown default: return .unavailable("The Apple Intelligence model is not available.")
+            }
+        }
+    }
+
+    public func notes(for chunk: NotesChunk, style: NotesStyle) async throws -> ChunkNotes {
+        // A session per part: the framework keeps the whole conversation in
+        // its window, and two parts in one session would overflow it.
+        let session = LanguageModelSession(instructions: NotesPrompt.instructions(style: style))
+        do {
+            let response = try await session.respond(
+                to: "Transcript, part \(chunk.index + 1):\n\n\(chunk.text)",
+                generating: GeneratedNotes.self,
+                options: GenerationOptions(temperature: 0.2)
+            )
+            return response.content.chunkNotes
+        } catch let error as LanguageModelSession.GenerationError {
+            throw Self.map(error)
+        }
+    }
+
+    public func summary(partSummaries: [String], title: String, style: NotesStyle) async throws -> String {
+        let session = LanguageModelSession(instructions: NotesPrompt.instructions(style: style))
+        do {
+            let response = try await session.respond(
+                to: NotesPrompt.summaryRequest(partSummaries: partSummaries, title: title),
+                options: GenerationOptions(temperature: 0.2)
+            )
+            return response.content
+        } catch let error as LanguageModelSession.GenerationError {
+            throw Self.map(error)
+        }
+    }
+
+    static func map(_ error: LanguageModelSession.GenerationError) -> NotesError {
+        switch error {
+        case .exceededContextWindowSize: return .partTooLong
+        case .guardrailViolation, .refusal: return .contentRefused
+        case .unsupportedLanguageOrLocale: return .languageNotSupported
+        case .assetsUnavailable: return .unavailable(.modelNotReady)
+        default: return .failed(error.localizedDescription)
+        }
+    }
+}
+
+@available(macOS 26, *)
+@Generable
+private enum GeneratedKind: String {
+    case keyPoint, decision, actionItem, question, followUp
+}
+
+@available(macOS 26, *)
+@Generable
+private struct GeneratedItem {
+    @Guide(description: "keyPoint, decision, actionItem, question or followUp")
+    var kind: GeneratedKind
+    @Guide(description: "The note, in one sentence.")
+    var text: String
+    @Guide(description: "The timestamp in square brackets at the start of the transcript line this note comes from, copied exactly, for example 7:05 or 1:02:33")
+    var at: String
+}
+
+@available(macOS 26, *)
+@Generable
+private struct GeneratedNotes {
+    @Guide(description: "Two or three sentences on what this part of the meeting was about.")
+    var summary: String
+    @Guide(description: "The notes worth keeping from this part: decisions made, tasks someone agreed to do, open questions, things to follow up, and the key points. Only what the transcript supports. Empty when there is nothing worth keeping.", .count(0...10))
+    var items: [GeneratedItem]
+
+    var chunkNotes: ChunkNotes {
+        ChunkNotes(summary: summary, items: items.map { item in
+            ChunkNotes.Item(kind: MeetingItemKind(rawValue: item.kind.rawValue) ?? .keyPoint,
+                            text: item.text, at: item.at)
+        })
+    }
+}
+#endif

--- a/app/Sources/TranscriberEngine/TranscriptionQueue.swift
+++ b/app/Sources/TranscriberEngine/TranscriptionQueue.swift
@@ -109,6 +109,20 @@ public struct TranscriptionPayload: Sendable {
     public var didDiarize: Bool
     public var waveform: [Float]
     public var metrics: TranscriptionMetrics
+
+    public init(segments: [Segment], roster: [SpeakerLabel], durationMs: Int, processMs: Int,
+                modelId: String, language: String, didDiarize: Bool, waveform: [Float],
+                metrics: TranscriptionMetrics) {
+        self.segments = segments
+        self.roster = roster
+        self.durationMs = durationMs
+        self.processMs = processMs
+        self.modelId = modelId
+        self.language = language
+        self.didDiarize = didDiarize
+        self.waveform = waveform
+        self.metrics = metrics
+    }
 }
 
 public enum JobEvent: Sendable {

--- a/app/Sources/TranscriberFlow/AutoDraft.swift
+++ b/app/Sources/TranscriberFlow/AutoDraft.swift
@@ -1,0 +1,65 @@
+import Foundation
+import TranscriberCore
+
+/// Whether a finished transcription should draft its notes by itself.
+///
+/// The rule that matters is the last one: **the notes model never runs while
+/// a recording does.** A draft is two minutes of the GPU, and the live
+/// decoder shares it -- a hop that arrives late is dropped, and a dropped hop
+/// is missing words. The whole-file queue already refuses to start work
+/// during a recording for the same reason; this is that rule for the notes.
+///
+/// A decision rather than a branch inside the app state, so a test can put
+/// every combination to it without a model, a microphone or a window.
+nonisolated public enum AutoDraft {
+
+    public enum Decision: Equatable, Sendable {
+        case draft
+        case skip(Skip)
+
+        public var isDraft: Bool { self == .draft }
+    }
+
+    /// Why a draft did not start. Each case is a real state the app reaches,
+    /// and the reason is what the log and the tests name.
+    public enum Skip: String, Equatable, Sendable {
+        /// Settings › General › Automatic notes is off.
+        case turnedOff
+        /// No notes model on this macOS, or the chosen one is not downloaded.
+        case noModel
+        /// The job failed or was cancelled, so there is nothing to read.
+        case notComplete
+        /// Complete, but no rows: a recording that captured silence.
+        case noTranscript
+        /// A recording is running. The model waits.
+        case recording
+        /// A draft for this recording is already running or waiting to be read.
+        case busy
+    }
+
+    /// - Parameters:
+    ///   - enabled: Settings › General › Automatic notes › after a recording.
+    ///   - hasModel: a notes backend exists and its weights are on this Mac.
+    ///   - status: the recording's status now that the job has finished.
+    ///   - hasTranscript: the recording has a transcript with rows.
+    ///   - isRecording: the live session is capturing, paused included.
+    ///   - hasDraft: the notes coordinator already holds a state for it.
+    public static func decide(
+        enabled: Bool,
+        hasModel: Bool,
+        status: TranscriptionStatus,
+        hasTranscript: Bool,
+        isRecording: Bool,
+        hasDraft: Bool
+    ) -> Decision {
+        guard enabled else { return .skip(.turnedOff) }
+        guard hasModel else { return .skip(.noModel) }
+        guard status == .completed else { return .skip(.notComplete) }
+        guard hasTranscript else { return .skip(.noTranscript) }
+        // Checked after the cheap reasons so that the log says "off" rather
+        // than "recording" for a user who never turned this on.
+        guard !isRecording else { return .skip(.recording) }
+        guard !hasDraft else { return .skip(.busy) }
+        return .draft
+    }
+}

--- a/app/Sources/TranscriberFlow/JobCoordinator.swift
+++ b/app/Sources/TranscriberFlow/JobCoordinator.swift
@@ -5,7 +5,7 @@ import TranscriberEngine
 import TranscriberStore
 
 /// Per-recording progress of a job in the queue, as the views show it.
-public struct JobProgress: Equatable, Sendable {
+nonisolated public struct JobProgress: Equatable, Sendable {
     public var status: TranscriptionStatus
     public var fraction: Double
     /// Seconds left in this stage, once enough of it has run to say.

--- a/app/Sources/TranscriberFlow/JobCoordinator.swift
+++ b/app/Sources/TranscriberFlow/JobCoordinator.swift
@@ -1,17 +1,90 @@
 import Foundation
-import SwiftData
-import SwiftUI
+import Observation
 import TranscriberCore
 import TranscriberEngine
 import TranscriberStore
 
-/// Consuming the transcription queue: progress, partial and final transcripts,
-/// warnings, and the time-remaining estimate.
-extension AppState {
+/// Per-recording progress of a job in the queue, as the views show it.
+public struct JobProgress: Equatable, Sendable {
+    public var status: TranscriptionStatus
+    public var fraction: Double
+    /// Seconds left in this stage, once enough of it has run to say.
+    public var remaining: TimeInterval?
+    /// How far into the audio the decode has reached.
+    public var coveredMs: Int
 
-    // MARK: - Job events
+    public init(status: TranscriptionStatus, fraction: Double,
+                remaining: TimeInterval? = nil, coveredMs: Int = 0) {
+        self.status = status
+        self.fraction = fraction
+        self.remaining = remaining
+        self.coveredMs = coveredMs
+    }
+}
 
-    func startPump() {
+/// The reduction from queue events to store writes and to the three values
+/// the views read: progress, warnings and the transcript ticks.
+///
+/// This used to be a private method on the app state, with six bookkeeping
+/// dictionaries beside it that the views read directly. No test reached the
+/// method, and the dictionaries were the interface. Here the reduction owns
+/// its state, the interface is three reads and three commands, and a test
+/// feeds events and checks the store.
+@Observable
+public final class JobCoordinator {
+
+    /// Per-recording pipeline progress, while a job runs.
+    public private(set) var progress: [UUID: JobProgress] = [:]
+    /// Per-recording notes about work that finished imperfectly, kept until a
+    /// new job starts on the recording. Persisted on the row as well.
+    public private(set) var warnings: [UUID: String] = [:]
+    /// Bumped when a job writes rows into a recording's transcript: a batch
+    /// of partial rows, the final rows, the speaker labels, a redone turn.
+    /// The transcript view reads it instead of counting the rows.
+    public private(set) var transcriptTicks: [UUID: Int] = [:]
+
+    /// Jobs handed to the queue, kept until they finish: `.partial` events
+    /// need the model and language the job was started with.
+    private var queuedJobs: [UUID: TranscriptionJob] = [:]
+    /// The revision each running job is appending to, from its first window.
+    private var openTranscripts: [UUID: UUID] = [:]
+    /// When the current stage of each job began and the last estimate made
+    /// from it. The estimate is smoothed against this.
+    private var stageClock: [UUID: StageClock] = [:]
+
+    private struct StageClock {
+        var status: TranscriptionStatus
+        var since: Date
+        var remaining: TimeInterval?
+    }
+
+    private let queue: TranscriptionQueue
+    private let writer: TranscriptWriter
+    private let now: @Sendable () -> Date
+    private var pump: Task<Void, Never>?
+
+    /// - Parameter now: the clock for the time-remaining estimate. Tests
+    ///   pass their own.
+    public init(queue: TranscriptionQueue, writer: TranscriptWriter,
+                now: @escaping @Sendable () -> Date = { Date() }) {
+        self.queue = queue
+        self.writer = writer
+        self.now = now
+    }
+
+    // MARK: - Reads
+
+    public func progress(for id: UUID) -> JobProgress? { progress[id] }
+    public func warning(for id: UUID) -> String? { warnings[id] }
+    public func tick(for id: UUID) -> Int { transcriptTicks[id] ?? 0 }
+    /// Whether a job is queued or running on the recording.
+    public func isBusy(_ id: UUID) -> Bool { progress[id] != nil }
+
+    // MARK: - Commands
+
+    /// Starts consuming the queue's events. Once, at launch.
+    public func start() {
+        guard pump == nil else { return }
         pump = Task { [weak self] in
             guard let self else { return }
             for await event in self.queue.events {
@@ -20,7 +93,32 @@ extension AppState {
         }
     }
 
-    private func handle(_ event: JobEvent) async {
+    /// Hands a job to the queue. The row shows "In queue" at once, and the
+    /// warning from the previous job on the recording is cleared: the new
+    /// job's own warnings are what the row will carry.
+    public func enqueue(_ job: TranscriptionJob) {
+        warnings[job.id] = nil
+        progress[job.id] = JobProgress(status: .pending, fraction: 0)
+        queuedJobs[job.id] = job
+        Task { await queue.enqueue(job) }
+    }
+
+    public func cancel(_ id: UUID) {
+        Task { await queue.cancel(id) }
+    }
+
+    /// A warning from outside the queue, such as the live session's. Added
+    /// to what the recording already carries, never put in its place, and
+    /// persisted so it survives a relaunch.
+    public func addWarning(_ message: String, for id: UUID) async {
+        let joined = Self.join(warnings[id], message)
+        warnings[id] = joined
+        try? await writer.setWarning(joined, for: id)
+    }
+
+    // MARK: - The reduction
+
+    func handle(_ event: JobEvent) async {
         switch event {
         case .queued(let id, _):
             progress[id] = JobProgress(status: .pending, fraction: 0)
@@ -101,9 +199,7 @@ extension AppState {
             // relaunch. Added to what the row already says rather than put in
             // its place: a microphone that was replaced during the recording
             // is still true after the transcription that followed it.
-            let combined = [warnings[id], message].compactMap { $0 }
-            let joined = Array(NSOrderedSet(array: combined)).compactMap { $0 as? String }
-                .joined(separator: " ")
+            let joined = Self.join(warnings[id], message)
             warnings[id] = joined
             try? await writer.setWarning(joined, for: id)
 
@@ -115,6 +211,15 @@ extension AppState {
         }
     }
 
+    /// The existing warning plus a new one, with a repeat dropped.
+    private static func join(_ existing: String?, _ message: String) -> String {
+        var parts: [String] = []
+        for part in [existing, message].compactMap({ $0 }) where !parts.contains(part) {
+            parts.append(part)
+        }
+        return parts.joined(separator: " ")
+    }
+
     /// Seconds left in the current stage, from how long the fraction done has
     /// taken so far. Nothing until 5 % is in, since a first window's timing
     /// says little; smoothed after that so one slow window does not swing the
@@ -122,7 +227,7 @@ extension AppState {
     private func estimateRemaining(_ id: UUID, status: TranscriptionStatus,
                                    fraction: Double) -> TimeInterval? {
         guard status.isBusy else { stageClock[id] = nil; return nil }
-        let now = Date()
+        let now = now()
         guard var clock = stageClock[id], clock.status == status else {
             stageClock[id] = StageClock(status: status, since: now, remaining: nil)
             return nil

--- a/app/Sources/TranscriberFlow/JobCoordinator.swift
+++ b/app/Sources/TranscriberFlow/JobCoordinator.swift
@@ -58,6 +58,11 @@ public final class JobCoordinator {
         var remaining: TimeInterval?
     }
 
+    /// Called when a job leaves the queue, whatever became of it. The app
+    /// reads the recording's own status to find out which. Set once, at
+    /// launch; `AutoDraft` decides what happens next.
+    public var onFinished: ((UUID) -> Void)?
+
     private let queue: TranscriptionQueue
     private let writer: TranscriptWriter
     private let now: @Sendable () -> Date
@@ -208,6 +213,9 @@ public final class JobCoordinator {
             stageClock[id] = nil
             queuedJobs[id] = nil
             openTranscripts[id] = nil
+            // After the bookkeeping, so a handler that reads `isBusy` sees
+            // the job gone rather than still running.
+            onFinished?(id)
         }
     }
 

--- a/app/Sources/TranscriberFlow/NotesCoordinator.swift
+++ b/app/Sources/TranscriberFlow/NotesCoordinator.swift
@@ -1,0 +1,107 @@
+import Foundation
+import Observation
+import TranscriberCore
+import TranscriberEngine
+
+/// One draft of notes per recording, from the request to the review.
+///
+/// The pane reads one value: the state for its recording. Running carries
+/// the progress, ready carries the draft the review sheet shows, failed
+/// carries the message. Nothing is written to the store here: the draft is
+/// a proposal until the user accepts some of it, and that write is
+/// `RecordingStore.apply`.
+@MainActor
+@Observable
+public final class NotesCoordinator {
+
+    public enum State: Equatable, Sendable {
+        case running(NotesProgress)
+        case ready(NotesDraft)
+        case failed(String)
+    }
+
+    public private(set) var states: [UUID: State] = [:]
+    private var tasks: [UUID: Task<Void, Never>] = [:]
+
+    public init() {}
+
+    // MARK: - Reads
+
+    public func state(for id: UUID) -> State? { states[id] }
+
+    public func isBusy(_ id: UUID) -> Bool {
+        if case .running = states[id] { return true }
+        return false
+    }
+
+    public func progress(for id: UUID) -> NotesProgress? {
+        if case .running(let progress) = states[id] { return progress }
+        return nil
+    }
+
+    public func draft(for id: UUID) -> NotesDraft? {
+        if case .ready(let draft) = states[id] { return draft }
+        return nil
+    }
+
+    public func failure(for id: UUID) -> String? {
+        if case .failed(let message) = states[id] { return message }
+        return nil
+    }
+
+    // MARK: - Commands
+
+    /// Starts a draft. The transcript comes in as values, read by the caller
+    /// off the main actor; the pipeline runs detached so the window never
+    /// waits on the chunking, and each progress step hops back here.
+    public func generate(id: UUID, title: String, segments: [Segment], speakers: [SpeakerLabel],
+                         style: NotesStyle, using engine: any NotesGenerating,
+                         maxCharacters: Int = NotesChunker.defaultMaxCharacters) {
+        guard !isBusy(id) else { return }
+        states[id] = .running(NotesProgress(stage: .reading, chunksDone: 0, chunkCount: 0))
+        let report: @Sendable (NotesProgress) -> Void = { [weak self] progress in
+            guard let self else { return }
+            Task { @MainActor in self.advance(id, to: progress) }
+        }
+        tasks[id] = Task.detached { [weak self] in
+            let outcome: State?
+            do {
+                let draft = try await NotesPipeline.generate(
+                    segments: segments, speakers: speakers, title: title, style: style,
+                    using: engine, maxCharacters: maxCharacters, progress: report
+                )
+                outcome = .ready(draft)
+            } catch is CancellationError {
+                outcome = nil
+            } catch {
+                outcome = .failed(error.localizedDescription)
+            }
+            guard let self else { return }
+            await self.finish(id, with: outcome)
+        }
+    }
+
+    private func advance(_ id: UUID, to progress: NotesProgress) {
+        guard isBusy(id) else { return }
+        states[id] = .running(progress)
+    }
+
+    private func finish(_ id: UUID, with outcome: State?) {
+        // A cancel that landed while the pipeline was finishing wins.
+        guard tasks[id] != nil else { return }
+        tasks[id] = nil
+        states[id] = outcome
+    }
+
+    public func cancel(_ id: UUID) {
+        tasks[id]?.cancel()
+        tasks[id] = nil
+        states[id] = nil
+    }
+
+    /// Clears a finished or failed state, after the review sheet closes.
+    public func dismiss(_ id: UUID) {
+        guard !isBusy(id) else { return }
+        states[id] = nil
+    }
+}

--- a/app/Sources/TranscriberFlow/RecordingDisplayStatus.swift
+++ b/app/Sources/TranscriberFlow/RecordingDisplayStatus.swift
@@ -1,0 +1,134 @@
+import Foundation
+import TranscriberCore
+
+/// What the sidebar row, the detail header and the empty transcript show
+/// about the state of one recording.
+///
+/// Three views used to rebuild the same ladder, each with its own branches,
+/// and the warning had two sources: one view read the stored one only, one
+/// read stored-or-in-memory. This is the one ladder. The caller resolves the
+/// inputs; every view reads the same answer.
+nonisolated public struct RecordingDisplayStatus: Equatable, Sendable {
+
+    /// The chip in the row and the header. Nil when the recording is complete
+    /// and quiet.
+    public struct Chip: Equatable, Sendable {
+        public var status: TranscriptionStatus
+        public var fraction: Double
+        public var remaining: TimeInterval?
+    }
+
+    /// The one button beside the chip, when there is one.
+    public enum Action: Equatable, Sendable {
+        /// A job runs; the button stops it.
+        case cancel
+        /// The last job failed and the audio is here.
+        case retry
+        /// The last job was cancelled and the audio is here.
+        case transcribe
+        /// Complete; a second pass on another tier is possible.
+        case transcribeAgain
+    }
+
+    /// What the transcript pane says when it has no rows.
+    public struct EmptyState: Equatable, Sendable {
+        public var title: String
+        public var symbol: String
+        public var detail: String
+    }
+
+    public var chip: Chip?
+    /// The live session is on this recording and paused.
+    public var isPaused: Bool
+    /// A job or the live session is on this recording: no edits now.
+    public var isBusy: Bool
+    /// The note about imperfect work, from one source.
+    public var warning: String?
+    public var action: Action?
+    public var emptyState: EmptyState
+
+    /// - Parameters:
+    ///   - status: the stored status of the recording.
+    ///   - progress: the queue's progress on it, if a job is queued or runs.
+    ///   - isLive: the live session is on this recording, in any phase.
+    ///   - isPaused: that session is paused.
+    ///   - warning: the stored warning, or the coordinator's when the row has
+    ///     none yet. The caller resolves the two sources into one.
+    ///   - hasAudio: the audio file exists.
+    ///   - errorMessage: the stored error of a failed job.
+    public static func make(
+        status: TranscriptionStatus, progress: JobProgress?,
+        isLive: Bool, isPaused: Bool, warning: String?,
+        hasAudio: Bool, errorMessage: String?
+    ) -> RecordingDisplayStatus {
+        let cleanWarning = warning.flatMap { $0.isEmpty ? nil : $0 }
+
+        if let progress {
+            let detail: String
+            if let remaining = progress.remaining {
+                detail = "\(progress.status.label) · \(TimeFormat.remaining(seconds: remaining)) left"
+            } else {
+                detail = progress.status.label
+            }
+            return RecordingDisplayStatus(
+                chip: Chip(status: progress.status, fraction: progress.fraction,
+                           remaining: progress.remaining),
+                isPaused: false, isBusy: true, warning: cleanWarning, action: .cancel,
+                emptyState: EmptyState(title: "Work in progress", symbol: "text.alignleft",
+                                       detail: detail)
+            )
+        }
+
+        if isLive {
+            // Live work never reaches the queue, so it has no progress entry;
+            // the stored status is what there is.
+            return RecordingDisplayStatus(
+                chip: isPaused ? nil : Chip(status: status, fraction: 0, remaining: nil),
+                isPaused: isPaused, isBusy: true, warning: cleanWarning, action: nil,
+                emptyState: EmptyState(title: "Recording", symbol: "waveform",
+                                       detail: "The transcript comes after you stop.")
+            )
+        }
+
+        switch status {
+        case .failed:
+            // "Transcription failed" is wrong for a recording that never
+            // captured anything -- nothing got as far as being transcribed.
+            return RecordingDisplayStatus(
+                chip: Chip(status: .failed, fraction: 0, remaining: nil),
+                isPaused: false, isBusy: false, warning: cleanWarning,
+                action: hasAudio ? .retry : nil,
+                emptyState: EmptyState(
+                    title: hasAudio ? "Transcription failed" : "The recording stopped early",
+                    symbol: "exclamationmark.triangle",
+                    detail: errorMessage ?? Self.noTranscriptDetail(hasAudio: hasAudio))
+            )
+        case .cancelled:
+            return RecordingDisplayStatus(
+                chip: Chip(status: .cancelled, fraction: 0, remaining: nil),
+                isPaused: false, isBusy: false, warning: cleanWarning,
+                action: hasAudio ? .transcribe : nil,
+                emptyState: EmptyState(title: "Transcription cancelled", symbol: "xmark.circle",
+                                       detail: Self.noTranscriptDetail(hasAudio: hasAudio))
+            )
+        default:
+            // Pending with no job, or a stale busy status the queue does not
+            // know: nothing runs. Complete is the common case.
+            return RecordingDisplayStatus(
+                chip: status.isBusy || status == .pending
+                    ? Chip(status: status, fraction: 0, remaining: nil) : nil,
+                isPaused: false, isBusy: false, warning: cleanWarning,
+                action: hasAudio ? .transcribeAgain : nil,
+                emptyState: EmptyState(title: "No transcript yet", symbol: "text.alignleft",
+                                       detail: Self.noTranscriptDetail(hasAudio: hasAudio))
+            )
+        }
+    }
+
+    private static func noTranscriptDetail(hasAudio: Bool) -> String {
+        hasAudio
+            ? "The audio is on this Mac. It has no transcript yet."
+            : "The app captured no audio, thus there is nothing to transcribe. "
+              + "A file that you import becomes a new recording. You can delete this one."
+    }
+}

--- a/app/Sources/TranscriberFlow/StopPlan.swift
+++ b/app/Sources/TranscriberFlow/StopPlan.swift
@@ -1,0 +1,110 @@
+import Foundation
+import TranscriberCore
+import TranscriberEngine
+
+/// What to do with a live session that just stopped, decided before any of
+/// it is done.
+///
+/// The method that stopped a recording was 110 lines that decided and acted
+/// in the same breath: the failure warning, the persister-or-writer choice,
+/// the three-way follow-up, the notice merging and the short-take question,
+/// each between awaited effects. None of the decisions ran without SwiftUI,
+/// a microphone and a model. This value is the decisions; the method that
+/// executes it is awaits only.
+nonisolated public struct StopPlan: Equatable, Sendable {
+
+    /// Where the live transcript, if any, goes.
+    public enum TranscriptStep: Equatable, Sendable {
+        /// The persister that wrote lines during the recording completes its
+        /// revision with the final list.
+        case completePersister
+        /// No persister was open; store the final list as a fresh revision.
+        case storeFresh
+        /// Nothing was decoded live.
+        case none
+    }
+
+    /// The job, if any, that follows the stop.
+    public enum FollowUp: Equatable, Sendable {
+        /// The whole-file pass: the transcript for a capture-only session, and
+        /// the better transcript for a two-lane one, whose live decode ran on
+        /// the lanes summed and cannot say which side a line came from.
+        case fullTranscription
+        /// The live transcript stands; identify the speakers over it.
+        case diarizeOnly(DiarizationMode)
+        /// Done. Drop the working copy unless Settings keeps it.
+        case markCompleted(discardCache: Bool)
+    }
+
+    /// "Keep this recording?" for a take that stopped almost at once.
+    public struct ShortTakeQuestion: Equatable, Sendable {
+        public var durationMs: Int
+        /// Nil when nothing was decoded live, so there is no count to give.
+        public var words: Int?
+    }
+
+    /// The live decoder threw on some or every hop.
+    public var liveFailureWarning: String?
+    public var transcript: TranscriptStep
+    public var followUp: FollowUp
+    /// What changed under the recording: a replaced microphone, a moved
+    /// default input. One string, in order.
+    public var noticesWarning: String?
+    public var shortTake: ShortTakeQuestion?
+
+    /// - Parameters:
+    ///   - result: what the session handed back.
+    ///   - decodedLive: whether the session decoded while it recorded.
+    ///   - hadPersister: whether committed lines were written during the
+    ///     recording, so a revision is already open.
+    ///   - diarizationMode: Settings › After you record.
+    ///   - keepWorkingCopy: Settings › Storage.
+    ///   - shortTakeMs: below this the take is asked about.
+    public static func make(
+        result: LiveSessionResult, decodedLive: Bool, hadPersister: Bool,
+        diarizationMode: DiarizationMode, keepWorkingCopy: Bool, shortTakeMs: Int
+    ) -> StopPlan {
+        var warning: String?
+        if decodedLive, result.stats.failedHops > 0 {
+            let detail = result.stats.lastError.map { " Last error: \($0)" } ?? ""
+            warning = result.stats.hops == 0
+                ? "Live transcription failed for this entire recording "
+                  + "(\(result.stats.failedHops) decode errors).\(detail) "
+                  + "The audio was saved. Use Transcribe Again to recover it."
+                : "\(result.stats.failedHops) decode(s) failed during this "
+                  + "recording, so some words may be missing.\(detail)"
+        }
+
+        let transcript: TranscriptStep = decodedLive
+            ? (hadPersister ? .completePersister : .storeFresh)
+            : .none
+
+        let followUp: FollowUp
+        if !decodedLive || result.lanes.count > 1 {
+            followUp = .fullTranscription
+        } else if diarizationMode.performsDiarization {
+            followUp = .diarizeOnly(diarizationMode)
+        } else {
+            followUp = .markCompleted(discardCache: !keepWorkingCopy)
+        }
+
+        let notices = result.notices.isEmpty
+            ? nil
+            : result.notices.map(\.message).joined(separator: " ")
+
+        var shortTake: ShortTakeQuestion?
+        if result.durationMs < shortTakeMs {
+            shortTake = ShortTakeQuestion(
+                durationMs: result.durationMs,
+                words: decodedLive
+                    ? result.segments.reduce(0) {
+                        $0 + $1.displayText.split(whereSeparator: \.isWhitespace).count
+                    }
+                    : nil
+            )
+        }
+
+        return StopPlan(liveFailureWarning: warning, transcript: transcript, followUp: followUp,
+                        noticesWarning: notices, shortTake: shortTake)
+    }
+}

--- a/app/Sources/TranscriberStore/GraphMutations.swift
+++ b/app/Sources/TranscriberStore/GraphMutations.swift
@@ -1,0 +1,57 @@
+import Foundation
+import SwiftData
+import TranscriberCore
+
+// Two mutations of the recording graph that both sides of the actor seam
+// make: the main-actor store when the user edits, and the writer actor when a
+// job finishes. Each used to exist twice, byte for byte, once per isolation.
+// A fix to either had to be made twice. They are `nonisolated` and take the
+// context they work on, so each caller runs them on its own actor.
+
+/// The roster: one `StoredSpeaker` row per label the diarizer produced, names
+/// the user chose left alone, labels the transcript no longer uses removed.
+public enum SpeakerSync {
+
+    /// Ensures a row exists for every label in `roster`, updates the talk time
+    /// and the colour of the rows that stay, and deletes the rows for labels
+    /// that are gone. A re-run with fewer speakers would otherwise leave
+    /// ghosts in the roster.
+    nonisolated public static func apply(_ roster: [SpeakerLabel],
+                                         to recording: StoredRecording,
+                                         in context: ModelContext) {
+        var existing = Dictionary(
+            (recording.speakers ?? []).map { ($0.speakerId, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        for (offset, label) in roster.enumerated() {
+            if let row = existing.removeValue(forKey: label.id) {
+                row.speechMs = label.speechMs
+                row.colorIndex = offset
+            } else {
+                let row = StoredSpeaker(speakerId: label.id,
+                                        displayName: label.displayName,
+                                        speechMs: label.speechMs,
+                                        colorIndex: offset)
+                row.recording = recording
+                context.insert(row)
+            }
+        }
+        for orphan in existing.values { context.delete(orphan) }
+    }
+}
+
+/// The flattened text that search reads: title, summary, notes, every
+/// transcript line as displayed, every item and every bookmark label.
+public enum SearchIndex {
+
+    /// Rebuilds `searchText`. Called after any edit to the transcript or the
+    /// notes, and once when a job finishes. It reads the transcript through
+    /// the same indexed fetch as everything else.
+    nonisolated public static func rebuild(_ recording: StoredRecording) {
+        var parts = [recording.title, recording.summary, recording.body]
+        parts.append(contentsOf: (recording.transcript?.orderedSegments ?? []).map(\.displayText))
+        parts.append(contentsOf: (recording.items ?? []).map(\.text))
+        parts.append(contentsOf: (recording.bookmarks ?? []).map(\.label))
+        recording.searchText = parts.filter { !$0.isEmpty }.joined(separator: "\n")
+    }
+}

--- a/app/Sources/TranscriberStore/NotesApply.swift
+++ b/app/Sources/TranscriberStore/NotesApply.swift
@@ -1,0 +1,38 @@
+import Foundation
+import SwiftData
+import TranscriberCore
+
+/// Writing an accepted draft into the recording.
+extension RecordingStore {
+
+    /// Adds the accepted items as typed rows with their back-links, after the
+    /// rows of the same kind the recording already has, and replaces the
+    /// summary when one is given. Nil leaves the summary as it is: a summary
+    /// the user wrote is never overwritten without the user asking.
+    @discardableResult
+    public static func apply(_ items: [NotesDraft.Item], summary: String?,
+                             to recording: StoredRecording, in context: ModelContext) throws -> Int {
+        var next: [MeetingItemKind: Int] = [:]
+        for row in recording.items ?? [] {
+            next[row.kind] = max(next[row.kind] ?? 0, row.order + 1)
+        }
+        for item in items {
+            let text = item.text.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !text.isEmpty else { continue }
+            let order = next[item.kind] ?? 0
+            next[item.kind] = order + 1
+            let row = StoredMeetingItem(kind: item.kind, text: text, order: order,
+                                        sourceSegmentId: item.sourceSegmentId,
+                                        sourceMs: item.sourceMs)
+            row.recording = recording
+            context.insert(row)
+        }
+        if let summary {
+            recording.summary = summary.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        recording.updatedAt = Date()
+        SearchIndex.rebuild(recording)
+        try context.save()
+        return items.count
+    }
+}

--- a/app/Sources/TranscriberStore/RecordingStore.swift
+++ b/app/Sources/TranscriberStore/RecordingStore.swift
@@ -29,10 +29,16 @@ public enum RecordingStore {
     }
 
     public static func defaultTitle(for kind: RecordingKind, at date: Date) -> String {
+        "\(kind.label) \(titleFormatter.string(from: date))"
+    }
+
+    /// One formatter for the life of the process. `DateFormatter` is costly
+    /// to make and this is a static helper, so a fresh one per call was waste.
+    private static let titleFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "d MMM, HH:mm"
-        return "\(kind.label) \(formatter.string(from: date))"
-    }
+        return formatter
+    }()
 
     // MARK: - Deleting
 

--- a/app/Sources/TranscriberStore/RecordingStore.swift
+++ b/app/Sources/TranscriberStore/RecordingStore.swift
@@ -165,31 +165,11 @@ public enum RecordingStore {
 
     // MARK: - Speakers
 
-    /// Ensures a `StoredSpeaker` row exists for every label the diarizer used,
-    /// leaving names the user already chose alone.
+    /// The main-actor entry to `SpeakerSync.apply`.
     public static func syncSpeakers(_ roster: [SpeakerLabel],
                                     on recording: StoredRecording,
                                     in context: ModelContext) {
-        var existing = Dictionary(
-            (recording.speakers ?? []).map { ($0.speakerId, $0) },
-            uniquingKeysWith: { first, _ in first }
-        )
-        for (offset, label) in roster.enumerated() {
-            if let row = existing.removeValue(forKey: label.id) {
-                row.speechMs = label.speechMs
-                row.colorIndex = offset
-            } else {
-                let row = StoredSpeaker(speakerId: label.id,
-                                        displayName: label.displayName,
-                                        speechMs: label.speechMs,
-                                        colorIndex: offset)
-                row.recording = recording
-                context.insert(row)
-            }
-        }
-        // Labels no longer produced by the current transcript: drop them, or a
-        // re-run with fewer speakers leaves ghosts in the roster.
-        for orphan in existing.values { context.delete(orphan) }
+        SpeakerSync.apply(roster, to: recording, in: context)
     }
 
     public static func rename(_ speaker: StoredSpeaker, to name: String,
@@ -370,12 +350,9 @@ public enum RecordingStore {
         )
     }
 
-    /// Rebuilds the flattened search text. Called after any transcript or note edit.
+    /// The main-actor entry to `SearchIndex.rebuild`. Called after any
+    /// transcript or note edit.
     public static func reindex(_ recording: StoredRecording) {
-        var parts = [recording.title, recording.summary, recording.body]
-        parts.append(contentsOf: (recording.transcript?.orderedSegments ?? []).map(\.displayText))
-        parts.append(contentsOf: (recording.items ?? []).map(\.text))
-        parts.append(contentsOf: (recording.bookmarks ?? []).map(\.label))
-        recording.searchText = parts.filter { !$0.isEmpty }.joined(separator: "\n")
+        SearchIndex.rebuild(recording)
     }
 }

--- a/app/Sources/TranscriberStore/TranscriptWriter.swift
+++ b/app/Sources/TranscriberStore/TranscriptWriter.swift
@@ -77,9 +77,9 @@ public actor TranscriptWriter {
         modelContext.insert(transcript)
         insert(segments, into: transcript)
 
-        syncSpeakers(roster, on: recording)
+        SpeakerSync.apply(roster, to: recording, in: modelContext)
         recording.updatedAt = Date()
-        RecordingStore.reindexOffMain(recording)
+        SearchIndex.rebuild(recording)
         try modelContext.save()
         return revision
     }
@@ -152,9 +152,9 @@ public actor TranscriptWriter {
         transcript.didDiarize = didDiarize
         transcript.isComplete = true
 
-        syncSpeakers(roster, on: recording)
+        SpeakerSync.apply(roster, to: recording, in: modelContext)
         recording.updatedAt = Date()
-        RecordingStore.reindexOffMain(recording)
+        SearchIndex.rebuild(recording)
         try modelContext.save()
         return transcript.revision
     }
@@ -185,7 +185,7 @@ public actor TranscriptWriter {
             row.index = index
         }
         recording.updatedAt = Date()
-        RecordingStore.reindexOffMain(recording)
+        SearchIndex.rebuild(recording)
         try modelContext.save()
         return removed
     }
@@ -223,30 +223,9 @@ public actor TranscriptWriter {
             )?.speakerId
         }
         transcript.didDiarize = true
-        syncSpeakers(roster, on: recording)
+        SpeakerSync.apply(roster, to: recording, in: modelContext)
         recording.updatedAt = Date()
         try modelContext.save()
-    }
-
-    private func syncSpeakers(_ roster: [SpeakerLabel], on recording: StoredRecording) {
-        var existing = Dictionary(
-            (recording.speakers ?? []).map { ($0.speakerId, $0) },
-            uniquingKeysWith: { first, _ in first }
-        )
-        for (offset, label) in roster.enumerated() {
-            if let row = existing.removeValue(forKey: label.id) {
-                row.speechMs = label.speechMs
-                row.colorIndex = offset
-            } else {
-                let row = StoredSpeaker(speakerId: label.id,
-                                        displayName: label.displayName,
-                                        speechMs: label.speechMs,
-                                        colorIndex: offset)
-                row.recording = recording
-                modelContext.insert(row)
-            }
-        }
-        for orphan in existing.values { modelContext.delete(orphan) }
     }
 
     private func find(_ id: UUID) throws -> StoredRecording? {
@@ -255,19 +234,5 @@ public actor TranscriptWriter {
         )
         descriptor.fetchLimit = 1
         return try modelContext.fetch(descriptor).first
-    }
-}
-
-extension RecordingStore {
-    /// The same flattening as `reindex`, callable from the writer actor.
-    ///
-    /// `RecordingStore` is main-actor because it is the UI's entry point; the
-    /// background writer needs this one operation and nothing else from it.
-    nonisolated static func reindexOffMain(_ recording: StoredRecording) {
-        var parts = [recording.title, recording.summary, recording.body]
-        parts.append(contentsOf: (recording.transcript?.orderedSegments ?? []).map(\.displayText))
-        parts.append(contentsOf: (recording.items ?? []).map(\.text))
-        parts.append(contentsOf: (recording.bookmarks ?? []).map(\.label))
-        recording.searchText = parts.filter { !$0.isEmpty }.joined(separator: "\n")
     }
 }

--- a/app/Tests/TranscriberCoreTests/MeetingNotesTests.swift
+++ b/app/Tests/TranscriberCoreTests/MeetingNotesTests.swift
@@ -1,0 +1,257 @@
+import XCTest
+@testable import TranscriberCore
+
+final class MeetingNotesTests: XCTestCase {
+
+    private func segment(_ index: Int, _ start: Int, _ end: Int, _ text: String,
+                         speaker: String? = "S1") -> Segment {
+        Segment(index: index, startMs: start, endMs: end, text: text, speakerId: speaker)
+    }
+
+    private let roster = [SpeakerLabel(id: "S1", displayName: "Juan"),
+                          SpeakerLabel(id: "S2", displayName: "Maria")]
+
+    /// A meeting of alternating turns, `count` segments of ~40 characters.
+    private func meeting(_ count: Int) -> [Segment] {
+        (0..<count).map { i in
+            segment(i, i * 5_000, i * 5_000 + 4_000,
+                    "Line \(i) tungkol sa product taxonomy at flowchart.",
+                    speaker: i % 2 == 0 ? "S1" : "S2")
+        }
+    }
+
+    // MARK: - Chunker
+
+    func testLinesCarryTheSpeakerNameAndTheStamp() {
+        let lines = NotesChunker.lines(from: meeting(2), speakers: roster)
+        XCTAssertEqual(lines.count, 2)
+        XCTAssertEqual(lines[0].speaker, "Juan")
+        XCTAssertEqual(lines[1].speaker, "Maria")
+        XCTAssertEqual(lines[0].rendered, "[0:00] Juan: Line 0 tungkol sa product taxonomy at flowchart.")
+        XCTAssertEqual(lines[1].stamp, "0:05")
+    }
+
+    func testAnUnnamedSpeakerGetsTheDefaultNameAndNoSpeakerGetsNone() {
+        let lines = NotesChunker.lines(from: [
+            segment(0, 0, 1_000, "Hello", speaker: "S7"),
+            segment(1, 5_000, 6_000, "Hello again", speaker: nil),
+        ], speakers: [])
+        XCTAssertEqual(lines[0].speaker, "Speaker 7")
+        XCTAssertNil(lines[1].speaker)
+        XCTAssertEqual(lines[1].rendered, "[0:05] Hello again")
+    }
+
+    func testChunksStayUnderTheBudgetAndCoverEveryLine() {
+        let segments = meeting(40)
+        let chunks = NotesChunker.chunks(from: segments, speakers: roster, maxCharacters: 300)
+        XCTAssertGreaterThan(chunks.count, 1)
+        for chunk in chunks {
+            XCTAssertLessThanOrEqual(chunk.characterCount, 300, "part \(chunk.index) over budget")
+        }
+        let rendered = chunks.flatMap(\.lines).map(\.text)
+        XCTAssertEqual(rendered.count, 40)
+        XCTAssertEqual(Set(chunks.flatMap(\.lines).map(\.segmentId)), Set(segments.map(\.id)))
+        // Indexed in order, and each part ends where the next begins.
+        XCTAssertEqual(chunks.map(\.index), Array(0..<chunks.count))
+        for (a, b) in zip(chunks, chunks.dropFirst()) {
+            XCTAssertEqual(a.endMs, b.startMs)
+        }
+        XCTAssertEqual(chunks.last?.endMs, segments.last?.endMs)
+    }
+
+    func testATurnOverTheBudgetIsCutAtSegmentBoundaries() {
+        // Ten segments from one speaker with no gap: one 500-character turn.
+        let segments = (0..<10).map { i in
+            segment(i, i * 2_000, i * 2_000 + 1_900, String(repeating: "salita ", count: 7))
+        }
+        let chunks = NotesChunker.chunks(from: segments, speakers: roster, maxCharacters: 200)
+        XCTAssertGreaterThan(chunks.count, 1)
+        for chunk in chunks { XCTAssertLessThanOrEqual(chunk.characterCount, 200) }
+        XCTAssertEqual(chunks.flatMap(\.lines).count, 10, "one line per segment once the turn is over budget")
+    }
+
+    func testHalvesCutAtALineAndRefuseASingleLine() {
+        let chunks = NotesChunker.chunks(from: meeting(6), speakers: roster, maxCharacters: 10_000)
+        XCTAssertEqual(chunks.count, 1)
+        let halves = NotesChunker.halves(of: chunks[0])!
+        XCTAssertEqual(halves.count, 2)
+        XCTAssertEqual(halves[0].lines.count, 3)
+        XCTAssertEqual(halves[1].lines.count, 3)
+        XCTAssertEqual(halves[0].endMs, halves[1].startMs)
+        XCTAssertEqual(halves[1].endMs, chunks[0].endMs)
+
+        let single = NotesChunk(index: 0, lines: [chunks[0].lines[0]], endMs: 4_000)
+        XCTAssertNil(NotesChunker.halves(of: single))
+    }
+
+    // MARK: - Parsing what the model said
+
+    func testParseReadsTheObjectOutOfProseAndAcceptsLabelsAsKinds() {
+        let text = """
+        Here are the notes:
+        {"summary": "Taxonomy was discussed.", "items": [
+          {"kind": "Action Item", "text": "Maria to send the sheet.", "at": "[12:34]"},
+          {"kind": "decision", "text": "Colour is an attribute.", "at": "13:02"},
+          {"kind": "follow-up", "text": "Review on Thursday.", "at": 800},
+          {"kind": "nonsense", "text": "dropped"},
+          {"kind": "question", "text": "   "}
+        ]}
+        Hope this helps.
+        """
+        let notes = ChunkNotes.parse(json: text)!
+        XCTAssertEqual(notes.summary, "Taxonomy was discussed.")
+        XCTAssertEqual(notes.items.map(\.kind), [.actionItem, .decision, .followUp])
+        XCTAssertEqual(notes.items[0].at, "[12:34]")
+        XCTAssertEqual(notes.items[2].at, "13:20", "a bare number is read as seconds")
+    }
+
+    func testParseReturnsNilWithoutAnObject() {
+        XCTAssertNil(ChunkNotes.parse(json: "I cannot do that."))
+        XCTAssertNil(ChunkNotes.parse(json: "{not json}"))
+    }
+
+    func testParseReadsAnAnswerWithBrokenBrackets() {
+        // What Qwen2.5-3B wrote on 8 of 14 parts: the items array is never
+        // closed, and the object ends with three braces.
+        let text = """
+        {"summary": "The team discusses \\"groupings\\".", "items": [{"kind": "keyPoint", "text": "One", "at": "6:42"}, \
+        {"kind": "decision", "text": "Two", "at": "7:05"}}}
+        """
+        let notes = ChunkNotes.parse(json: text)!
+        XCTAssertEqual(notes.summary, "The team discusses \"groupings\".")
+        XCTAssertEqual(notes.items.map(\.text), ["One", "Two"])
+        XCTAssertEqual(notes.items.map(\.kind), [.keyPoint, .decision])
+        XCTAssertEqual(notes.items[1].at, "7:05")
+    }
+
+    func testKindNames() {
+        XCTAssertEqual(ChunkNotes.kind(named: "actionItem"), .actionItem)
+        XCTAssertEqual(ChunkNotes.kind(named: "action_item"), .actionItem)
+        XCTAssertEqual(ChunkNotes.kind(named: "Key Point"), .keyPoint)
+        XCTAssertEqual(ChunkNotes.kind(named: "Follow-up"), .followUp)
+        XCTAssertEqual(ChunkNotes.kind(named: "task"), .actionItem)
+        XCTAssertNil(ChunkNotes.kind(named: "remark"))
+    }
+
+    func testParseStamp() {
+        XCTAssertEqual(NotesReducer.parseStamp("12:34"), 754_000)
+        XCTAssertEqual(NotesReducer.parseStamp("[12:34]"), 754_000)
+        XCTAssertEqual(NotesReducer.parseStamp("at 1:02:03"), 3_723_000)
+        XCTAssertEqual(NotesReducer.parseStamp("07:05"), 425_000)
+        XCTAssertNil(NotesReducer.parseStamp("later"))
+        XCTAssertNil(NotesReducer.parseStamp("12:99"))
+        XCTAssertNil(NotesReducer.parseStamp(nil))
+    }
+
+    // MARK: - Resolving
+
+    func testResolveLinksAStampInsideThePartToTheLineAtOrBeforeIt() {
+        let segments = meeting(6) // lines at 0:00, 0:05, 0:10, 0:15, 0:20, 0:25
+        let chunk = NotesChunker.chunks(from: segments, speakers: roster)[0]
+        let notes = ChunkNotes(summary: "", items: [
+            ChunkNotes.Item(kind: .decision, text: "Inside, exact", at: "0:10"),
+            ChunkNotes.Item(kind: .decision, text: "Inside, between lines", at: "0:17"),
+            ChunkNotes.Item(kind: .keyPoint, text: "Outside the part", at: "45:00"),
+            ChunkNotes.Item(kind: .question, text: "No stamp", at: nil),
+            ChunkNotes.Item(kind: .question, text: "  ", at: "0:05"),
+        ])
+        let items = NotesReducer.resolve(notes, in: chunk)
+        XCTAssertEqual(items.count, 4, "the empty note is dropped")
+        XCTAssertEqual(items[0].sourceMs, 10_000)
+        XCTAssertEqual(items[0].sourceSegmentId, segments[2].id)
+        XCTAssertEqual(items[1].sourceMs, 15_000)
+        XCTAssertNil(items[2].sourceMs, "a stamp outside the part is a copy error, not a link")
+        XCTAssertNil(items[3].sourceMs)
+    }
+
+    func testDedupeDropsARestatementOfTheSameKindOnly() {
+        let items = [
+            NotesDraft.Item(kind: .decision, text: "Paint colour goes in attributes, not variants.", sourceMs: 1_000),
+            NotesDraft.Item(kind: .decision, text: "Paint colour goes in the attributes and not in the variants.", sourceMs: 9_000),
+            NotesDraft.Item(kind: .keyPoint, text: "Paint colour goes in attributes, not variants.", sourceMs: 2_000),
+            NotesDraft.Item(kind: .decision, text: "Version sits above variant.", sourceMs: 3_000),
+        ]
+        let kept = NotesReducer.dedupe(items)
+        XCTAssertEqual(kept.map(\.sourceMs), [1_000, 2_000, 3_000])
+    }
+
+    func testContentWordsDropFunctionWordsInBothLanguages() {
+        let words = NotesReducer.contentWords("Ang product taxonomy ay tungkol sa mga variants, and the colour is an attribute.")
+        XCTAssertEqual(words, ["product", "taxonomy", "variants", "colour", "attribute"])
+    }
+
+    // MARK: - Measurement
+
+    func testGroundingSeparatesANoteFromTheTranscriptFromAnInventedOne() {
+        let segments = [
+            segment(0, 0, 4_000, "Paint colour goes in attributes kasi every colour costs the same."),
+            segment(1, 5_000, 9_000, "Version is its own level above variant."),
+            segment(2, 600_000, 604_000, "Maria will send the link bukas."),
+        ]
+        let grounded = NotesDraft.Item(kind: .decision, text: "Paint colour goes in attributes because every colour costs the same.", sourceMs: 0)
+        let invented = NotesDraft.Item(kind: .decision, text: "The budget was approved by the finance committee.", sourceMs: 0)
+        let farAway = NotesDraft.Item(kind: .actionItem, text: "Maria sends the link.", sourceMs: 0)
+
+        let score = NotesScoring.grounding(of: [grounded, invented, farAway], in: segments, windowMs: 60_000)
+        XCTAssertEqual(score.itemsScored, 3)
+        XCTAssertEqual(score.ungrounded, 2, "the invented note and the note whose words are ten minutes away")
+
+        let alone = NotesScoring.grounding(of: [grounded], in: segments)
+        XCTAssertEqual(alone.meanOverlap, 1, accuracy: 0.001)
+
+        let unlinked = NotesDraft.Item(kind: .actionItem, text: "Maria sends the link.")
+        XCTAssertEqual(NotesScoring.grounding(of: [unlinked], in: segments).ungrounded, 0,
+                       "with no timestamp the whole transcript counts")
+    }
+
+    func testLanguageMixLeansTheRightWay() {
+        let tagalog = NotesScoring.languageMix(of: "Sige, mag-start na tayo. Na-send ko na yung email kahapon pero hindi pa na-approve.")
+        let english = NotesScoring.languageMix(of: "The group agreed to review the taxonomy on Thursday and send the sheet to Maria.")
+        XCTAssertGreaterThan(tagalog.tagalogShare, 0.5)
+        XCTAssertLessThan(english.tagalogShare, 0.1)
+        XCTAssertEqual(english.words, 15)
+    }
+
+    func testCoverageCountsHandWrittenNotesTheDraftAlsoHas() {
+        let reference = [
+            MeetingItem(kind: .decision, text: "Paint color goes in attributes, not variants, because every color costs the same."),
+            MeetingItem(kind: .followUp, text: "The sub-modules will be worked on Thursday."),
+            MeetingItem(kind: .actionItem, text: "Send Maria the link and confirm with him."),
+        ]
+        let draft = [
+            NotesDraft.Item(kind: .decision, text: "Paint color is an attribute rather than a variant since every color costs the same."),
+            NotesDraft.Item(kind: .keyPoint, text: "The backbone is shared by everyone."),
+        ]
+        let coverage = NotesScoring.coverage(reference: reference, draft: draft)
+        XCTAssertEqual(coverage.reference, 3)
+        XCTAssertEqual(coverage.covered, 1)
+        XCTAssertEqual(coverage.draft, 2)
+        XCTAssertEqual(coverage.matched, 1)
+    }
+
+    // MARK: - Prompt
+
+    func testPromptNamesTheStyleAndThePart() {
+        XCTAssertTrue(NotesPrompt.instructions(style: .english).contains("in English"))
+        XCTAssertTrue(NotesPrompt.instructions(style: .asSpoken).contains("same mix of languages"))
+        let chunk = NotesChunker.chunks(from: meeting(2), speakers: roster)[0]
+        let request = NotesPrompt.request(for: chunk)
+        XCTAssertTrue(request.contains("part 1"))
+        XCTAssertTrue(request.contains("[0:05] Maria:"))
+        XCTAssertTrue(request.contains("\"items\""))
+        let summary = NotesPrompt.summaryRequest(partSummaries: ["A", "B"], title: "Taxonomy")
+        XCTAssertTrue(summary.contains("Part 2: B"))
+        XCTAssertTrue(summary.contains("\"Taxonomy\""))
+    }
+
+    func testProgressLabelsAndFraction() {
+        let reading = NotesProgress(stage: .reading, chunksDone: 2, chunkCount: 10)
+        XCTAssertEqual(reading.label, "Part 3 of 10")
+        XCTAssertEqual(reading.fraction, 0.18, accuracy: 0.001)
+        let last = NotesProgress(stage: .reading, chunksDone: 10, chunkCount: 10)
+        XCTAssertEqual(last.label, "Part 10 of 10")
+        let summarizing = NotesProgress(stage: .summarizing, chunksDone: 10, chunkCount: 10)
+        XCTAssertEqual(summarizing.label, "Writing the summary")
+        XCTAssertEqual(summarizing.fraction, 0.95)
+    }
+}

--- a/app/Tests/TranscriberEngineTests/InputGainSessionTests.swift
+++ b/app/Tests/TranscriberEngineTests/InputGainSessionTests.swift
@@ -52,6 +52,33 @@ final class InputGainSessionTests: XCTestCase {
         XCTAssertEqual(session.inputGainDb, InputGain.minDb)
     }
 
+    /// One value carries every setting the session reads. A caller cannot
+    /// forget a field, which is how the launch warm-up once prepared a
+    /// session with four of six.
+    func testConfigureSetsEveryField() {
+        let session = makeSession()
+        let configuration = LiveConfiguration(
+            session: SessionConfig(hopMs: 1_200, language: "en"),
+            decodeLive: false, captureSource: .both, microphoneUID: "mic-42",
+            inputGainDb: 9, isRoomMode: true
+        )
+        session.configure(configuration)
+        XCTAssertEqual(session.config.hopMs, 1_200)
+        XCTAssertEqual(session.config.language, "en")
+        XCTAssertFalse(session.decodeLive)
+        XCTAssertEqual(session.captureSource, .both)
+        XCTAssertEqual(session.microphoneUID, "mic-42")
+        XCTAssertEqual(session.inputGainDb, 9)
+        XCTAssertTrue(session.isRoomMode)
+
+        // The default value is the app's default too.
+        session.configure(LiveConfiguration())
+        XCTAssertTrue(session.decodeLive)
+        XCTAssertEqual(session.captureSource, .default)
+        XCTAssertNil(session.microphoneUID)
+        XCTAssertEqual(session.inputGainDb, InputGain.defaultDb)
+    }
+
     /// Pause is a flag the audio callback reads per buffer, like gain. A
     /// session that ends paused must not leave the next one paused.
     func testPauseRoundTripsAndClearsTheMeter() throws {

--- a/app/Tests/TranscriberEngineTests/NotesPipelineTests.swift
+++ b/app/Tests/TranscriberEngineTests/NotesPipelineTests.swift
@@ -1,0 +1,227 @@
+import XCTest
+import TranscriberCore
+@testable import TranscriberEngine
+
+/// The pipeline over a scripted backend: what it does with the two
+/// recoverable errors, the one that is not, cancellation and progress.
+final class NotesPipelineTests: XCTestCase {
+
+    /// Answers by part index, and records what it was asked.
+    actor ScriptedEngine: NotesGenerating {
+        nonisolated let modelId = "fake"
+        var availabilityValue: NotesAvailability = .available
+        /// Part index -> error to throw the first `n` times it is asked.
+        var failures: [Int: (error: NotesError, times: Int)] = [:]
+        /// Every chunk the engine was handed, in order.
+        var asked: [NotesChunk] = []
+        var summaryCalls: [[String]] = []
+        var summaryTooLongAbove = Int.max
+
+        func set(availability: NotesAvailability) { availabilityValue = availability }
+        func fail(part: Int, with error: NotesError, times: Int = 1) { failures[part] = (error, times) }
+        func setSummaryTooLongAbove(_ count: Int) { summaryTooLongAbove = count }
+
+        func availability() async -> NotesAvailability { availabilityValue }
+
+        func notes(for chunk: NotesChunk, style: NotesStyle) async throws -> ChunkNotes {
+            asked.append(chunk)
+            if let failure = failures[chunk.index], failure.times > 0 {
+                failures[chunk.index] = (failure.error, failure.times - 1)
+                throw failure.error
+            }
+            // One decision per part, pointing at the part's first line. The
+            // text names the line, so two parts' decisions do not read as
+            // one restated and get merged by the reducer.
+            let first = chunk.lines[0]
+            return ChunkNotes(summary: "Part \(chunk.index) from \(first.stamp).", items: [
+                ChunkNotes.Item(kind: .decision, text: "Agreed on line\(chunk.startMs) of the taxonomy", at: first.stamp),
+                ChunkNotes.Item(kind: .keyPoint, text: "Point with no stamp", at: nil),
+            ])
+        }
+
+        func summary(partSummaries: [String], title: String, style: NotesStyle) async throws -> String {
+            summaryCalls.append(partSummaries)
+            if partSummaries.count > summaryTooLongAbove { throw NotesError.partTooLong }
+            return "Summary of \(partSummaries.count) parts of \(title)."
+        }
+    }
+
+    private func meeting(_ count: Int) -> [Segment] {
+        (0..<count).map { i in
+            Segment(index: i, startMs: i * 5_000, endMs: i * 5_000 + 4_000,
+                    text: "Line \(i) tungkol sa product taxonomy at flowchart.",
+                    speakerId: i % 2 == 0 ? "S1" : "S2")
+        }
+    }
+
+    private let roster = [SpeakerLabel(id: "S1", displayName: "Juan"),
+                          SpeakerLabel(id: "S2", displayName: "Maria")]
+
+    func testReadsEveryPartResolvesLinksAndSummarizesOnce() async throws {
+        let engine = ScriptedEngine()
+        let progressBox = ProgressBox()
+        let draft = try await NotesPipeline.generate(
+            segments: meeting(40), speakers: roster, title: "Taxonomy", style: .english,
+            using: engine, maxCharacters: 400
+        ) { progressBox.append($0) }
+
+        let asked = await engine.asked
+        XCTAssertGreaterThan(asked.count, 2)
+        XCTAssertEqual(draft.chunkCount, asked.count)
+        XCTAssertEqual(draft.modelId, "fake")
+        XCTAssertEqual(draft.style, .english)
+        XCTAssertTrue(draft.warnings.isEmpty)
+
+        // One decision per part with a link, and the unlinked key point kept
+        // once: the parts all said "Point with no stamp".
+        let decisions = draft.items(.decision)
+        XCTAssertEqual(decisions.count, asked.count)
+        XCTAssertEqual(decisions.map(\.sourceMs), asked.map(\.startMs))
+        XCTAssertEqual(decisions.map(\.sourceSegmentId), asked.map { $0.lines[0].segmentId })
+        XCTAssertEqual(draft.items(.keyPoint).count, 1)
+
+        let summaries = await engine.summaryCalls
+        XCTAssertEqual(summaries.count, 1)
+        XCTAssertEqual(summaries[0].count, asked.count)
+        XCTAssertEqual(draft.summary, "Summary of \(asked.count) parts of Taxonomy.")
+
+        let seen = progressBox.values
+        XCTAssertEqual(seen.first, NotesProgress(stage: .reading, chunksDone: 0, chunkCount: asked.count))
+        XCTAssertEqual(seen.last?.stage, .summarizing)
+        XCTAssertEqual(seen.filter { $0.stage == .reading }.count, asked.count)
+    }
+
+    func testOnePartUsesItsOwnSummaryWithNoSecondCall() async throws {
+        let engine = ScriptedEngine()
+        let draft = try await NotesPipeline.generate(
+            segments: meeting(4), speakers: roster, title: "Short", style: .asSpoken, using: engine)
+        XCTAssertEqual(draft.chunkCount, 1)
+        XCTAssertEqual(draft.summary, "Part 0 from 0:00.")
+        let calls = await engine.summaryCalls
+        XCTAssertTrue(calls.isEmpty)
+    }
+
+    func testAPartThatIsTooLongIsHalvedAndBothHalvesRead() async throws {
+        let engine = ScriptedEngine()
+        await engine.fail(part: 0, with: .partTooLong)
+        let draft = try await NotesPipeline.generate(
+            segments: meeting(8), speakers: roster, title: "Long", style: .english, using: engine)
+
+        let asked = await engine.asked
+        XCTAssertEqual(asked.count, 3, "the whole part, then its two halves")
+        XCTAssertEqual(asked[1].lines.count, 4)
+        XCTAssertEqual(asked[2].lines.count, 4)
+        XCTAssertEqual(asked[1].endMs, asked[2].startMs)
+        XCTAssertEqual(draft.items(.decision).map(\.sourceMs), [0, 20_000])
+        XCTAssertTrue(draft.warnings.isEmpty)
+        XCTAssertEqual(draft.chunkCount, 1, "the halves are retries, not parts")
+    }
+
+    func testASingleLineThatIsTooLongIsSkippedWithAWarning() async throws {
+        let engine = ScriptedEngine()
+        await engine.fail(part: 0, with: .partTooLong, times: 10)
+        let draft = try await NotesPipeline.generate(
+            segments: meeting(1), speakers: roster, title: "One line", style: .english, using: engine)
+        XCTAssertTrue(draft.items.isEmpty)
+        XCTAssertEqual(draft.warnings.count, 1)
+        XCTAssertTrue(draft.warnings[0].contains("too long"))
+    }
+
+    func testARefusedPartIsSkippedAndTheRestIsKept() async throws {
+        let engine = ScriptedEngine()
+        await engine.fail(part: 1, with: .contentRefused)
+        let draft = try await NotesPipeline.generate(
+            segments: meeting(40), speakers: roster, title: "Refused", style: .english,
+            using: engine, maxCharacters: 400)
+        XCTAssertEqual(draft.warnings.count, 1)
+        XCTAssertTrue(draft.warnings[0].contains("refused part 2"))
+        XCTAssertEqual(draft.items(.decision).count, draft.chunkCount - 1)
+    }
+
+    func testALanguageRefusalStopsTheDraft() async throws {
+        let engine = ScriptedEngine()
+        await engine.fail(part: 1, with: .languageNotSupported)
+        do {
+            _ = try await NotesPipeline.generate(
+                segments: meeting(40), speakers: roster, title: "Tagalog", style: .english,
+                using: engine, maxCharacters: 400)
+            XCTFail("expected a throw")
+        } catch let error as NotesError {
+            XCTAssertEqual(error, .languageNotSupported)
+        }
+    }
+
+    func testAnUnavailableModelThrowsBeforeAnyPartIsRead() async throws {
+        let engine = ScriptedEngine()
+        await engine.set(availability: .appleIntelligenceOff)
+        do {
+            _ = try await NotesPipeline.generate(
+                segments: meeting(4), speakers: roster, title: "Off", style: .english, using: engine)
+            XCTFail("expected a throw")
+        } catch let error as NotesError {
+            XCTAssertEqual(error, .unavailable(.appleIntelligenceOff))
+        }
+        let asked = await engine.asked
+        XCTAssertTrue(asked.isEmpty)
+    }
+
+    func testAnEmptyTranscriptThrows() async throws {
+        do {
+            _ = try await NotesPipeline.generate(
+                segments: [], speakers: [], title: "Empty", style: .english, using: ScriptedEngine())
+            XCTFail("expected a throw")
+        } catch let error as NotesError {
+            XCTAssertEqual(error, .noTranscript)
+        }
+    }
+
+    func testTooManySummariesAreFolded() async throws {
+        let engine = ScriptedEngine()
+        await engine.setSummaryTooLongAbove(3)
+        let draft = try await NotesPipeline.generate(
+            segments: meeting(60), speakers: roster, title: "Folded", style: .english,
+            using: engine, maxCharacters: 400)
+        let calls = await engine.summaryCalls
+        XCTAssertGreaterThan(draft.chunkCount, 3)
+        XCTAssertEqual(calls[0].count, draft.chunkCount, "the first call tries everything")
+        XCTAssertEqual(calls.last?.count, 2, "the last call joins the two halves")
+        XCTAssertEqual(draft.summary, "Summary of 2 parts of Folded.")
+    }
+
+    func testCancellationStopsBetweenParts() async throws {
+        let engine = SlowEngine()
+        let segments = meeting(40)
+        let speakers = roster
+        let task = Task {
+            try await NotesPipeline.generate(
+                segments: segments, speakers: speakers, title: "Slow", style: .english,
+                using: engine, maxCharacters: 400)
+        }
+        try await Task.sleep(for: .milliseconds(50))
+        task.cancel()
+        do {
+            _ = try await task.value
+            XCTFail("expected cancellation")
+        } catch is CancellationError {
+            // expected
+        }
+    }
+
+    /// Takes a while per part, so a cancel lands mid-way.
+    actor SlowEngine: NotesGenerating {
+        nonisolated let modelId = "slow"
+        func availability() async -> NotesAvailability { .available }
+        func notes(for chunk: NotesChunk, style: NotesStyle) async throws -> ChunkNotes {
+            try await Task.sleep(for: .milliseconds(30))
+            return ChunkNotes(summary: "s", items: [])
+        }
+        func summary(partSummaries: [String], title: String, style: NotesStyle) async throws -> String { "s" }
+    }
+
+    final class ProgressBox: @unchecked Sendable {
+        private let lock = NSLock()
+        private var stored: [NotesProgress] = []
+        func append(_ value: NotesProgress) { lock.lock(); stored.append(value); lock.unlock() }
+        var values: [NotesProgress] { lock.lock(); defer { lock.unlock() }; return stored }
+    }
+}

--- a/app/Tests/TranscriberFlowTests/AutoDraftTests.swift
+++ b/app/Tests/TranscriberFlowTests/AutoDraftTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+import TranscriberCore
+@testable import TranscriberFlow
+
+final class AutoDraftTests: XCTestCase {
+
+    /// Every argument in the state where a draft should start. Each test
+    /// below changes one of them.
+    private func decide(
+        enabled: Bool = true, hasModel: Bool = true, status: TranscriptionStatus = .completed,
+        hasTranscript: Bool = true, isRecording: Bool = false, hasDraft: Bool = false
+    ) -> AutoDraft.Decision {
+        AutoDraft.decide(enabled: enabled, hasModel: hasModel, status: status,
+                         hasTranscript: hasTranscript, isRecording: isRecording, hasDraft: hasDraft)
+    }
+
+    func testACompletedTranscriptionDrafts() {
+        XCTAssertEqual(decide(), .draft)
+        XCTAssertTrue(decide().isDraft)
+    }
+
+    func testTheSettingIsTheFirstGate() {
+        XCTAssertEqual(decide(enabled: false), .skip(.turnedOff))
+        // Off wins over every other reason, so a user who never turned this
+        // on is never told the app skipped because of a recording.
+        XCTAssertEqual(decide(enabled: false, hasModel: false, status: .failed,
+                              hasTranscript: false, isRecording: true, hasDraft: true),
+                       .skip(.turnedOff))
+    }
+
+    func testNoModelSkips() {
+        XCTAssertEqual(decide(hasModel: false), .skip(.noModel))
+    }
+
+    /// The status the job left behind decides, not the fact that it ended.
+    func testOnlyACompletedRecordingDrafts() {
+        XCTAssertEqual(decide(status: .failed), .skip(.notComplete))
+        XCTAssertEqual(decide(status: .cancelled), .skip(.notComplete))
+        XCTAssertEqual(decide(status: .transcribing), .skip(.notComplete))
+        XCTAssertEqual(decide(status: .recording), .skip(.notComplete))
+    }
+
+    func testASilentRecordingHasNothingToRead() {
+        XCTAssertEqual(decide(hasTranscript: false), .skip(.noTranscript))
+    }
+
+    /// The rule this exists for: a two-minute draft must not take the GPU
+    /// from a live decoder, whose dropped hops are missing words.
+    func testARunningRecordingStopsTheDraft() {
+        XCTAssertEqual(decide(isRecording: true), .skip(.recording))
+    }
+
+    func testADraftThatIsAlreadyThereIsNotRepeated() {
+        XCTAssertEqual(decide(hasDraft: true), .skip(.busy))
+    }
+}

--- a/app/Tests/TranscriberFlowTests/JobCoordinatorTests.swift
+++ b/app/Tests/TranscriberFlowTests/JobCoordinatorTests.swift
@@ -1,0 +1,190 @@
+import Foundation
+import SwiftData
+import XCTest
+import TranscriberCore
+import TranscriberEngine
+import TranscriberStore
+@testable import TranscriberFlow
+
+/// The reduction from queue events to the store and to what the views read,
+/// driven with events and checked against a real in-memory store.
+@MainActor
+final class JobCoordinatorTests: XCTestCase {
+
+    private var container: ModelContainer!
+    private var writer: TranscriptWriter!
+    private var clock: Date!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        container = try StoreContainer.ephemeral()
+        writer = TranscriptWriter(modelContainer: container)
+        clock = Date(timeIntervalSinceReferenceDate: 1_000)
+    }
+
+    override func tearDown() async throws {
+        writer = nil
+        container = nil
+        try await super.tearDown()
+    }
+
+    private func makeCoordinator() -> JobCoordinator {
+        let queue = TranscriptionQueue(engines: EngineHost(modelsDirectory: URL(fileURLWithPath: "/nonexistent")))
+        let clockBox = ClockBox(self.clock)
+        self.clockBox = clockBox
+        return JobCoordinator(queue: queue, writer: writer) { clockBox.now }
+    }
+
+    private final class ClockBox: @unchecked Sendable {
+        var now: Date
+        init(_ now: Date) { self.now = now }
+    }
+    private var clockBox: ClockBox!
+
+    private func advance(_ seconds: TimeInterval) {
+        clockBox.now = clockBox.now.addingTimeInterval(seconds)
+    }
+
+    private func recording() throws -> StoredRecording {
+        try RecordingStore.create(kind: .recording, title: "Job", in: container.mainContext)
+    }
+
+    private func fresh(_ id: UUID) throws -> StoredRecording? {
+        try ModelContext(container).fetch(FetchDescriptor<StoredRecording>(
+            predicate: #Predicate { $0.id == id }
+        )).first
+    }
+
+    private func job(_ id: UUID) -> TranscriptionJob {
+        TranscriptionJob(id: id, title: "Job", sourceURL: nil,
+                         cacheURL: URL(fileURLWithPath: "/tmp/x.wav"),
+                         modelId: "model", language: "tl")
+    }
+
+    func testEnqueueShowsTheQueueAtOnceAndClearsTheOldWarning() async throws {
+        let coordinator = makeCoordinator()
+        let id = try recording().id
+        await coordinator.addWarning("old", for: id)
+        XCTAssertEqual(coordinator.warning(for: id), "old")
+
+        coordinator.enqueue(job(id))
+        XCTAssertEqual(coordinator.progress(for: id)?.status, .pending)
+        XCTAssertTrue(coordinator.isBusy(id))
+        XCTAssertNil(coordinator.warning(for: id))
+    }
+
+    func testStageWritesTheStatusOnceAndTheFractionNever() async throws {
+        let coordinator = makeCoordinator()
+        let id = try recording().id
+        await coordinator.handle(.queued(id: id, title: "Job"))
+        await coordinator.handle(.stage(id: id, status: .transcribing, progress: 0))
+        await coordinator.handle(.stage(id: id, status: .transcribing, progress: 0.4))
+
+        XCTAssertEqual(coordinator.progress(for: id)?.fraction, 0.4)
+        let row = try XCTUnwrap(try fresh(id))
+        XCTAssertEqual(row.status, .transcribing)
+        XCTAssertEqual(row.progress, 0, "only the stage change reaches the store")
+    }
+
+    func testPartialRowsThenTheFinalTranscriptReachTheStore() async throws {
+        let coordinator = makeCoordinator()
+        let id = try recording().id
+        coordinator.enqueue(job(id))
+        await coordinator.handle(.queued(id: id, title: "Job"))
+        await coordinator.handle(.stage(id: id, status: .transcribing, progress: 0))
+        await coordinator.handle(.partial(id: id, segments: [
+            Segment(index: 0, startMs: 0, endMs: 900, text: "una"),
+            Segment(index: 1, startMs: 1_000, endMs: 1_900, text: "dalawa"),
+        ], coveredMs: 2_000))
+
+        XCTAssertEqual(coordinator.tick(for: id), 1)
+        XCTAssertEqual(coordinator.progress(for: id)?.coveredMs, 2_000)
+        var row = try XCTUnwrap(try fresh(id))
+        XCTAssertEqual(row.transcript?.orderedSegments.map(\.text), ["una", "dalawa"])
+        XCTAssertEqual(row.transcript?.isComplete, false)
+
+        let payload = TranscriptionPayload(
+            segments: [Segment(index: 0, startMs: 0, endMs: 1_900, text: "una dalawa", speakerId: "S1")],
+            roster: [SpeakerLabel(id: "S1", displayName: "Speaker 1", speechMs: 1_900)],
+            durationMs: 2_000, processMs: 50, modelId: "model", language: "tl",
+            didDiarize: true, waveform: [0.5], metrics: TranscriptionMetrics()
+        )
+        await coordinator.handle(.transcribed(id: id, payload: payload))
+        await coordinator.handle(.stage(id: id, status: .completed, progress: 1))
+        await coordinator.handle(.finished(id: id))
+
+        XCTAssertEqual(coordinator.tick(for: id), 2)
+        XCTAssertNil(coordinator.progress(for: id), "finished clears the progress")
+        XCTAssertFalse(coordinator.isBusy(id))
+        row = try XCTUnwrap(try fresh(id))
+        XCTAssertEqual(row.transcript?.orderedSegments.map(\.text), ["una dalawa"])
+        XCTAssertEqual(row.transcript?.isComplete, true)
+        XCTAssertEqual(row.transcript?.revision, 1, "the partial revision was completed, not replaced")
+        XCTAssertEqual(row.speakers?.count, 1)
+        XCTAssertEqual(row.durationMs, 2_000)
+        XCTAssertEqual(row.status, .completed)
+    }
+
+    func testWarningsAccumulateWithoutRepeatsAndPersist() async throws {
+        let coordinator = makeCoordinator()
+        let id = try recording().id
+        await coordinator.handle(.warning(id: id, message: "A window was dropped."))
+        await coordinator.handle(.warning(id: id, message: "A window was dropped."))
+        await coordinator.handle(.warning(id: id, message: "The microphone changed."))
+        await coordinator.addWarning("Live decoding failed.", for: id)
+
+        let expected = "A window was dropped. The microphone changed. Live decoding failed."
+        XCTAssertEqual(coordinator.warning(for: id), expected)
+        XCTAssertEqual(try fresh(id)?.warningMessage, expected)
+    }
+
+    func testFailureWritesTheMessageToTheRow() async throws {
+        let coordinator = makeCoordinator()
+        let id = try recording().id
+        await coordinator.handle(.failed(id: id, message: "no audio"))
+        let row = try XCTUnwrap(try fresh(id))
+        XCTAssertEqual(row.status, .failed)
+        XCTAssertEqual(row.errorMessage, "no audio")
+    }
+
+    func testTimeRemainingWaitsForFivePercentThenSmooths() async throws {
+        let coordinator = makeCoordinator()
+        let id = try recording().id
+        await coordinator.handle(.queued(id: id, title: "Job"))
+        await coordinator.handle(.stage(id: id, status: .transcribing, progress: 0))
+        XCTAssertNil(coordinator.progress(for: id)?.remaining, "the stage has only just begun")
+
+        advance(10)
+        await coordinator.handle(.stage(id: id, status: .transcribing, progress: 0.5))
+        XCTAssertEqual(coordinator.progress(for: id)?.remaining ?? -1, 10, accuracy: 0.01,
+                       "half in ten seconds means ten more")
+
+        advance(10)
+        await coordinator.handle(.stage(id: id, status: .transcribing, progress: 0.75))
+        // Raw: 20 s for 75 % leaves 6.67 s. Smoothed 70/30 against the 10 s.
+        XCTAssertEqual(coordinator.progress(for: id)?.remaining ?? -1, 9.0, accuracy: 0.01)
+
+        // A new stage starts its own clock.
+        await coordinator.handle(.stage(id: id, status: .diarizing, progress: 0))
+        XCTAssertNil(coordinator.progress(for: id)?.remaining)
+    }
+
+    func testARedoneTurnBumpsTheTickAndReplacesRows() async throws {
+        let coordinator = makeCoordinator()
+        let rec = try recording()
+        let id = rec.id
+        _ = try await writer.storeTranscript(
+            segments: [Segment(index: 0, startMs: 0, endMs: 900, text: "a"),
+                       Segment(index: 1, startMs: 5_000, endMs: 5_900, text: "bad"),
+                       Segment(index: 2, startMs: 9_000, endMs: 9_900, text: "c")],
+            roster: [], modelId: "m", language: "tl", processMs: 1, didDiarize: false, for: id
+        )
+        await coordinator.handle(.rangeTranscribed(
+            id: id, fromMs: 5_000, toMs: 6_000,
+            segments: [Segment(index: 0, startMs: 5_100, endMs: 5_800, text: "good")],
+            modelId: "accurate"
+        ))
+        XCTAssertEqual(coordinator.tick(for: id), 1)
+        XCTAssertEqual(try fresh(id)?.transcript?.orderedSegments.map(\.text), ["a", "good", "c"])
+    }
+}

--- a/app/Tests/TranscriberFlowTests/JobCoordinatorTests.swift
+++ b/app/Tests/TranscriberFlowTests/JobCoordinatorTests.swift
@@ -73,6 +73,34 @@ final class JobCoordinatorTests: XCTestCase {
         XCTAssertNil(coordinator.warning(for: id))
     }
 
+    /// The hook the automatic draft hangs on. It fires after the job's own
+    /// bookkeeping, so a handler that asks `isBusy` is told the truth.
+    func testFinishedCallsBackOnceTheJobIsNoLongerBusy() async throws {
+        let coordinator = makeCoordinator()
+        let id = try recording().id
+        let seen = Box()
+        coordinator.onFinished = { finished in seen.record(finished, busy: coordinator.isBusy(finished)) }
+
+        coordinator.enqueue(job(id))
+        XCTAssertTrue(coordinator.isBusy(id))
+        XCTAssertTrue(seen.ids.isEmpty, "nothing yet")
+
+        await coordinator.handle(.finished(id: id))
+        XCTAssertEqual(seen.ids, [id])
+        XCTAssertEqual(seen.busyWhenCalled, [false])
+        XCTAssertFalse(coordinator.isBusy(id))
+    }
+
+    @MainActor
+    final class Box {
+        var ids: [UUID] = []
+        var busyWhenCalled: [Bool] = []
+        func record(_ id: UUID, busy: Bool) {
+            ids.append(id)
+            busyWhenCalled.append(busy)
+        }
+    }
+
     func testStageWritesTheStatusOnceAndTheFractionNever() async throws {
         let coordinator = makeCoordinator()
         let id = try recording().id

--- a/app/Tests/TranscriberFlowTests/NotesCoordinatorTests.swift
+++ b/app/Tests/TranscriberFlowTests/NotesCoordinatorTests.swift
@@ -1,0 +1,92 @@
+import Foundation
+import XCTest
+import TranscriberCore
+import TranscriberEngine
+@testable import TranscriberFlow
+
+@MainActor
+final class NotesCoordinatorTests: XCTestCase {
+
+    actor StubEngine: NotesGenerating {
+        nonisolated let modelId = "stub"
+        let outcome: Result<Void, NotesError>
+        let delayMs: Int
+        init(outcome: Result<Void, NotesError> = .success(()), delayMs: Int = 0) {
+            self.outcome = outcome
+            self.delayMs = delayMs
+        }
+        func availability() async -> NotesAvailability { .available }
+        func notes(for chunk: NotesChunk, style: NotesStyle) async throws -> ChunkNotes {
+            if delayMs > 0 { try await Task.sleep(for: .milliseconds(delayMs)) }
+            try outcome.get()
+            return ChunkNotes(summary: "Part.", items: [
+                ChunkNotes.Item(kind: .actionItem, text: "Do the thing", at: chunk.lines[0].stamp),
+            ])
+        }
+        func summary(partSummaries: [String], title: String, style: NotesStyle) async throws -> String {
+            "Whole."
+        }
+    }
+
+    private let segments = (0..<4).map { i in
+        Segment(index: i, startMs: i * 5_000, endMs: i * 5_000 + 4_000, text: "Line \(i)", speakerId: "S1")
+    }
+
+    private func settle(_ coordinator: NotesCoordinator, _ id: UUID) async {
+        for _ in 0..<200 where coordinator.isBusy(id) {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+    }
+
+    func testGenerateRunsThenHoldsTheDraftForReview() async {
+        let coordinator = NotesCoordinator()
+        let id = UUID()
+        coordinator.generate(id: id, title: "T", segments: segments, speakers: [],
+                             style: .english, using: StubEngine())
+        XCTAssertTrue(coordinator.isBusy(id))
+        await settle(coordinator, id)
+
+        let draft = coordinator.draft(for: id)
+        XCTAssertNotNil(draft)
+        XCTAssertEqual(draft?.items.count, 1)
+        XCTAssertEqual(draft?.items.first?.sourceMs, 0)
+        XCTAssertEqual(draft?.summary, "Part.")
+        XCTAssertFalse(coordinator.isBusy(id))
+
+        coordinator.dismiss(id)
+        XCTAssertNil(coordinator.state(for: id))
+    }
+
+    func testAFailureIsHeldAsAMessage() async {
+        let coordinator = NotesCoordinator()
+        let id = UUID()
+        coordinator.generate(id: id, title: "T", segments: segments, speakers: [],
+                             style: .english, using: StubEngine(outcome: .failure(.languageNotSupported)))
+        await settle(coordinator, id)
+        XCTAssertEqual(coordinator.failure(for: id), NotesError.languageNotSupported.errorDescription)
+        XCTAssertNil(coordinator.draft(for: id))
+    }
+
+    func testCancelClearsTheStateAndTheLateResultIsDropped() async {
+        let coordinator = NotesCoordinator()
+        let id = UUID()
+        coordinator.generate(id: id, title: "T", segments: segments, speakers: [],
+                             style: .english, using: StubEngine(delayMs: 200))
+        XCTAssertTrue(coordinator.isBusy(id))
+        coordinator.cancel(id)
+        XCTAssertNil(coordinator.state(for: id))
+        try? await Task.sleep(for: .milliseconds(400))
+        XCTAssertNil(coordinator.state(for: id), "a result that lands after a cancel is not shown")
+    }
+
+    func testASecondGenerateWhileBusyIsIgnored() async {
+        let coordinator = NotesCoordinator()
+        let id = UUID()
+        coordinator.generate(id: id, title: "T", segments: segments, speakers: [],
+                             style: .english, using: StubEngine(delayMs: 100))
+        coordinator.generate(id: id, title: "T", segments: segments, speakers: [],
+                             style: .english, using: StubEngine(outcome: .failure(.contentRefused)))
+        await settle(coordinator, id)
+        XCTAssertNotNil(coordinator.draft(for: id), "the first request's result stands")
+    }
+}

--- a/app/Tests/TranscriberFlowTests/RecordingDisplayStatusTests.swift
+++ b/app/Tests/TranscriberFlowTests/RecordingDisplayStatusTests.swift
@@ -1,0 +1,81 @@
+import XCTest
+import TranscriberCore
+@testable import TranscriberFlow
+
+final class RecordingDisplayStatusTests: XCTestCase {
+
+    private func make(status: TranscriptionStatus = .completed, progress: JobProgress? = nil,
+                      isLive: Bool = false, isPaused: Bool = false, warning: String? = nil,
+                      hasAudio: Bool = true, error: String? = nil) -> RecordingDisplayStatus {
+        RecordingDisplayStatus.make(status: status, progress: progress, isLive: isLive,
+                                    isPaused: isPaused, warning: warning, hasAudio: hasAudio,
+                                    errorMessage: error)
+    }
+
+    func testAJobInProgressShowsItsChipAndACancelButton() {
+        let display = make(status: .transcribing,
+                           progress: JobProgress(status: .transcribing, fraction: 0.4, remaining: 90))
+        XCTAssertEqual(display.chip, .init(status: .transcribing, fraction: 0.4, remaining: 90))
+        XCTAssertEqual(display.action, .cancel)
+        XCTAssertTrue(display.isBusy)
+        XCTAssertEqual(display.emptyState.title, "Work in progress")
+        XCTAssertEqual(display.emptyState.detail,
+                       "Transcription · \(TimeFormat.remaining(seconds: 90)) left")
+    }
+
+    func testTheLiveSessionIsBusyWithNoActionAndPausedHasNoChip() {
+        let recording = make(status: .recording, isLive: true)
+        XCTAssertEqual(recording.chip?.status, .recording)
+        XCTAssertNil(recording.action)
+        XCTAssertTrue(recording.isBusy)
+        XCTAssertFalse(recording.isPaused)
+
+        let paused = make(status: .recording, isLive: true, isPaused: true)
+        XCTAssertNil(paused.chip, "the row shows Paused in the chip's place")
+        XCTAssertTrue(paused.isPaused)
+        XCTAssertTrue(paused.isBusy)
+    }
+
+    func testFailedOffersRetryOnlyWhenThereIsAudio() {
+        let withAudio = make(status: .failed, hasAudio: true, error: "The model refused a window.")
+        XCTAssertEqual(withAudio.action, .retry)
+        XCTAssertEqual(withAudio.emptyState.title, "Transcription failed")
+        XCTAssertEqual(withAudio.emptyState.detail, "The model refused a window.")
+
+        let noAudio = make(status: .failed, hasAudio: false)
+        XCTAssertNil(noAudio.action)
+        XCTAssertEqual(noAudio.emptyState.title, "The recording stopped early")
+        XCTAssertTrue(noAudio.emptyState.detail.contains("captured no audio"))
+    }
+
+    func testCancelledOffersTranscribe() {
+        let display = make(status: .cancelled)
+        XCTAssertEqual(display.chip?.status, .cancelled)
+        XCTAssertEqual(display.action, .transcribe)
+        XCTAssertEqual(display.emptyState.symbol, "xmark.circle")
+    }
+
+    func testCompleteIsQuietWithTranscribeAgain() {
+        let display = make(status: .completed)
+        XCTAssertNil(display.chip)
+        XCTAssertEqual(display.action, .transcribeAgain)
+        XCTAssertFalse(display.isBusy)
+        XCTAssertNil(display.warning)
+        XCTAssertEqual(display.emptyState.title, "No transcript yet")
+    }
+
+    func testTheWarningComesThroughFromOneSourceAndBlankIsNone() {
+        XCTAssertEqual(make(warning: "A window was dropped.").warning, "A window was dropped.")
+        XCTAssertNil(make(warning: "").warning)
+        // A warning does not change the action: the recording is complete.
+        XCTAssertEqual(make(warning: "x").action, .transcribeAgain)
+    }
+
+    func testAPendingRowWithNoJobStillShowsItsStoredChip() {
+        // An import that has not reached the queue yet, or a row a relaunch
+        // found pending: the stored status is shown until the queue reports.
+        let display = make(status: .pending)
+        XCTAssertEqual(display.chip?.status, .pending)
+        XCTAssertFalse(display.isBusy)
+    }
+}

--- a/app/Tests/TranscriberFlowTests/StopPlanTests.swift
+++ b/app/Tests/TranscriberFlowTests/StopPlanTests.swift
@@ -1,0 +1,90 @@
+import XCTest
+import TranscriberCore
+import TranscriberEngine
+@testable import TranscriberFlow
+
+final class StopPlanTests: XCTestCase {
+
+    private func result(durationMs: Int = 60_000, lanes: [CaptureLane] = [.room],
+                        segments: [Segment] = [], stats: SessionStats = SessionStats(),
+                        notices: [CaptureNotice] = []) -> LiveSessionResult {
+        LiveSessionResult(recordingId: UUID(), segments: segments, durationMs: durationMs,
+                          archiveFileName: "a.m4a", archiveSampleRate: 48_000,
+                          cacheURL: URL(fileURLWithPath: "/tmp/c.wav"), waveform: [],
+                          stats: stats, modelId: "m", language: "tl", lanes: lanes,
+                          notices: notices)
+    }
+
+    private func plan(_ result: LiveSessionResult, decodedLive: Bool = true, hadPersister: Bool = true,
+                      diarization: DiarizationMode = .accurate, keep: Bool = false) -> StopPlan {
+        StopPlan.make(result: result, decodedLive: decodedLive, hadPersister: hadPersister,
+                      diarizationMode: diarization, keepWorkingCopy: keep, shortTakeMs: 10_000)
+    }
+
+    func testCaptureOnlyGetsTheWholeFilePassAndNoLiveTranscript() {
+        let plan = plan(result(), decodedLive: false, hadPersister: false)
+        XCTAssertEqual(plan.transcript, .none)
+        XCTAssertEqual(plan.followUp, .fullTranscription)
+        XCTAssertNil(plan.liveFailureWarning)
+    }
+
+    func testLiveWithSpeakersCompletesThePersisterThenIdentifiesSpeakers() {
+        let plan = plan(result(), diarization: .fast)
+        XCTAssertEqual(plan.transcript, .completePersister)
+        XCTAssertEqual(plan.followUp, .diarizeOnly(.fast))
+    }
+
+    func testLiveWithoutAPersisterStoresAFreshRevision() {
+        XCTAssertEqual(plan(result(), hadPersister: false).transcript, .storeFresh)
+    }
+
+    func testLiveWithoutSpeakersIsDoneAndDropsTheWorkingCopyUnlessKept() {
+        XCTAssertEqual(plan(result(), diarization: .off).followUp, .markCompleted(discardCache: true))
+        XCTAssertEqual(plan(result(), diarization: .off, keep: true).followUp,
+                       .markCompleted(discardCache: false))
+    }
+
+    func testTwoLanesAlwaysGetTheWholeFilePass() {
+        let plan = plan(result(lanes: [.room, .remote]), diarization: .off)
+        XCTAssertEqual(plan.transcript, .completePersister, "the live lines are kept meanwhile")
+        XCTAssertEqual(plan.followUp, .fullTranscription)
+    }
+
+    func testFailedHopsBecomeAWarningWithTheDistinctionBetweenSomeAndAll() {
+        var some = SessionStats()
+        some.hops = 10
+        some.failedHops = 2
+        some.lastError = "boom"
+        let partial = plan(result(stats: some))
+        XCTAssertEqual(partial.liveFailureWarning,
+                       "2 decode(s) failed during this recording, so some words may be missing. Last error: boom")
+
+        var all = SessionStats()
+        all.failedHops = 5
+        let total = plan(result(stats: all))
+        XCTAssertTrue(total.liveFailureWarning?.hasPrefix("Live transcription failed for this entire recording (5 decode errors).") == true)
+
+        XCTAssertNil(plan(result(stats: all), decodedLive: false).liveFailureWarning,
+                     "a capture-only session has no decodes to fail")
+    }
+
+    func testNoticesJoinInOrder() {
+        let plan = plan(result(notices: [.microphoneChanged(now: "AirPods"), .microphoneLost("AirPods")]))
+        let text = plan.noticesWarning ?? ""
+        XCTAssertTrue(text.hasPrefix("The default input changed."))
+        XCTAssertTrue(text.contains("no other microphone is connected"))
+        XCTAssertNil(self.plan(result()).noticesWarning)
+    }
+
+    func testAShortTakeIsQuestionedWithItsWordCountOnlyWhenDecodedLive() {
+        let segments = [Segment(index: 0, startMs: 0, endMs: 900, text: "sige na"),
+                        Segment(index: 1, startMs: 1_000, endMs: 1_900, text: "ulit")]
+        let live = plan(result(durationMs: 4_000, segments: segments))
+        XCTAssertEqual(live.shortTake, .init(durationMs: 4_000, words: 3))
+
+        let captureOnly = plan(result(durationMs: 4_000, segments: segments), decodedLive: false)
+        XCTAssertEqual(captureOnly.shortTake, .init(durationMs: 4_000, words: nil))
+
+        XCTAssertNil(plan(result(durationMs: 10_000)).shortTake, "at the threshold it is kept quietly")
+    }
+}

--- a/app/Tests/TranscriberStoreTests/GraphMutationsTests.swift
+++ b/app/Tests/TranscriberStoreTests/GraphMutationsTests.swift
@@ -1,0 +1,94 @@
+import SwiftData
+import XCTest
+import TranscriberCore
+@testable import TranscriberStore
+
+/// The two graph mutations that the main-actor store and the writer actor
+/// share. Both callers must get the same result from the same input.
+@MainActor
+final class GraphMutationsTests: XCTestCase {
+
+    private var container: ModelContainer!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        container = try StoreContainer.ephemeral()
+    }
+
+    override func tearDown() async throws {
+        container = nil
+        try await super.tearDown()
+    }
+
+    private func roster(_ ids: [String]) -> [SpeakerLabel] {
+        ids.enumerated().map { SpeakerLabel(id: $1, displayName: "Person \($0 + 1)", speechMs: ($0 + 1) * 1_000) }
+    }
+
+    func testSyncKeepsRenamedRowsAndDropsOrphans() throws {
+        let context = container.mainContext
+        let recording = try RecordingStore.create(kind: .meeting, in: context)
+        SpeakerSync.apply(roster(["S1", "S2", "S3"]), to: recording, in: context)
+        try context.save()
+        let s2 = try XCTUnwrap((recording.speakers ?? []).first { $0.speakerId == "S2" })
+        s2.displayName = "Maria"
+
+        // A second pass without S3 and with S2 first.
+        SpeakerSync.apply(roster(["S2", "S1"]), to: recording, in: context)
+        try context.save()
+
+        let rows = (recording.speakers ?? []).sorted { $0.colorIndex < $1.colorIndex }
+        XCTAssertEqual(rows.map(\.speakerId), ["S2", "S1"], "colours follow roster order")
+        XCTAssertEqual(rows.first?.displayName, "Maria", "the user's name survives")
+        XCTAssertEqual(rows.first?.speechMs, 1_000, "talk time follows the new roster")
+        XCTAssertFalse(rows.contains { $0.speakerId == "S3" }, "the orphan is gone")
+    }
+
+    func testTheWriterAndTheStoreProduceTheSameRoster() async throws {
+        let context = container.mainContext
+        let viaStore = try RecordingStore.create(kind: .meeting, title: "store", in: context)
+        RecordingStore.syncSpeakers(roster(["S1", "S2"]), on: viaStore, in: context)
+        try context.save()
+
+        let viaWriter = try RecordingStore.create(kind: .meeting, title: "writer", in: context)
+        let writer = TranscriptWriter(modelContainer: container)
+        _ = try await writer.storeTranscript(
+            segments: [Segment(index: 0, startMs: 0, endMs: 1_000, text: "hello", speakerId: "S1")],
+            roster: roster(["S1", "S2"]), modelId: "m", language: "tl",
+            processMs: 1, didDiarize: true, for: viaWriter.id
+        )
+
+        let fresh = ModelContext(container)
+        let all = try fresh.fetch(FetchDescriptor<StoredRecording>())
+        let a = try XCTUnwrap(all.first { $0.title == "store" })
+        let b = try XCTUnwrap(all.first { $0.title == "writer" })
+        let shape: (StoredRecording) -> [(String, Int, Int)] = { recording in
+            (recording.speakers ?? []).sorted { $0.colorIndex < $1.colorIndex }
+                .map { ($0.speakerId, $0.colorIndex, $0.speechMs) }
+        }
+        XCTAssertEqual(shape(a).map(\.0), shape(b).map(\.0))
+        XCTAssertEqual(shape(a).map(\.1), shape(b).map(\.1))
+        XCTAssertEqual(shape(a).map(\.2), shape(b).map(\.2))
+        XCTAssertTrue(b.searchText.contains("hello"), "the writer rebuilt the index")
+    }
+
+    func testSearchIndexFlattensEverySource() throws {
+        let context = container.mainContext
+        let recording = try RecordingStore.create(kind: .meeting, title: "Budget", in: context)
+        recording.summary = "Q4 plan"
+        recording.body = "scratch"
+        let transcript = StoredTranscript(modelId: "m", language: "tl")
+        transcript.recording = recording
+        context.insert(transcript)
+        let row = StoredSegment(index: 0, startMs: 0, endMs: 900, text: "raw text", textClean: "clean text")
+        row.transcript = transcript
+        context.insert(row)
+        _ = try RecordingStore.addItem(.decision, text: "ship it", to: recording, in: context)
+        _ = try RecordingStore.addBookmark(at: 100, label: "important", to: recording, in: context)
+        try context.save()
+
+        SearchIndex.rebuild(recording)
+        let lines = recording.searchText.split(separator: "\n").map(String.init)
+        XCTAssertEqual(lines, ["Budget", "Q4 plan", "scratch", "clean text", "ship it", "important"])
+        XCTAssertFalse(recording.searchText.contains("raw text"), "the edit is what search sees")
+    }
+}

--- a/app/Tests/TranscriberStoreTests/NotesApplyTests.swift
+++ b/app/Tests/TranscriberStoreTests/NotesApplyTests.swift
@@ -1,0 +1,56 @@
+import SwiftData
+import XCTest
+import TranscriberCore
+@testable import TranscriberStore
+
+@MainActor
+final class NotesApplyTests: XCTestCase {
+
+    private var container: ModelContainer!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        container = try StoreContainer.ephemeral()
+    }
+
+    override func tearDown() async throws {
+        container = nil
+        try await super.tearDown()
+    }
+
+    func testAppliedItemsFollowTheExistingOnesAndKeepTheirLinks() throws {
+        let context = container.mainContext
+        let recording = try RecordingStore.create(kind: .meeting, title: "Taxonomy", in: context)
+        try RecordingStore.addItem(.decision, text: "Hand-written first", to: recording, in: context)
+        let segmentId = UUID()
+
+        let added = try RecordingStore.apply([
+            NotesDraft.Item(kind: .decision, text: " Colour is an attribute. ", sourceMs: 4_000, sourceSegmentId: segmentId),
+            NotesDraft.Item(kind: .actionItem, text: "Send the sheet.", sourceMs: 9_000),
+            NotesDraft.Item(kind: .question, text: "   "),
+        ], summary: nil, to: recording, in: context)
+        XCTAssertEqual(added, 3, "counts what it was handed; the blank one is not written")
+
+        let decisions = RecordingStore.items(.decision, of: recording)
+        XCTAssertEqual(decisions.map(\.text), ["Hand-written first", "Colour is an attribute."])
+        XCTAssertEqual(decisions.map(\.order), [0, 1])
+        XCTAssertEqual(decisions[1].sourceMs, 4_000)
+        XCTAssertEqual(decisions[1].sourceSegmentId, segmentId)
+        XCTAssertEqual(RecordingStore.items(.actionItem, of: recording).map(\.order), [0])
+        XCTAssertTrue(RecordingStore.items(.question, of: recording).isEmpty)
+        XCTAssertTrue(recording.searchText.contains("Colour is an attribute."))
+    }
+
+    func testTheSummaryIsReplacedOnlyWhenOneIsGiven() throws {
+        let context = container.mainContext
+        let recording = try RecordingStore.create(kind: .meeting, title: "Taxonomy", in: context)
+        recording.summary = "Written by hand."
+
+        try RecordingStore.apply([], summary: nil, to: recording, in: context)
+        XCTAssertEqual(recording.summary, "Written by hand.")
+
+        try RecordingStore.apply([], summary: "  Written by the model. ", to: recording, in: context)
+        XCTAssertEqual(recording.summary, "Written by the model.")
+        XCTAssertTrue(recording.searchText.contains("Written by the model."))
+    }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -68,7 +68,9 @@ the microphone, the audio of this Mac through `SystemAudioTap`, or both.
 `SpeakerEngine` wrap WhisperKit and FluidAudio. `LiveDecoder` and `LiveSession`
 run the live path. `OfflinePipeline` runs the whole-file path.
 `TranscriptionQueue` runs the background jobs. `EngineHost` owns the models.
-`BenchmarkRunner` measures the tiers.
+`BenchmarkRunner` measures the tiers. `NotesEngine.swift` holds the
+`NotesGenerating` seam, `NotesPipeline` and the Apple Intelligence backend for
+the automatic notes.
 
 ### `TranscriberFlow`
 
@@ -82,8 +84,10 @@ progress, the live session and the warning to what a row, a header and an
 empty transcript show. `StopPlan` decides what a stop of the live session does:
 the failure warning, where the live transcript goes, the follow-up job, the
 device-notice warning and the short-take question. The app executes the plan.
+`NotesCoordinator` holds one draft of automatic notes per recording, from the
+request through the progress to the review, and writes nothing to the store.
 
-Before this layer existed, these three lived on the app state as private
+Before this layer existed, the first three lived on the app state as private
 methods and internal dictionaries, and no test reached them.
 
 ### `Transcriber`
@@ -96,22 +100,24 @@ address of the releases page, which is the only address in the app target.
 
 ### `TranscriberCLI`
 
-`transcribe` is two files, `main.swift` and `Record.swift`. It is not a second
-implementation. It calls `OfflinePipeline`, `LiveDecoder`, `SpeakerEngine` and
-`Exporter` exactly as the app does. It therefore verifies the real path on real
-audio with no window, no microphone and no person. That is what makes it usable
-from CI and from the evaluation harness in `eval/`. [CLI.md](CLI.md) gives its
-options.
+`transcribe` is three files, `main.swift`, `Record.swift` and `Notes.swift`. It
+is not a second implementation. It calls `OfflinePipeline`, `LiveDecoder`,
+`SpeakerEngine`, `NotesPipeline` and `Exporter` exactly as the app does. It
+therefore verifies the real path on real audio with no window, no microphone
+and no person. That is what makes it usable from CI and from the evaluation
+harness in `eval/`. [CLI.md](CLI.md) gives its options.
 
 ## The engine protocols
 
-Three protocols in `TranscriberEngine/Protocols.swift` hide the backends:
+Three protocols in `TranscriberEngine/Protocols.swift` and one in
+`TranscriberEngine/NotesEngine.swift` hide the backends:
 
 | Protocol | Current backend |
 | --- | --- |
 | `SpeechRecognizing` | WhisperKit |
 | `VoiceActivityDetecting` | FluidAudio Silero VAD, with an energy fallback |
 | `SpeakerDiarizing` | FluidAudio pyannote segmentation and WeSpeaker embedding |
+| `NotesGenerating` | The Apple Intelligence model, through Foundation Models, on macOS 26 |
 
 To replace a backend, write a new conformance to the related protocol. You do
 not have to change the user interface. The tests use fake conformances, which
@@ -361,3 +367,58 @@ false while the user is likely to run a stage again.
 is `HighPassFilter.roomCornerHz`. The queue reads the setting when it puts the job in the queue, and
 it does not store the mode on the recording. A meeting that was captured in the
 wrong mode is therefore fixed with the switch and one more transcription.
+
+## Automatic notes
+
+The notes model reads the transcript in parts and writes into the shape the
+user fills by hand: a summary, and `MeetingItemKind` rows with a source line.
+Nothing is written until the user has selected what to keep.
+
+```
+segments ──► NotesChunker ──► parts ──► NotesGenerating ──► ChunkNotes
+                                              │                   │
+                                        (one call each)     NotesReducer
+                                                                  │
+                                              summaries ──► NotesGenerating ──► NotesDraft
+```
+
+`NotesChunker` in `TranscriberCore` cuts the transcript into parts of at most
+5,000 characters, at turn boundaries. Apple's model has a window of 4,096
+tokens for the instructions, the part and the answer together, and Tagalog
+costs more tokens per word than English, thus the budget is in characters and
+it is low. Each line of a part is `[m:ss] Name: text`, and the model is asked
+to copy the timestamp of the line that a note comes from. `NotesReducer`
+resolves that timestamp to the line at or before it, inside the part only: a
+timestamp outside the part is a copy error, and the note keeps no link. Two
+notes of the same kind that share 70 % of their content words are one note.
+
+`NotesPipeline` in `TranscriberEngine` runs the parts through a
+`NotesGenerating` backend and knows two recoveries. A part that the model
+reports as too long is cut in two and each half is read, down to one line. A
+part that the content filter refuses is skipped, and the draft carries a
+warning that says so. A language refusal is not recovered: the rest of the
+transcript is in the same language, and a draft made from the parts that
+happened to pass would misrepresent the meeting.
+
+`FoundationNotesEngine` is the backend on macOS 26: the Apple Intelligence
+model through the Foundation Models framework, with guided generation, thus the
+answer is a typed value and not text to parse. **It refuses Tagalog.** Measured
+on 2026-09-06 on a 93-minute Taglish meeting, a part with 28 % Tagalog words
+was accepted and parts with 50 % and 92 % were refused before any generation,
+with the default and the permissive guardrails alike. Finding 13 in
+[FINDINGS.md](FINDINGS.md) gives the measurement, and the measurement of the
+MLX models on the same meeting. A second backend for those models is a new
+conformance to `NotesGenerating` and one line in `AppState+Notes`.
+
+`NotesCoordinator` in `TranscriberFlow` holds one state per recording:
+running with the progress, ready with the draft, or failed with the message.
+The pane shows the state; the sheet shows the draft; `RecordingStore.apply`
+writes the rows the user selected. The package on macOS 15 builds without the
+framework, and the pane shows no button there.
+
+`NotesScoring` in `TranscriberCore` is how a backend is measured before it is
+trusted: grounding (the content words of a note that occur in the transcript
+near its timestamp), the language mix of the transcript against the notes, and
+the coverage of the hand-written notes by the draft. `transcribe --notes`
+reports the three for the Apple model and `eval/notes_eval.py` for an MLX model,
+on the app's JSON export of a recording.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -407,8 +407,19 @@ on 2026-09-06 on a 93-minute Taglish meeting, a part with 28 % Tagalog words
 was accepted and parts with 50 % and 92 % were refused before any generation,
 with the default and the permissive guardrails alike. Finding 13 in
 [FINDINGS.md](FINDINGS.md) gives the measurement, and the measurement of the
-MLX models on the same meeting. A second backend for those models is a new
-conformance to `NotesGenerating` and one line in `AppState+Notes`.
+models that do accept it, none of which is in the app. A second backend is a
+new conformance to `NotesGenerating` and one line in `AppState+Notes`.
+
+`AutoDraft` in `TranscriberFlow` decides whether a finished transcription
+drafts its own notes. Six inputs, one of which is the point: **the notes model
+never runs while a recording does.** A draft is minutes of the chip and the
+live decoder shares it, so a hop that arrives late is dropped and a dropped
+hop is missing words. The whole-file queue already refuses to start during a
+recording; this is that rule for the notes, in both directions -- a draft does
+not start during a recording, and one that is running is cancelled when a
+recording starts. The status it reads comes from a context of its own: the
+queue emits `.completed` and then `.finished`, and the main context has not
+always merged the writer actor's save by then.
 
 `NotesCoordinator` in `TranscriberFlow` holds one state per recording:
 running with the progress, ready with the draft, or failed with the message.
@@ -420,5 +431,5 @@ framework, and the pane shows no button there.
 trusted: grounding (the content words of a note that occur in the transcript
 near its timestamp), the language mix of the transcript against the notes, and
 the coverage of the hand-written notes by the draft. `transcribe --notes`
-reports the three for the Apple model and `eval/notes_eval.py` for an MLX model,
+reports the three for the Apple model and `eval/notes_eval.py` for a candidate,
 on the app's JSON export of a recording.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -12,6 +12,7 @@ app/            Swift 6 and SwiftUI. The product.
 ├── Sources/TranscriberCore/     pure logic: commit policy, merger, exports, search
 ├── Sources/TranscriberStore/    SwiftData schema and queries
 ├── Sources/TranscriberEngine/   audio, WhisperKit, FluidAudio VAD and speaker models
+├── Sources/TranscriberFlow/     the app's decisions with no window
 ├── Sources/Transcriber/         the SwiftUI app
 └── Sources/TranscriberCLI/      the same pipeline, with no window
 ```
@@ -21,7 +22,7 @@ Transcriber, which the app had through its private builds. The data directory
 holds the recordings that those builds wrote, thus a rename there hides them.
 The module names are internal, and a rename gives the user nothing.
 
-## The four layers
+## The five layers
 
 Each layer builds and tests without the layer above it:
 
@@ -30,17 +31,18 @@ Each layer builds and tests without the layer above it:
 | `TranscriberCore` | nothing | AVFoundation, CoreML, SwiftUI, SwiftData, models |
 | `TranscriberStore` | Core | inference of any kind |
 | `TranscriberEngine` | Core | SwiftUI |
-| `Transcriber` | Core, Store, Engine | — |
+| `TranscriberFlow` | Core, Store, Engine | SwiftUI, AppKit |
+| `Transcriber` | Core, Store, Engine, Flow | — |
 
 This split lets you test the commit policy, the segment merger, the exporters
 and the search index on a Mac that has no microphone and no model weights. That
 property is what keeps the CI job free of secrets and free of model downloads.
 
-The diagram in the [README](../README.md) shows the same four layers as a
-stack, from the user interface down to the models. The table above is the
-dependency rule. `TranscriberStore` and `TranscriberEngine` both depend on
-`TranscriberCore` and not on each other. The SwiftUI app is the only layer that
-sees all three.
+The diagram in the [README](../README.md) shows the same layers as a stack,
+from the user interface down to the models. The table above is the dependency
+rule. `TranscriberStore` and `TranscriberEngine` both depend on
+`TranscriberCore` and not on each other. `TranscriberFlow` and the SwiftUI app
+see all three.
 
 ### `TranscriberCore`
 
@@ -67,6 +69,22 @@ the microphone, the audio of this Mac through `SystemAudioTap`, or both.
 run the live path. `OfflinePipeline` runs the whole-file path.
 `TranscriptionQueue` runs the background jobs. `EngineHost` owns the models.
 `BenchmarkRunner` measures the tiers.
+
+### `TranscriberFlow`
+
+The decisions of the app, with no window and no AppKit, so a test can make
+them. `JobCoordinator` consumes the events of the transcription queue, writes
+to the store through `TranscriptWriter`, and holds the three values the views
+read about a job: the progress, the warning and the transcript tick. It also
+takes the three commands: enqueue, cancel and add a warning.
+`RecordingDisplayStatus` is the one ladder from the stored status, the job
+progress, the live session and the warning to what a row, a header and an
+empty transcript show. `StopPlan` decides what a stop of the live session does:
+the failure warning, where the live transcript goes, the follow-up job, the
+device-notice warning and the short-take question. The app executes the plan.
+
+Before this layer existed, these three lived on the app state as private
+methods and internal dictionaries, and no test reached them.
 
 ### `Transcriber`
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -185,7 +185,7 @@ The tool reports:
 - The parts that the model skipped, and why.
 
 `--json FILE` writes the `NotesRunReport` structure with these scores and the
-draft. `eval/notes_eval.py` writes the same scores for an MLX model, thus the
+draft. `eval/notes_eval.py` writes the same scores for a candidate model, thus the
 two can be compared.
 
 ## Live mode

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -30,6 +30,8 @@ transcribe --audio FILE [--reference FILE] [--models DIR]
            [--format txt|markdown|srt|vtt|json] [--out FILE] [--json FILE]
            [--live [--realtime] [--hop MS] [--pre-roll MS] [--context MS] [--adaptive-hop]]
 transcribe --audio FILE --lane room|remote
+transcribe --notes EXPORT.json [--notes-style english|spoken] [--notes-chars N]
+           [--out DRAFT.md] [--json REPORT.json]
 transcribe --record [--source microphone|systemAudio|both] [--device UID]
            [--seconds N] [--out FILE.m4a] [--gui]
 transcribe --devices
@@ -101,6 +103,9 @@ Replay a file through the live path at wall-clock speed:
 | `--devices` | List each audio device with its channel counts and its UID, then stop. |
 | `--channels` | Capture the raw channels of the combined device and report the peak level of each channel. |
 | `--log FILE` | Write a copy of the stderr output to this file. |
+| `--notes EXPORT.json` | Draft the notes for a recording that the app exported as JSON, and score the draft. Refer to "Automatic notes". |
+| `--notes-style english\|spoken` | With `--notes`, the language of the notes. The default is `english`. |
+| `--notes-chars N` | With `--notes`, the characters of transcript per part. The default is 5000. |
 
 The default speaker mode is `accurate`. Use `--fast-diarize` or `--no-diarize`
 to change it.
@@ -153,6 +158,35 @@ the language that you asked for, the language that the model detected, the
 language of each window, the duration, the decode time, the RTF, the word
 count, the transcript, each token, the WER, the live statistics and the live
 configuration.
+
+## Automatic notes
+
+`--notes EXPORT.json` reads a recording that the app exported as JSON, drafts
+the notes with the same pipeline and the same model as the app, prints the
+draft as Markdown, and scores it. It needs macOS 26 with Apple Intelligence on.
+The model refuses a transcript that is mostly Tagalog; finding 13 in
+[FINDINGS.md](FINDINGS.md) gives the limit.
+
+```bash
+./.build/release/transcribe --notes meeting.json --json out/notes.json
+```
+
+The tool reports:
+
+- The share of Tagalog words in the transcript and in the notes.
+- **Grounding:** the share of the content words of each note that occur in the
+  transcript within two minutes of the note's timestamp, and how many notes are
+  under 0.4. A low value means that the model invented. English notes about
+  Tagalog speech score lower by construction.
+- **Coverage:** how many of the hand-written notes in the export the draft also
+  has, and how many draft notes match a hand-written one, by content-word
+  overlap. A meeting with notes that you wrote by hand is therefore a scored
+  pair with no extra work.
+- The parts that the model skipped, and why.
+
+`--json FILE` writes the `NotesRunReport` structure with these scores and the
+draft. `eval/notes_eval.py` writes the same scores for an MLX model, thus the
+two can be compared.
 
 ## Live mode
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -63,7 +63,7 @@ catalogue and the storage layout.
 cd app && swift test
 ```
 
-There are 301 tests: 273 XCTest tests and 28 swift-testing tests. **They need
+There are 327 tests: 299 XCTest tests and 28 swift-testing tests. **They need
 no model weights, no microphone and no network.** This property is deliberate,
 and you must keep it. The four-layer split in
 [ARCHITECTURE.md](ARCHITECTURE.md) is what makes it possible.
@@ -73,6 +73,7 @@ and you must keep it. The four-layer split in
 | `TranscriberCoreTests` | Pure logic. No fakes are necessary. |
 | `TranscriberStoreTests` | The SwiftData schema and the queries. |
 | `TranscriberEngineTests` | The real pipeline, driven through fakes for the three engine protocols. |
+| `TranscriberFlowTests` | The job coordinator against an in-memory store, the display status and the stop plan. |
 
 If model weights are unavailable for a test, add a fake. Do not skip the test.
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -63,7 +63,7 @@ catalogue and the storage layout.
 cd app && swift test
 ```
 
-There are 360 tests: 332 XCTest tests and 28 swift-testing tests. **They need
+There are 369 tests: 341 XCTest tests and 28 swift-testing tests. **They need
 no model weights, no microphone and no network.** This property is deliberate,
 and you must keep it. The four-layer split in
 [ARCHITECTURE.md](ARCHITECTURE.md) is what makes it possible.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -63,7 +63,7 @@ catalogue and the storage layout.
 cd app && swift test
 ```
 
-There are 327 tests: 299 XCTest tests and 28 swift-testing tests. **They need
+There are 360 tests: 332 XCTest tests and 28 swift-testing tests. **They need
 no model weights, no microphone and no network.** This property is deliberate,
 and you must keep it. The four-layer split in
 [ARCHITECTURE.md](ARCHITECTURE.md) is what makes it possible.

--- a/docs/FINDINGS.md
+++ b/docs/FINDINGS.md
@@ -542,6 +542,117 @@ and this measurement says nothing about short prompts. `suppressBlank` was
 measured in the same run (25.8% / 27.3% / 58.3% against 24.2% / 27.3% / 71.7%)
 and left at WhisperKit's default.
 
+## 13. Automatic notes: Apple's model refuses Taglish, and the small MLX models write English notes from it but not Tagalog ones (2026-09-06)
+
+The notes workspace has had the shape for this since v1: a summary and five
+typed lists whose rows keep a source timestamp. The question was which
+on-device model could write into it, and how well, on a Taglish meeting. The
+reference is the one meeting in the library with notes written by hand: a
+93-minute product-taxonomy meeting, 1,525 segments, an 845-character summary and
+41 notes (15 decisions, 9 action items, 9 key points, 5 questions, 3
+follow-ups). `eval/langscore.py` classes 64 % of its words as Tagalog; the
+function-word list in `NotesScoring.languageMix` classes 43 %. Both numbers
+below name their heuristic.
+
+**Apple's Foundation Models framework refuses the transcript before it reads
+it.** `SystemLanguageModel.default` is available on this Mac and lists 23
+locales, none of them Filipino. A `LanguageModelSession.respond` with a part of
+the transcript as the prompt returns `unsupportedLanguageOrLocale` in 0.0 s.
+Four parts of the same meeting, chosen by their Tagalog share, with the default
+guardrails and with `.permissiveContentTransformations`:
+
+| Part of the meeting | Tagalog words (langscore) | Default guardrails | Permissive guardrails |
+|---|---:|---|---|
+| the most English turns, 3,646 chars | 28 % | accepted, 3.5 s | accepted, 2.0 s |
+| mixed turns, 3,744 chars | 50 % | refused | refused |
+| 6:21–12:00 in order, 4,450 chars | 71 % | refused | refused |
+| the most Tagalog turns, 3,452 chars | 92 % | refused | refused |
+
+The limit is somewhere between 28 % and 50 % Tagalog words, and it is a check on
+the prompt's language, not on its content: the guardrail setting changes
+nothing, and the instructions were English in every case. A Taglish meeting
+is refused whole, since every part of it is over the limit. The pipeline
+treats that refusal as fatal rather than skipping the refused parts: a draft
+made from the English-heavy minutes of a Taglish meeting would misrepresent
+it. The app says "The model does not accept the language of this transcript."
+
+On what it accepts, the model works. An export reduced to the 95 segments
+with at most 25 % Tagalog words (6 % overall) gave 8 notes in 11 s across 2
+parts, 6 of them with a source line, grounding 0.68 with none under 0.4 -- and
+two of the eight were noise ("25, 25." as a key point, "Akay, sir?" as a
+question). Guided generation held the shape; it did not hold the judgement.
+
+**The MLX models accept Taglish.** `eval/notes_eval.py` runs the same parts,
+the same instructions and the same JSON request through `mlx_lm`, and scores
+the draft as `transcribe --notes` does. Five runs on the reference meeting,
+14 parts of at most 5,000 characters, temperature 0.2, on this 24 GB Mac:
+
+| Model (4-bit) | Weights | s per part | Notes K/D/A/Q/F | With a line | Grounding mean, under 0.4 | Tagalog in notes (langscore) | Hand-written notes covered at 0.5 / 0.3 of 41 | Draft notes that match one at 0.5 / 0.3 |
+|---|---:|---:|---|---:|---|---:|---|---|
+| Qwen2.5-3B-Instruct, English | 1.6 GB | 4.1 | 41/5/27/10/20 = 103 | 100 | 0.42, 48 | 10 % | 3 / 15 | 5 / 28 of 103 |
+| Qwen3-4B-Instruct-2507, English | 2.1 GB | 6.6 | 90/0/3/7/13 = 113 | 111 | 0.47, 36 | 12 % | 11 / 25 | 15 / 48 of 113 |
+| Qwen3-4B-Instruct-2507, as spoken | 2.1 GB | 8.0 | 92/0/2/7/10 = 111 | 105 | 0.55, 30 | 46 % | 9 / 22 | 9 / 42 of 111 |
+| gemma-3-4b-it-qat, English | 2.8 GB | 7.0 | 74/12/21/15/9 = 131 | 126 | 0.46, 47 | 13 % | 6 / 21 | 8 / 35 of 131 |
+| Qwen3-8B, English | 4.3 GB | 11.3 | 71/1/13/8/7 = 100 | 92 | 0.42, 40 | 13 % | 5 / 17 | 5 / 33 of 100 |
+| Qwen3-4B-Instruct-2507, English, at most 5 notes a part | 2.1 GB | 4.5 | 47/0/2/4/6 = 59 | 56 | 0.47, 22 | 15 % | 10 / 19 | 10 / 25 of 59 |
+
+Loading takes 1.5 to 2.6 s; a 93-minute meeting is read in one and a half to
+two minutes on the 4B models. "Grounding" is the share of a note's content
+words that occur in the transcript within two minutes of the note's
+timestamp, and English notes about Tagalog speech score lower by
+construction -- which is why the as-spoken run has the best grounding and the
+worst text. "Covered at 0.5" needs half of a hand-written note's content words
+in one draft note; 0.3 is the looser match a paraphrase gets. Neither is a
+judgement of the writing, so the drafts were also read.
+
+What the reading says:
+
+- **Qwen3-4B's English summary is the hand-written summary in other words.**
+  It names the flowchart module and its highlighting, the hierarchy of
+  groupings, each person's own workspace with a super admin publishing to
+  the company backbone, the prefix for unapproved modules, the
+  taxonomy of category, product family, product, model and variant, the 10 %
+  costing buffer and the Thursday review. The key points are specific and
+  carry the right timestamps ("To avoid naming conflicts, modules created by
+  a user carry a prefix until they are approved. (30:39)").
+- **Every 4B-class model over-extracts, and Qwen3 cannot tell a decision from
+  a key point.** 103 to 131 notes against 41 by hand. Qwen3-4B filed 90 of
+  its 113 as key points and none as decisions, where the hand-written notes
+  have 15 decisions; sentences that begin "The group agreed to..." landed
+  under key points. Gemma spread its notes across the kinds but invented
+  more (47 under 0.4). Qwen2.5-3B called 27 notes action items. The content
+  is largely right; the kind is the weak part, and that is what the review
+  sheet's Change To menu is for until a second pass fixes it.
+- **The as-spoken style does not work at 4B.** Qwen3-4B reads Taglish well
+  enough to write the English notes above, and cannot write Tagalog: "Pinagkakatiwalaan
+  ang pagbabayad ng version at approval para sa pagkakaiba ng data" -- payment
+  for the version, entrusted, for the difference of the data -- is
+  representative, and the notes drift into English half-way through. The
+  notes reach 46 % Tagalog words against the transcript's 64 %, and the
+  Tagalog that is there is wrong. English is the default for the notes.
+- **Twice the weights bought nothing.** Qwen3-8B covered 5 hand-written
+  notes to the 4B's 11, took 11.3 s a part to its 6.6, and its summary says
+  "no specific decisions were made" of a meeting whose notes hold 15. The
+  4B-Instruct-2507 tune is the better note-taker of the two on this meeting.
+- **A cap of five notes a part halves the draft and keeps the coverage.** The
+  same Qwen3-4B with "at most 5 items" wrote 59 notes instead of 113, covered
+  10 hand-written notes at 0.5 to the 11 before, and took 4.5 s a part to
+  6.6. The cap costs nothing that the reference measures; the app's prompt
+  and the guided schema still say ten, and should say five.
+- Qwen2.5-3B broke the JSON on 8 of its 14 answers, closing with `}}}` and
+  no `]`. Every one of them held usable notes, and `ChunkNotes.parse` now
+  reads the summary string and each item object on its own when the brackets
+  are wrong. Its first score, with the strict parser, was 31 notes and
+  0 of 41 covered.
+
+What follows. English notes are the default. A Taglish meeting needs an MLX
+backend, which is a new `NotesGenerating` conformance and a 2.1 GB download;
+Qwen3-4B-Instruct-2507 is the candidate; the 8B row above rules out the
+larger one. Before either ships as a default, the kind
+classification needs a second pass or a sharper prompt, and the per-part cap
+should drop to five, as the variant row shows. The harness and the CLI report the same scores,
+so the next candidate is one command on the same meeting.
+
 ## Caveat: the audio was synthetic
 
 macOS ships no Filipino voice, so the fixture uses the Indonesian one reading a

--- a/docs/FINDINGS.md
+++ b/docs/FINDINGS.md
@@ -645,13 +645,28 @@ What the reading says:
   are wrong. Its first score, with the strict parser, was 31 notes and
   0 of 41 covered.
 
-What follows. English notes are the default. A Taglish meeting needs an MLX
-backend, which is a new `NotesGenerating` conformance and a 2.1 GB download;
-Qwen3-4B-Instruct-2507 is the candidate; the 8B row above rules out the
-larger one. Before either ships as a default, the kind
-classification needs a second pass or a sharper prompt, and the per-part cap
-should drop to five, as the variant row shows. The harness and the CLI report the same scores,
-so the next candidate is one command on the same meeting.
+**Measured and not shipped.** A working MLX backend was built against these
+numbers -- `MLXNotesEngine` over `mlx-swift-lm`, a picker, a downloader, and
+the Metal shader step that `swift build` cannot do -- and driven through the
+app: Qwen3 4B drafted 120 notes from the whole reference meeting in 1 min
+46 s. It is not in this change. Shipping it costs two Swift dependencies, a
+2.1 GB download per user, an app binary that grows from 41 MB to 107 MB, and
+a build that needs Xcode's separately-downloaded Metal Toolchain. The
+maintainer's judgement is that a hosted model is the better route for the
+notes, so the local one was left out rather than carried.
+
+That decision has a price this file should state. **Apple's model is the only
+backend in the app, and it refuses Taglish**, so automatic notes do nothing
+for the meetings this project exists for until another backend lands. And a
+hosted model would send the transcript off the machine, which every other
+part of this project promises not to do; whatever ships next has to answer
+that in the README, in SECURITY.md and at the point of use, not quietly.
+
+What the numbers say about any future backend, hosted or not: notes in
+English, a cap of five a part rather than ten, and a second pass on the kind
+of each note, which is the weak part of every model measured here. The
+harness and the CLI report the same scores, so the next candidate is one
+command on the same meeting.
 
 ## Caveat: the audio was synthetic
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -161,10 +161,22 @@ part with 28 % Tagalog words was accepted and parts with 50 % or more were
 refused. A Taglish meeting therefore gets the message "The model does not
 accept the language of this transcript", and no draft. Finding 13 in
 [FINDINGS.md](FINDINGS.md) gives the measurement, and the measurement of the
-MLX models that do accept Taglish. An English meeting works.
+models that do accept Taglish, none of which is in the app. An English
+meeting works.
 
 **Settings › General › Automatic notes** selects the language of the notes:
 English, or the mix of languages that the speakers used.
+
+**Draft after every recording, with no button.** Turn on **Draft the notes
+when a recording is complete** in the same place. The app then drafts as soon
+as a transcript is ready and shows you the sheet. It is off unless you turn it
+on, because it costs time on the chip after every recording.
+
+**The model never runs during a recording.** An automatic draft waits until
+the recording stops, and a draft that is already running stops when you press
+Record. The speech model and the notes model would otherwise share one chip,
+and a decode that arrives late is words missing from the transcript. This is
+the same rule that stops the transcription queue during a recording.
 
 ## Edit the transcript
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -143,6 +143,29 @@ speaker said.
 
 Press ⌘B to bookmark the moment during a recording or during playback.
 
+### Draft the notes automatically
+
+On macOS 26 with Apple Intelligence on, the notes pane has a button, **Draft
+Notes from the Transcript** (⇧⌘D). The Apple Intelligence model on this Mac
+reads the transcript in parts and proposes a summary and notes of the five
+kinds. Nothing leaves the Mac.
+
+**The app writes nothing until you select it.** A sheet shows the draft. Each
+note has a checkbox and the moment it came from, thus you can play the line
+before you keep the note. The summary has a checkbox too. If you wrote a
+summary, the draft does not replace it unless you select that.
+
+**The model does not accept Tagalog.** It refuses a part of the transcript
+that is mostly Tagalog before it reads it. On a 93-minute Taglish meeting, a
+part with 28 % Tagalog words was accepted and parts with 50 % or more were
+refused. A Taglish meeting therefore gets the message "The model does not
+accept the language of this transcript", and no draft. Finding 13 in
+[FINDINGS.md](FINDINGS.md) gives the measurement, and the measurement of the
+MLX models that do accept Taglish. An English meeting works.
+
+**Settings › General › Automatic notes** selects the language of the notes:
+English, or the mix of languages that the speakers used.
+
 ## Edit the transcript
 
 **Transcribe one turn again.** Right-click a turn and select **Transcribe

--- a/eval/notes_eval.py
+++ b/eval/notes_eval.py
@@ -1,0 +1,461 @@
+"""Measure an MLX language model as a note-taker on one of your own meetings.
+
+The app's automatic notes read the transcript in parts, ask a model for a
+summary and typed notes per part, then write one summary of the whole
+meeting. This harness does the same with `mlx_lm` so a candidate model can
+be measured before it is wired into the app. The prompt text mirrors
+`NotesPrompt` in `TranscriberCore/MeetingNotes.swift`; change both together.
+
+Input is the app's JSON export of a recording (File > Export > JSON), which
+carries the transcript, the speakers and the hand-written notes. Output is a
+draft you can read and a report you can compare:
+
+  * grounding: the share of each note's content words that occur in the
+    transcript within two minutes of the note's timestamp. Low means the model
+    invented. English notes about Tagalog speech score lower by construction.
+  * language: the Tagalog share of the transcript and of the notes, by the
+    heuristic in `langscore.py`.
+  * coverage: how many hand-written notes the draft also has, and how many
+    draft notes match a hand-written one, by content-word overlap.
+  * failures: parts whose answer was not JSON, and parts that ran over the
+    token budget.
+
+    ./.venv/bin/python eval/notes_eval.py --document meeting.json \
+        --model mlx-community/Qwen3-4B-Instruct-2507-4bit --style english \
+        --out eval/out/notes
+
+The document holds a real meeting. Do not attach it, or the output folder,
+to a public issue.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import langscore  # noqa: E402
+
+KINDS = ["keyPoint", "decision", "actionItem", "question", "followUp"]
+KIND_LABEL = {"keyPoint": "Key Points", "decision": "Decisions", "actionItem": "Action Items",
+              "question": "Questions", "followUp": "Follow-ups"}
+MAX_TURN_MS = 30_000
+GAP_MS = 1_500
+
+STOP = set("""
+the and for that this with have from are was were will would can could should they them their
+there here what when where which who whom how why not but all any some also into onto about
+then than been being does did doing has had our you your his her its out over under after
+before because while just very more most much many such only same other another each both
+ang mga ito iyan iyon yan yun yung nito dito diyan doon hindi wala walang may mayroon meron
+kung kasi para pero tapos lang lamang din rin naman daw raw kaya dahil pwede puwede dapat
+baka siguro talaga medyo masyado lahat bawat ngayon kanina mamaya muna ulit pala nga kaso
+saka sana yata kapag habang bago hanggang mula tungkol ganito ganyan ganun ganon mas sobrang
+ako ikaw siya kami tayo kayo sila natin namin ninyo nila niya kita nyo kayong ating
+""".split())
+
+
+def instructions(style: str) -> str:
+    language = ("Write the notes in English." if style == "english"
+                else "Write the notes in the same mix of languages that the speakers used.")
+    return (
+        "You take notes for a meeting. The transcript is from a business meeting in the Philippines. "
+        "The speakers mix Tagalog and English. Each line starts with a timestamp in square brackets "
+        f"and the name of the speaker. {language} Write only what the transcript supports. Do not "
+        "invent a name, a number or a decision. Keep names, product names and numbers exactly as "
+        "written. A decision is something the group agreed. An action item is a task that one "
+        "person agreed to do. A question is one that was asked and not answered. A follow-up is "
+        "something to return to later. A key point is a fact or a position worth keeping."
+    )
+
+
+def request(index: int, text: str, max_items: int = 10) -> str:
+    return (
+        f"Transcript, part {index + 1}:\n\n{text}\n\n"
+        "Answer with one JSON object and nothing else, in this form:\n"
+        '{"summary": "two or three sentences on what this part was about", '
+        '"items": [{"kind": "keyPoint|decision|actionItem|question|followUp", '
+        '"text": "the note in one sentence", "at": "the timestamp of the line it comes from, '
+        'copied exactly, for example 12:34"}]}\n'
+        f"Give at most {max_items} items. Leave the list empty when this part has nothing worth keeping."
+    )
+
+
+def summary_request(parts: list[str], title: str) -> str:
+    numbered = "\n".join(f"Part {i + 1}: {s}" for i, s in enumerate(parts))
+    return (
+        f'These are the summaries of the parts of the meeting "{title}", in order:\n\n{numbered}\n\n'
+        "Write one summary of the whole meeting in three to six sentences: what it was about, "
+        "what was decided, and what is still open. Answer with the summary only."
+    )
+
+
+def stamp(ms: int) -> str:
+    s = max(0, ms) // 1000
+    return f"{s // 3600}:{(s % 3600) // 60:02d}:{s % 60:02d}" if s >= 3600 else f"{s // 60}:{s % 60:02d}"
+
+
+def parse_stamp(text) -> int | None:
+    if text is None:
+        return None
+    digits = re.sub(r"[^0-9:]", "", str(text))
+    if ":" not in digits:
+        return None
+    parts = digits.split(":")
+    if len(parts) > 3 or any(p == "" for p in parts):
+        return None
+    values = [int(p) for p in parts]
+    if any(v >= 60 for v in values[1:]):
+        return None
+    seconds = 0
+    for v in values:
+        seconds = seconds * 60 + v
+    return seconds * 1000
+
+
+def content_words(text: str) -> set[str]:
+    out = set()
+    for raw in re.split(r"[^\w'-]+", text.lower()):
+        word = raw.strip("-'")
+        if len(word) >= 3 and word not in STOP:
+            out.add(word)
+    return out
+
+
+def turns(document: dict) -> list[dict]:
+    names = {s["id"]: s["displayName"] for s in document.get("speakers", [])}
+    out: list[dict] = []
+    for seg in sorted(document["segments"], key=lambda s: s["startMs"]):
+        text = (seg.get("textClean") or seg["text"]).strip()
+        if not text:
+            continue
+        spk = seg.get("speakerId")
+        if out and out[-1]["speakerId"] == spk and seg["startMs"] - out[-1]["endMs"] <= GAP_MS \
+                and seg["endMs"] - out[-1]["startMs"] <= MAX_TURN_MS:
+            out[-1]["endMs"] = seg["endMs"]
+            out[-1]["text"] += " " + text
+        else:
+            digits = "".join(ch for ch in (spk or "") if ch.isdigit())
+            name = names.get(spk) or (f"Speaker {int(digits)}" if digits else spk)
+            out.append({"startMs": seg["startMs"], "endMs": seg["endMs"], "speakerId": spk,
+                        "speaker": name, "text": text, "segmentId": seg["id"]})
+    return out
+
+
+def render(turn: dict) -> str:
+    who = f"{turn['speaker']}: " if turn["speaker"] else ""
+    return f"[{stamp(turn['startMs'])}] {who}{turn['text']}"
+
+
+def chunks(turn_list: list[dict], end_ms: int, max_chars: int) -> list[dict]:
+    out: list[dict] = []
+    bucket: list[dict] = []
+    count = 0
+    for t in turn_list:
+        cost = len(render(t)) + 1
+        if bucket and count + cost > max_chars:
+            out.append({"lines": bucket, "endMs": t["startMs"]})
+            bucket, count = [], 0
+        bucket.append(t)
+        count += cost
+    if bucket:
+        out.append({"lines": bucket, "endMs": end_ms})
+    for i, c in enumerate(out):
+        c["index"] = i
+        c["startMs"] = c["lines"][0]["startMs"]
+        c["text"] = "\n".join(render(t) for t in c["lines"])
+    return out
+
+
+def parse_item(raw) -> dict | None:
+    if not isinstance(raw, dict) or not raw.get("text"):
+        return None
+    key = re.sub(r"[^a-z]", "", str(raw.get("kind", "")).lower())
+    kind = next((k for k in KINDS if k.lower() == key or KIND_LABEL[k].lower().replace(" ", "") == key), None)
+    if kind is None:
+        kind = {"action": "actionItem", "task": "actionItem", "followup": "followUp",
+                "key": "keyPoint", "point": "keyPoint", "agreed": "decision"}.get(key)
+    if kind is None:
+        return None
+    return {"kind": kind, "text": str(raw["text"]).strip(), "at": raw.get("at")}
+
+
+def parse_notes(text: str) -> dict | None:
+    """The answer as JSON, or, when the brackets are broken, the summary
+    string and each item object read on their own. Qwen2.5-3B closed 8 of 14
+    answers with `}}}` and no `]`; every one held usable items."""
+    open_ = text.find("{")
+    close = text.rfind("}")
+    if open_ >= 0 and close > open_:
+        try:
+            obj = json.loads(text[open_:close + 1])
+            if isinstance(obj, dict):
+                items = [i for i in (parse_item(r) for r in obj.get("items") or []) if i]
+                return {"summary": str(obj.get("summary") or "").strip(), "items": items}
+        except json.JSONDecodeError:
+            pass
+    if '"summary"' not in text and '"items"' not in text:
+        return None
+    summary = ""
+    m = re.search(r'"summary"\s*:\s*("(?:[^"\\]|\\.)*")', text)
+    if m:
+        try:
+            summary = str(json.loads(m.group(1))).strip()
+        except json.JSONDecodeError:
+            summary = ""
+    items = []
+    for obj_text in re.findall(r"\{[^{}]*\}", text):
+        if '"text"' not in obj_text:
+            continue
+        try:
+            item = parse_item(json.loads(obj_text))
+        except json.JSONDecodeError:
+            continue
+        if item:
+            items.append(item)
+    if not summary and not items:
+        return None
+    return {"summary": summary, "items": items}
+
+
+def resolve(notes: dict, chunk: dict) -> list[dict]:
+    out = []
+    for item in notes["items"]:
+        ms = parse_stamp(item.get("at"))
+        source = None
+        if ms is not None and chunk["startMs"] <= ms <= chunk["endMs"]:
+            line = next((t for t in reversed(chunk["lines"]) if t["startMs"] <= ms), chunk["lines"][0])
+            source = line["startMs"]
+        out.append({"kind": item["kind"], "text": item["text"], "sourceMs": source, "at": item.get("at")})
+    return out
+
+
+def dedupe(items: list[dict], threshold: float = 0.7) -> list[dict]:
+    kept: list[tuple[dict, set[str]]] = []
+    for item in items:
+        words = content_words(item["text"])
+        dup = False
+        for prev, pw in kept:
+            if prev["kind"] != item["kind"]:
+                continue
+            union = pw | words
+            if not union or len(pw & words) / len(union) >= threshold:
+                dup = True
+                break
+        if not dup:
+            kept.append((item, words))
+    return [k for k, _ in kept]
+
+
+def grounding(items: list[dict], segments: list[dict], window_ms: int = 120_000) -> dict:
+    segs = sorted(segments, key=lambda s: s["startMs"])
+    whole = content_words(" ".join(s.get("textClean") or s["text"] for s in segs))
+    overlaps = []
+    for item in items:
+        words = content_words(item["text"])
+        if not words:
+            continue
+        if item.get("sourceMs") is not None:
+            at = item["sourceMs"]
+            near = content_words(" ".join(s.get("textClean") or s["text"] for s in segs
+                                          if s["endMs"] >= at - window_ms and s["startMs"] <= at + window_ms))
+        else:
+            near = whole
+        overlaps.append(len(words & near) / len(words))
+    return {"itemsScored": len(overlaps),
+            "meanOverlap": sum(overlaps) / len(overlaps) if overlaps else 0.0,
+            "ungrounded": sum(1 for o in overlaps if o < 0.4)}
+
+
+def language_mix(text: str) -> dict:
+    words = langscore.normalize(text)
+    if not words:
+        return {"words": 0, "tagalogShare": 0.0}
+    cls = langscore.classify_words(words)
+    return {"words": len(words), "tagalogShare": sum(c == "tl" for c in cls) / len(words)}
+
+
+def coverage(reference: list[dict], draft: list[dict], threshold: float = 0.5) -> dict:
+    ref_words = [content_words(r["text"]) for r in reference]
+    draft_words = [content_words(d["text"]) for d in draft]
+    matched: set[int] = set()
+    covered = 0
+    for words in ref_words:
+        if not words:
+            continue
+        hit = False
+        for i, cand in enumerate(draft_words):
+            if len(words & cand) / len(words) >= threshold:
+                hit = True
+                matched.add(i)
+        covered += hit
+    return {"reference": len(reference), "covered": covered, "draft": len(draft), "matched": len(matched)}
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--document", type=Path, required=True, help="the app's JSON export of one recording")
+    ap.add_argument("--model", required=True, help="an mlx-community model id, or a local path")
+    ap.add_argument("--style", choices=["english", "spoken"], default="english")
+    ap.add_argument("--max-chars", type=int, default=5000, help="characters of transcript per part")
+    ap.add_argument("--max-tokens", type=int, default=800, help="answer budget per part")
+    ap.add_argument("--max-chunks", type=int, default=0, help="stop after this many parts (0 = all)")
+    ap.add_argument("--temperature", type=float, default=0.2)
+    ap.add_argument("--out", type=Path, default=Path("eval/out/notes"))
+    ap.add_argument("--rescore", action="store_true",
+                    help="read the saved raw.json of an earlier run instead of asking the model again; "
+                         "for a change to the parser or the scores")
+    ap.add_argument("--max-items", type=int, default=10, help="the item cap the prompt states per part")
+    ap.add_argument("--tag", default="", help="a suffix for the output folder, to keep two runs of one model apart")
+    args = ap.parse_args()
+
+    document = json.loads(args.document.read_text())
+    turn_list = turns(document)
+    end_ms = max(s["endMs"] for s in document["segments"])
+    parts = chunks(turn_list, end_ms, args.max_chars)
+    if args.max_chunks:
+        parts = parts[:args.max_chunks]
+    slug = args.model.rstrip("/").split("/")[-1]
+    out_dir = args.out / f"{slug}-{args.style}{args.tag}"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    system = instructions(args.style)
+
+    if args.rescore:
+        saved = {r["part"]: r for r in json.loads((out_dir / "raw.json").read_text())}
+        old_report = json.loads((out_dir / "report.json").read_text())
+        load_s = old_report.get("loadSeconds", 0.0)
+        if "summary" not in saved:
+            # A run from before the summary was saved: take it from the draft.
+            draft_text = (out_dir / "draft.md").read_text()
+            m = re.search(r"## Summary\n\n(.*?)\n\n## ", draft_text, re.S)
+            saved["summary"] = {"raw": m.group(1) if m else "", "seconds": old_report.get("summarySeconds", 0.0)}
+
+        def ask(user: str, max_tokens: int) -> tuple[str, float]:
+            # The part index is in the request's first line; the summary
+            # request has none and is read from the saved summary.
+            m = re.match(r"Transcript, part (\d+):", user)
+            if m:
+                entry = saved[int(m.group(1)) - 1]
+                return entry["raw"], entry["seconds"]
+            return saved["summary"]["raw"], saved["summary"]["seconds"]
+    else:
+        from mlx_lm import load, generate
+        from mlx_lm.sample_utils import make_sampler
+
+        t0 = time.time()
+        model, tokenizer = load(args.model)
+        load_s = time.time() - t0
+        sampler = make_sampler(temp=args.temperature)
+
+    def ask_model(user: str, max_tokens: int) -> tuple[str, float]:
+        messages = [{"role": "system", "content": system}, {"role": "user", "content": user}]
+        kwargs = {}
+        if "qwen3" in args.model.lower():
+            kwargs["enable_thinking"] = False
+        try:
+            prompt = tokenizer.apply_chat_template(messages, add_generation_prompt=True, **kwargs)
+        except Exception:
+            # Gemma has no system role: fold the instructions into the turn.
+            prompt = tokenizer.apply_chat_template(
+                [{"role": "user", "content": system + "\n\n" + user}], add_generation_prompt=True)
+        started = time.time()
+        text = generate(model, tokenizer, prompt=prompt, max_tokens=max_tokens, sampler=sampler, verbose=False)
+        return text, time.time() - started
+
+    if not args.rescore:
+        ask = ask_model
+
+    part_summaries: list[str] = []
+    items: list[dict] = []
+    failures = 0
+    truncated = 0
+    part_times: list[float] = []
+    raw_log = []
+    for chunk in parts:
+        text, seconds = ask(request(chunk["index"], chunk["text"], args.max_items), args.max_tokens)
+        part_times.append(seconds)
+        raw_log.append({"part": chunk["index"], "seconds": seconds, "raw": text})
+        notes = parse_notes(text)
+        if notes is None:
+            failures += 1
+            if not args.rescore and len(tokenizer.encode(text)) >= args.max_tokens - 2:
+                truncated += 1
+            print(f"  part {chunk['index'] + 1}/{len(parts)}: no JSON ({seconds:.0f}s)", flush=True)
+            continue
+        part_summaries.append(notes["summary"])
+        resolved = resolve(notes, chunk)
+        items.extend(resolved)
+        print(f"  part {chunk['index'] + 1}/{len(parts)}: {len(resolved)} items ({seconds:.0f}s)", flush=True)
+
+    items = dedupe(items)
+    if len(part_summaries) == 1:
+        summary = part_summaries[0]
+        summary_s = 0.0
+    elif part_summaries:
+        summary, summary_s = ask(summary_request(part_summaries, document["title"]), 400)
+        summary = summary.strip()
+        raw_log.append({"part": "summary", "seconds": summary_s, "raw": summary})
+    else:
+        summary, summary_s = "", 0.0
+
+    transcript_text = " ".join(t["text"] for t in turn_list)
+    notes_text = summary + " " + " ".join(i["text"] for i in items)
+    report = {
+        "model": args.model,
+        "style": args.style,
+        "document": document["title"],
+        "durationMs": document["durationMs"],
+        "parts": len(parts),
+        "maxChars": args.max_chars,
+        "maxItems": args.max_items,
+        "loadSeconds": round(load_s, 1),
+        "partSeconds": {"mean": round(sum(part_times) / len(part_times), 1) if part_times else 0,
+                        "total": round(sum(part_times), 1)},
+        "summarySeconds": round(summary_s, 1),
+        "failures": {"noJSON": failures, "truncated": truncated},
+        "items": {k: sum(1 for i in items if i["kind"] == k) for k in KINDS},
+        "itemsTotal": len(items),
+        "withSource": sum(1 for i in items if i.get("sourceMs") is not None),
+        "grounding": grounding(items, document["segments"]),
+        "language": {"transcript": language_mix(transcript_text), "notes": language_mix(notes_text)},
+        "coverage": coverage(document.get("items", []), items),
+        # The same at a looser match, for notes that say the same thing in
+        # other words. A hand-written note and a draft note rarely share half
+        # their content words when one is a paraphrase of the other.
+        "coverageLoose": coverage(document.get("items", []), items, threshold=0.3),
+        "referenceSummaryChars": len(document.get("summary", "")),
+    }
+    (out_dir / "report.json").write_text(json.dumps(report, indent=2, ensure_ascii=False))
+    (out_dir / "raw.json").write_text(json.dumps(raw_log, indent=2, ensure_ascii=False))
+
+    lines = [f"# {document['title']} — {args.model} ({args.style})", "", "## Summary", "", summary, ""]
+    for kind in KINDS:
+        rows = [i for i in items if i["kind"] == kind]
+        if not rows:
+            continue
+        lines.append(f"## {KIND_LABEL[kind]}")
+        for i in rows:
+            where = f" *({stamp(i['sourceMs'])})*" if i.get("sourceMs") is not None else ""
+            lines.append(f"- {i['text']}{where}")
+        lines.append("")
+    (out_dir / "draft.md").write_text("\n".join(lines))
+
+    g = report["grounding"]
+    c = report["coverage"]
+    cl = report["coverageLoose"]
+    print(f"{slug} {args.style}: {len(parts)} parts, {report['partSeconds']['mean']}s/part, "
+          f"{failures} no-JSON; {len(items)} items ({report['withSource']} with source); "
+          f"grounding {g['meanOverlap']:.2f} ({g['ungrounded']} under 0.4); "
+          f"Tagalog share transcript {report['language']['transcript']['tagalogShare']:.0%} -> "
+          f"notes {report['language']['notes']['tagalogShare']:.0%}; "
+          f"coverage {c['covered']}/{c['reference']} hand-written notes at 0.5, {cl['covered']} at 0.3; "
+          f"{c['matched']}/{c['draft']} draft notes match one at 0.5, {cl['matched']} at 0.3")
+    print(f"wrote {out_dir}/draft.md and report.json")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
> **This branch also carries the SwiftUI refactor**, because none of it is on
> `main` yet. Eight of the ten commits are that refactor, ending at `a637e3f`;
> the last two are the notes work. To review them apart, read `b45a0e5` and
> `2a1f0bf`, or merge `refactor/swiftui-architecture` first and this shrinks to
> 32 files.
>
> The notes work needs that refactor: `NotesCoordinator` and `AutoDraft` live
> in the `TranscriberFlow` target it introduces.

The notes workspace has had the right shape since v1: a summary and five typed
lists whose rows keep a source timestamp. This fills it from the transcript.

**Draft Notes from the Transcript** (⇧⌘D) in the notes pane reads the
transcript in parts and proposes a summary and notes of the five kinds, each
carrying the line it came from. A sheet shows the draft with a checkbox on
every note. **The app writes nothing until the user selects it**, and it never
replaces a summary written by hand without a click that says so.

Turn on **Settings › General › Automatic notes › Draft the notes when a
recording is complete** and it drafts with no button, as soon as a transcript
is ready. Off unless asked for.

## The notes model never runs during a recording

Both directions. An automatic draft waits for the recording to stop, and a
draft that is already running is cancelled the moment Record is pressed. The
speech model and the notes model would otherwise share one chip, and a hop
that arrives late is words missing from the transcript. The transcription
queue has refused to start during a recording for that reason since it was
written; `AutoDraft` is that rule for the notes, with a test for each of the
six ways it can be refused.

## Read this before merging: it does nothing for a Taglish meeting

Apple's model **refuses a transcript that is mostly Tagalog**, before it reads
a word of it. Measured on a 93-minute Taglish meeting from the maintainer's
own library, with the default and the permissive guardrails alike:

| Part of the meeting | Tagalog words | Result |
|---|---:|---|
| the most English turns | 28 % | accepted, 3.5 s |
| mixed turns | 50 % | refused |
| in order, 6:21–12:00 | 71 % | refused |
| the most Tagalog turns | 92 % | refused |

Since every part of a Taglish meeting is over that limit, the whole meeting is
refused, and the pipeline treats that as fatal rather than drafting from the
parts that happen to pass. So this feature works on English meetings and is
inert on the ones this project exists for.

A local backend that does read Taglish was built against that finding, driven
through the app, and **deliberately left out of this change**: Qwen3 4B drafted
120 notes from the whole reference meeting in 1 min 46 s. Carrying it costs two
Swift dependencies, a 2.1 GB download per user, a binary that grows from 41 MB
to 107 MB, and a build step needing Xcode's separately-downloaded Metal
Toolchain. The intended direction is a hosted model instead.

**If that is the direction, it reverses this project's primary rule.** The
README, CONTRIBUTING and SECURITY.md all promise that no recording, transcript
or note leaves the Mac. A hosted model sends the transcript, which for these
meetings means names, pricing and decisions. Whatever ships next has to answer
that in those three files and at the point of use, not quietly. Nothing in
this change sends anything anywhere.

## Layout

`NotesGenerating` is a fourth engine protocol beside the three for speech,
voice activity and speakers, so a second backend is a new conformance and one
line in `AppState+Notes`. The pure half is in `TranscriberCore`: chunking the
transcript to fit a small window, resolving the model's timestamp back to a
line, merging restatements, and the three scores. `NotesPipeline` knows the
recoveries: a part too long is halved down to a single line, a part the filter
refuses is skipped with a warning, and a language refusal stops the draft.
`NotesCoordinator` holds one draft per recording and writes nothing.

`transcribe --notes EXPORT.json` drafts and scores an exported recording:
grounding (how much of each note is in the transcript near its timestamp),
the language the notes lean to, and how many hand-written notes in the export
the draft also found. `eval/notes_eval.py` reports the same for a candidate
model, so the next one is one command on the same meeting.

## Tests

369 tests, 0 warnings. `TranscriberNotesMLX` is not here, so the suite still
needs no weights, no microphone and no network.

Verified in the app on a real library: the review sheet, accepting 11 notes,
the refusal message on the Taglish meeting with the 41 hand-written notes left
untouched, and an automatic draft appearing on its own three seconds after a
transcription with the notes pane closed.

docs/FINDINGS.md finding 13 carries every number, including the models
measured and rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
